### PR TITLE
Allow v1.3.x harvester cluster link to v1.3 doc 

### DIFF
--- a/pkg/harvester/components/UpgradeInfo.vue
+++ b/pkg/harvester/components/UpgradeInfo.vue
@@ -1,6 +1,7 @@
 <script>
 import { Banner } from '@components/Banner';
-import { DOC_LINKS } from '../config/doc-links';
+import { DOC } from '../config/doc-links';
+import { docLink } from '../utils/feature-flags';
 
 export default {
   name: 'HarvesterUpgradeInfo',
@@ -20,7 +21,7 @@ export default {
     },
 
     upgradeLink() {
-      return DOC_LINKS.UPGRADE_URL;
+      return docLink(DOC.UPGRADE_URL, this.$store.getters);
     }
   },
 };

--- a/pkg/harvester/components/settings/storage-network.vue
+++ b/pkg/harvester/components/settings/storage-network.vue
@@ -10,7 +10,8 @@ import Tip from '@shell/components/Tip';
 import { allHash } from '@shell/utils/promise';
 import { NODE } from '@shell/config/types';
 import { HCI } from '../../types';
-import { DOC_LINKS } from '../../config/doc-links';
+import { DOC } from '../../config/doc-links';
+import { docLink } from '../../utils/feature-flags';
 
 export default {
   name: 'HarvesterEditStorageNetwork',
@@ -87,7 +88,7 @@ export default {
 
   computed: {
     storageNetworkExampleLink() {
-      return DOC_LINKS.STORAGE_NETWORK_EXAMPLE;
+      return docLink(DOC.STORAGE_NETWORK_EXAMPLE, this.$store.getters);
     },
     clusterNetworkOptions() {
       const inStore = this.$store.getters['currentProduct'].inStore;

--- a/pkg/harvester/config/doc-links.js
+++ b/pkg/harvester/config/doc-links.js
@@ -1,12 +1,8 @@
-import semver from 'semver';
-const pkgJson = require('../package.json');
-
-const docVersion = `v${ semver.major(pkgJson.version) }.${ semver.minor(pkgJson.version) }`;
-
-export const DOC_LINKS = {
-  CONSOLE_URL:             `https://docs.harvesterhci.io/${ docVersion }/host/#remote-console`,
-  RANCHER_INTEGRATION_URL: `https://docs.harvesterhci.io/${ docVersion }/rancher/rancher-integration`,
-  STORAGE_NETWORK_EXAMPLE: `https://docs.harvesterhci.io/${ docVersion }/advanced/storagenetwork#configuration-example`,
-  KSMTUNED_MODE:           `https://docs.harvesterhci.io/${ docVersion }/host/#ksmtuned-mode`,
-  UPGRADE_URL:             `https://docs.harvesterhci.io/${ docVersion }/upgrade/index`
+// suffix of doc link, see utils/feature-flags.js how to get complete doc link
+export const DOC = {
+  CONSOLE_URL:             `/host/#remote-console`,
+  RANCHER_INTEGRATION_URL: `/rancher/rancher-integration`,
+  STORAGE_NETWORK_EXAMPLE: `/advanced/storagenetwork#configuration-example`,
+  KSMTUNED_MODE:           `/host/#ksmtuned-mode`,
+  UPGRADE_URL:             `/upgrade/index`
 };

--- a/pkg/harvester/edit/harvesterhci.io.host/HarvesterKsmtuned.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/HarvesterKsmtuned.vue
@@ -5,7 +5,8 @@ import UnitInput from '@shell/components/form/UnitInput';
 import { RadioGroup } from '@components/Form/Radio';
 import { Checkbox } from '@components/Form/Checkbox';
 import { HCI } from '../../types';
-import { DOC_LINKS } from '../../config/doc-links';
+import { DOC } from '../../config/doc-links';
+import { docLink } from '../../utils/feature-flags';
 
 export const ksmtunedMode = [{
   value: 'standard',
@@ -90,7 +91,7 @@ export default {
     },
 
     ksmtunedLink() {
-      return DOC_LINKS.KSMTUNED_MODE;
+      return docLink(DOC.KSMTUNED_MODE, this.$store.getters);
     }
   },
 

--- a/pkg/harvester/list/harvesterhci.io.host.vue
+++ b/pkg/harvester/list/harvesterhci.io.host.vue
@@ -8,7 +8,8 @@ import {
 import { allHash } from '@shell/utils/promise';
 import metricPoller from '@shell/mixins/metric-poller';
 import { HCI } from '../types';
-import { DOC_LINKS } from '../config/doc-links';
+import { DOC } from '../config/doc-links';
+import { docLink } from '../utils/feature-flags';
 
 const schema = {
   id:         HCI.HOST,
@@ -166,7 +167,7 @@ export default {
     },
 
     consoleDocLink() {
-      return DOC_LINKS.CONSOLE_URL;
+      return docLink(DOC.CONSOLE_URL, this.$store.getters);
     }
   },
   methods: {

--- a/pkg/harvester/pages/c/_cluster/support/index.vue
+++ b/pkg/harvester/pages/c/_cluster/support/index.vue
@@ -7,7 +7,8 @@ import CommunityLinks from '@shell/components/CommunityLinks';
 import { SCHEMA } from '@shell/config/types';
 import HarvesterSupportBundle from '../../../../dialog/HarvesterSupportBundle';
 import { HCI } from '../../../../types';
-import { DOC_LINKS } from '../../../../config/doc-links';
+import { DOC } from '../../../../config/doc-links';
+import { docLink } from '../../../../utils/feature-flags';
 
 export default {
   components: {
@@ -75,7 +76,7 @@ export default {
     },
 
     rancherIntegrationLink() {
-      return DOC_LINKS.RANCHER_INTEGRATION_URL;
+      return docLink(DOC.RANCHER_INTEGRATION_URL, this.$store.getters);
     },
   },
 

--- a/pkg/harvester/utils/feature-flags.js
+++ b/pkg/harvester/utils/feature-flags.js
@@ -2,6 +2,14 @@ import semver from 'semver';
 import { HCI } from '../types';
 import { RELEASE_FEATURES } from '../config/feature-flags';
 
+export const docLink = (suffix, getter) => {
+  const v = serverVersion(getter);
+
+  const docVersion = `v${ semver.major(v) }.${ semver.minor(v) }`;
+
+  return `https://docs.harvesterhci.io/${ docVersion }${ suffix }`;
+};
+
 export function serverVersion(getters) {
   // e.g v1.4.0
   if (process.env.VUE_APP_SERVER_VERSION) {


### PR DESCRIPTION
### Summary

This PR updates the doc version from serverVersion().

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/6935



### Test screenshot/video
<img width="1494" alt="Screenshot 2024-11-04 at 2 15 50 PM" src="https://github.com/user-attachments/assets/f8b47be9-b2da-4eaa-bfa4-7adbf8765a5e">



<img width="1490" alt="Screenshot 2024-11-04 at 2 15 56 PM" src="https://github.com/user-attachments/assets/6d00309d-ccb3-4cd8-8f76-068a72524d50">

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


