### PR TITLE
Live change link-example color by user selected color

### DIFF
--- a/pkg/harvester/pages/c/_cluster/brand/index.vue
+++ b/pkg/harvester/pages/c/_cluster/brand/index.vue
@@ -85,6 +85,9 @@ export default {
       const schema = this.$store.getters[`management/schemaFor`](MANAGEMENT.SETTING);
 
       return schema?.resourceMethods?.includes('PUT') ? _EDIT : _VIEW;
+    },
+    customLinkColor() {
+      return { color: this.uiLinkColor };
     }
   },
   mounted() {
@@ -320,7 +323,7 @@ export default {
           component-testid="link"
         />
         <span class="col link-example">
-          <a>
+          <a :style="customLinkColor">
             {{ t('branding.linkColor.example') }}
           </a>
         </span>


### PR DESCRIPTION
Current custom link setting doesn't reflect to the live color user selected.

This PR enhances user experience that user can see the selected color on link-example

 

https://github.com/user-attachments/assets/2820c58b-d362-4168-88cc-07df7bb998d6

