### PR TITLE
Add compatibility functions to support multiple server version

### DIFF
--- a/pkg/harvester/components/ResourceDetail/index.vue
+++ b/pkg/harvester/components/ResourceDetail/index.vue
@@ -1,0 +1,479 @@
+<script>
+import CreateEditView from '@shell/mixins/create-edit-view/impl';
+import Loading from '@shell/components/Loading';
+import ResourceYaml from '@shell/components/ResourceYaml';
+import {
+  _VIEW, _EDIT, _CLONE, _IMPORT, _STAGE, _CREATE,
+  AS, _YAML, _DETAIL, _CONFIG, _GRAPH, PREVIEW, MODE,
+} from '@shell/config/query-params';
+import { FLEET, SCHEMA } from '@shell/config/types';
+import { createYaml } from '@shell/utils/create-yaml';
+import Masthead from '@shell/components/ResourceDetail/Masthead';
+import DetailTop from '@shell/components/DetailTop';
+import { clone, diff } from '@shell/utils/object';
+import IconMessage from '@shell/components/IconMessage';
+import ForceDirectedTreeChart from '@shell/components/fleet/ForceDirectedTreeChart';
+import { checkSchemasForFindAllHash } from '@shell/utils/auth';
+
+function modeFor(route) {
+  if ( route.query?.mode === _IMPORT ) {
+    return _IMPORT;
+  }
+
+  if ( route.params?.id ) {
+    return route.query.mode || _VIEW;
+  } else {
+    return _CREATE;
+  }
+}
+
+async function getYaml(store, model) {
+  let yaml;
+  const opt = { headers: { accept: 'application/yaml' } };
+
+  if ( model.hasLink('view') ) {
+    yaml = (await model.followLink('view', opt)).data;
+  }
+
+  return model.cleanForDownload(yaml);
+}
+
+export default {
+  emits: ['input'],
+
+  components: {
+    Loading,
+    DetailTop,
+    ForceDirectedTreeChart,
+    ResourceYaml,
+    Masthead,
+    IconMessage,
+  },
+
+  mixins: [CreateEditView],
+
+  props: {
+    storeOverride: {
+      type:    String,
+      default: null,
+    },
+
+    resourceOverride: {
+      type:    String,
+      default: null,
+    },
+
+    parentRouteOverride: {
+      type:    String,
+      default: null,
+    },
+
+    flexContent: {
+      type:    Boolean,
+      default: false,
+    },
+
+    /**
+     * Inherited global identifier prefix for tests
+     * Define a term based on the parent component to avoid conflicts on multiple components
+     */
+    componentTestid: {
+      type:    String,
+      default: 'resource-details'
+    }
+  },
+
+  async fetch() {
+    const store = this.$store;
+    const route = this.$route;
+    const params = route.params;
+    let resourceType = this.resourceOverride || params.resource;
+
+    const inStore = this.storeOverride || store.getters['currentStore'](resourceType);
+    const realMode = this.realMode;
+
+    // eslint-disable-next-line prefer-const
+    let { namespace, id } = params;
+
+    // There are 6 "real" modes that can be put into the query string
+    // These are mapped down to the 3 regular page "mode"s that create-edit-view components
+    // know about:  view, edit, create (stage, import and clone become "create")
+    const mode = ([_CLONE, _IMPORT, _STAGE].includes(realMode) ? _CREATE : realMode);
+
+    const getGraphConfig = store.getters['type-map/hasGraph'](resourceType);
+    const hasGraph = !!getGraphConfig;
+    const hasCustomDetail = !!store.getters['harvester/hasCustomDetail'](resourceType, id);
+    const hasCustomEdit = !!store.getters['harvester/hasCustomEdit'](resourceType, id);
+
+    const schemas = store.getters[`${ inStore }/all`](SCHEMA);
+
+    // As determines what component will be rendered
+    const requested = route.query[AS];
+    let as;
+    let notFound = false;
+
+    if ( mode === _VIEW && hasCustomDetail && (!requested || requested === _DETAIL) ) {
+      as = _DETAIL;
+    } else if ( mode === _VIEW && hasGraph && requested === _GRAPH) {
+      as = _GRAPH;
+    } else if ( hasCustomEdit && (!requested || requested === _CONFIG) ) {
+      as = _CONFIG;
+    } else {
+      as = _YAML;
+    }
+
+    this.as = as;
+
+    const options = store.getters[`type-map/optionsFor`](resourceType);
+
+    this.showMasthead = [_CREATE, _EDIT].includes(mode) ? options.resourceEditMasthead : true;
+    const canViewYaml = options.canYaml;
+
+    if ( options.resource ) {
+      resourceType = options.resource;
+    }
+
+    const schema = store.getters[`${ inStore }/schemaFor`](resourceType);
+    let model, initialModel, liveModel, yaml;
+
+    if ( realMode === _CREATE || realMode === _IMPORT ) {
+      if ( !namespace ) {
+        namespace = store.getters['defaultNamespace'];
+      }
+
+      const data = { type: resourceType };
+
+      if ( schema?.attributes?.namespaced ) {
+        data.metadata = { namespace };
+      }
+
+      liveModel = await store.dispatch(`${ inStore }/create`, data);
+      initialModel = await store.dispatch(`${ inStore }/clone`, { resource: liveModel });
+      model = await store.dispatch(`${ inStore }/clone`, { resource: liveModel });
+
+      if (model.forceYaml === true) {
+        as = _YAML;
+        this.as = as;
+      }
+
+      if ( as === _YAML ) {
+        if (schema?.fetchResourceFields) {
+          // fetch resourceFields for createYaml
+          await schema.fetchResourceFields();
+        }
+
+        yaml = createYaml(schemas, resourceType, data);
+      }
+    } else {
+      if ( as === _GRAPH ) {
+        const graphSchema = await checkSchemasForFindAllHash({
+          cluster: {
+            inStoreType: 'management',
+            type:        FLEET.CLUSTER
+          },
+          bundle: {
+            inStoreType: 'management',
+            type:        FLEET.BUNDLE
+          },
+
+          bundleDeployment: {
+            inStoreType: 'management',
+            type:        FLEET.BUNDLE_DEPLOYMENT
+          }
+
+        }, this.$store);
+
+        this.canViewChart = graphSchema.cluster && graphSchema.bundle && graphSchema.bundleDeployment;
+      }
+
+      let fqid = id;
+
+      if ( schema.attributes?.namespaced && namespace ) {
+        fqid = `${ namespace }/${ fqid }`;
+      }
+
+      try {
+        liveModel = await store.dispatch(`${ inStore }/find`, {
+          type: resourceType,
+          id:   fqid,
+          opt:  { watch: true }
+        });
+      } catch (e) {
+        if (e.status === 404 || e.status === 403) {
+          store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceIdNotFound', { resource: resourceType, fqid }, true)));
+        }
+        liveModel = {};
+        notFound = fqid;
+      }
+
+      if (realMode === _VIEW) {
+        model = liveModel;
+      } else {
+        model = await store.dispatch(`${ inStore }/clone`, { resource: liveModel });
+      }
+
+      initialModel = await store.dispatch(`${ inStore }/clone`, { resource: liveModel });
+
+      if ( as === _YAML ) {
+        yaml = await getYaml(this.$store, liveModel);
+      }
+
+      if ( as === _GRAPH ) {
+        this.chartData = liveModel;
+      }
+
+      if ( [_CLONE, _IMPORT, _STAGE].includes(realMode) ) {
+        model.cleanForNew();
+        yaml = model.cleanYaml(yaml, realMode);
+      }
+    }
+
+    // Ensure common properties exists
+    model = await store.dispatch(`${ inStore }/cleanForDetail`, model);
+
+    const out = {
+      hasGraph,
+      getGraphConfig,
+      hasCustomDetail,
+      hasCustomEdit,
+      canViewYaml,
+      resourceType,
+      as,
+      yaml,
+      initialModel,
+      liveModel,
+      mode,
+      value: model,
+      notFound,
+    };
+
+    for ( const key in out ) {
+      this[key] = out[key];
+    }
+
+    if ( this.mode === _CREATE ) {
+      this.value.applyDefaults(this, realMode);
+    }
+  },
+  data() {
+    return {
+      chartData:       null,
+      resourceSubtype: null,
+
+      // Set by fetch
+      hasGraph:        null,
+      hasCustomDetail: null,
+      hasCustomEdit:   null,
+      resourceType:    null,
+      asYaml:          null,
+      yaml:            null,
+      liveModel:       null,
+      initialModel:    null,
+      mode:            null,
+      as:              null,
+      value:           null,
+      model:           null,
+      notFound:        null,
+      canViewChart:    true,
+      canViewYaml:     null,
+    };
+  },
+
+  computed: {
+    realMode() {
+      // There are 5 "real" modes that you can start in: view, edit, create, stage, clone
+      const realMode = modeFor(this.$route);
+
+      return realMode;
+    },
+
+    isView() {
+      return this.mode === _VIEW;
+    },
+
+    isYaml() {
+      return this.as === _YAML;
+    },
+
+    isDetail() {
+      return this.as === _DETAIL;
+    },
+
+    isGraph() {
+      return this.as === _GRAPH;
+    },
+
+    offerPreview() {
+      return this.as === _YAML && [_EDIT, _CLONE, _IMPORT, _STAGE].includes(this.mode);
+    },
+
+    showComponent() {
+      switch ( this.as ) {
+      case _DETAIL: return this.detailComponent;
+      case _CONFIG: return this.editComponent;
+      }
+
+      return null;
+    },
+  },
+
+  watch: {
+    '$route'(current, prev) {
+      if (current.name !== prev.name) {
+        return;
+      }
+      const neu = clone(current.query);
+      const old = clone(prev.query);
+
+      delete neu[PREVIEW];
+      delete old[PREVIEW];
+
+      if ( !this.isView ) {
+        delete neu[AS];
+        delete old[AS];
+      }
+
+      const queryDiff = Object.keys(diff(neu, old));
+
+      if (queryDiff.includes(MODE) || queryDiff.includes(AS)) {
+        this.$fetch();
+      }
+    },
+
+    // Auto refresh YAML when the model changes
+    async 'value.metadata.resourceVersion'(a, b) {
+      if ( this.mode === _VIEW && this.as === _YAML && a && b && a !== b) {
+        this.yaml = await getYaml(this.$store, this.liveModel);
+      }
+    }
+  },
+
+  created() {
+    // eslint-disable-next-line prefer-const
+    const id = this.$route.params.id;
+    const resource = this.resourceOverride || this.$route.params.resource;
+    const options = this.$store.getters[`type-map/optionsFor`](resource);
+
+    const detailResource = options.resourceDetail || options.resource || resource;
+    const editResource = options.resourceEdit || options.resource || resource;
+
+    // FIXME: These aren't right... signature is (rawType, subType).. not (rawType, resourceId)
+    // Remove id? How does subtype get in (cluster/node)
+    this.detailComponent = this.$store.getters['harvester/importDetail'](detailResource, id);
+    this.editComponent = this.$store.getters['harvester/importEdit'](editResource, id);
+  },
+
+  methods: {
+    setSubtype(subtype) {
+      this.resourceSubtype = subtype;
+    },
+
+    keyAction(act) {
+      const m = this.liveModel;
+
+      if ( m?.[act] ) {
+        m[act]();
+      }
+    },
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending || notFound" />
+  <div v-else>
+    <Masthead
+      v-if="showMasthead"
+      :resource="resourceType"
+      :value="liveModel"
+      :mode="mode"
+      :real-mode="realMode"
+      :as="as"
+      :has-graph="hasGraph"
+      :has-detail="hasCustomDetail"
+      :has-edit="hasCustomEdit"
+      :can-view-yaml="canViewYaml"
+      :resource-subtype="resourceSubtype"
+      :parent-route-override="parentRouteOverride"
+      :store-override="storeOverride"
+    >
+      <DetailTop
+        v-if="isView && isDetail"
+        :value="liveModel"
+      />
+    </Masthead>
+
+    <ForceDirectedTreeChart
+      v-if="isGraph && canViewChart"
+      :data="chartData"
+      :fdc-config="getGraphConfig"
+    />
+
+    <ResourceYaml
+      v-else-if="isYaml"
+      ref="resourceyaml"
+      :value="value"
+      :mode="mode"
+      :yaml="yaml"
+      :offer-preview="offerPreview"
+      :done-route="doneRoute"
+      :done-override="value.doneOverride"
+      :class="{'flex-content': flexContent}"
+      @update:value="$emit('input', $event)"
+    />
+
+    <component
+      :is="showComponent"
+      v-else
+      ref="comp"
+      v-model:value="value"
+      v-bind="$data"
+      :done-params="doneParams"
+      :done-route="doneRoute"
+      :mode="mode"
+      :initial-value="initialModel"
+      :live-value="liveModel"
+      :real-mode="realMode"
+      :class="{'flex-content': flexContent}"
+      @update:value="$emit('input', $event)"
+      @set-subtype="setSubtype"
+    />
+
+    <button
+      v-if="isView"
+      v-shortkey.once="['shift','d']"
+      :data-testid="componentTestid + '-detail'"
+      class="hide"
+      @shortkey="keyAction('goToDetail')"
+    />
+    <button
+      v-if="isView"
+      v-shortkey.once="['shift','c']"
+      :data-testid="componentTestid + '-config'"
+      class="hide"
+      @shortkey="keyAction('goToViewConfig')"
+    />
+    <button
+      v-if="isView"
+      v-shortkey.once="['shift','y']"
+      :data-testid="componentTestid + '-yaml'"
+      class="hide"
+      @shortkey="keyAction('goToViewYaml')"
+    />
+    <button
+      v-if="isView"
+      v-shortkey.once="['shift','e']"
+      :data-testid="componentTestid + '-edit'"
+      class="hide"
+      @shortkey="keyAction('goToEdit')"
+    />
+  </div>
+</template>
+
+<style lang='scss' scoped>
+.flex-content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+</style>

--- a/pkg/harvester/components/ResourceList/index.vue
+++ b/pkg/harvester/components/ResourceList/index.vue
@@ -1,0 +1,306 @@
+<script>
+import ResourceTable from '@shell/components/ResourceTable';
+import Loading from '@shell/components/Loading';
+import Masthead from '@shell/components/ResourceList/Masthead';
+import ResourceLoadingIndicator from '@shell/components/ResourceList/ResourceLoadingIndicator';
+import ResourceFetch from '@shell/mixins/resource-fetch';
+import IconMessage from '@shell/components/IconMessage.vue';
+import { ResourceListComponentName } from '@shell/components/ResourceList/resource-list.config';
+import { PanelLocation, ExtensionPoint } from '@shell/core/types';
+import ExtensionPanel from '@shell/components/ExtensionPanel';
+import { sameContents } from '@shell/utils/array';
+
+export default {
+  name: ResourceListComponentName,
+
+  components: {
+    Loading,
+    ResourceTable,
+    Masthead,
+    ResourceLoadingIndicator,
+    IconMessage,
+    ExtensionPanel
+  },
+  mixins: [ResourceFetch],
+
+  props: {
+    hasAdvancedFiltering: {
+      type:    Boolean,
+      default: false
+    },
+    advFilterHideLabelsAsCols: {
+      type:    Boolean,
+      default: false
+    },
+    advFilterPreventFilteringLabels: {
+      type:    Boolean,
+      default: false
+    },
+  },
+
+  async fetch() {
+    const store = this.$store;
+    const resource = this.resource;
+
+    const schema = this.schema;
+
+    if ( this.hasListComponent ) {
+      // If you provide your own list then call its fetch
+      const importer = this.listComponent;
+
+      const component = await importer.__asyncLoader();
+
+      if ( component?.typeDisplay ) {
+        this.customTypeDisplay = component.typeDisplay.apply(this);
+      }
+
+      // If your list page has a fetch then it's responsible for populating rows itself
+      if ( component?.fetch ) {
+        this.componentWillFetch = true;
+      }
+
+      // If the custom component supports it, ask it what resources it loads, so we can
+      // use the incremental loading indicator when enabled
+      if (component?.$loadingResources) {
+        const { loadResources, loadIndeterminate } = component?.$loadingResources(this.$route, this.$store);
+
+        this.loadResources = loadResources || [resource];
+        this.loadIndeterminate = loadIndeterminate || false;
+      }
+    }
+
+    if ( !this.componentWillFetch ) {
+      if ( !schema ) {
+        store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceListNotFound', { resource }, true)));
+
+        return;
+      }
+
+      // See comment for `namespaceFilter` and `pagination` watchers, skip fetch if we're not ready yet... and something is going to call fetch later on
+      if (!this.namespaceFilterRequired && (!this.canPaginate || this.refreshFlag)) {
+        await this.$fetchType(resource);
+      }
+    }
+  },
+
+  data() {
+    const getters = this.$store.getters;
+    const params = { ...this.$route.params };
+    const resource = params.resource;
+
+    const hasListComponent = !!getters['harvester/getCustomList'](resource);
+
+    const inStore = getters['currentStore'](resource);
+    const schema = getters[`${ inStore }/schemaFor`](resource);
+
+    const showMasthead = getters[`type-map/optionsFor`](resource).showListMasthead;
+
+    return {
+      inStore,
+      schema,
+      hasListComponent,
+      showMasthead:                     showMasthead === undefined ? true : showMasthead,
+      resource,
+      extensionType:                    ExtensionPoint.PANEL,
+      extensionLocation:                PanelLocation.RESOURCE_LIST,
+      loadResources:                    [resource], // List of resources that will be loaded, this could be many (`Workloads`)
+      /**
+       * Will the custom component handle the fetch of resources....
+       * or will this instance fetch resources
+       */
+      componentWillFetch:               false,
+      // manual refresh
+      manualRefreshInit:                false,
+      watch:                            false,
+      force:                            false,
+      // Provided by fetch later
+      customTypeDisplay:                null,
+      // incremental loading
+      loadIndeterminate:                false,
+      // query param for simple filtering
+      useQueryParamsForSimpleFiltering: true,
+    };
+  },
+
+  computed: {
+    headers() {
+      if ( this.hasListComponent || !this.schema ) {
+        // Custom lists figure out their own headers
+        return [];
+      }
+
+      return this.$store.getters['type-map/headersFor'](this.schema, this.canPaginate);
+    },
+
+    groupBy() {
+      return this.$store.getters['type-map/groupByFor'](this.schema);
+    },
+
+    showIncrementalLoadingIndicator() {
+      return this.perfConfig?.incrementalLoading?.enabled;
+    },
+
+  },
+
+  watch: {
+
+    /**
+     * When a NS filter is required and the user selects a different one, kick off a new set of API requests
+     *
+     * ResourceList has two modes
+     * 1) ResourceList component handles API request to fetch resources
+     * 2) Custom list component handles API request to fetch resources
+     *
+     * This covers case 1
+     */
+    namespaceFilter(neu, old) {
+      if (neu && !this.componentWillFetch) {
+        if (sameContents(neu, old)) {
+          return;
+        }
+
+        this.$fetchType(this.resource);
+      }
+    },
+
+    /**
+     * When a pagination is required and the user changes page / sort / filter, kick off a new set of API requests
+     *
+     * ResourceList has two modes
+     * 1) ResourceList component handles API request to fetch resources
+     * 2) Custom list component handles API request to fetch resources
+     *
+     * This covers case 1
+     */
+    pagination(neu, old) {
+      if (neu && !this.componentWillFetch && !this.paginationEqual(neu, old)) {
+        this.$fetchType(this.resource);
+      }
+    },
+
+    /**
+     * Monitor the rows to ensure deleting the last entry in a server-side paginated page doesn't
+     * result in an empty page
+     */
+    rows(neu) {
+      if (!this.pagination) {
+        return;
+      }
+
+      if (this.pagination.page > 1 && neu.length === 0) {
+        this.setPagination({
+          ...this.pagination,
+          page: this.pagination.page - 1
+        });
+      }
+    },
+  },
+
+  created() {
+    let listComponent = false;
+
+    const resource = this.$route.params.resource;
+
+    const customList = this.$store.getters['harvester/getCustomList'](resource);
+
+    if ( customList ) {
+      listComponent = this.$store.getters['type-map/importList'](customList);
+    }
+
+    this.listComponent = listComponent;
+  },
+};
+</script>
+
+<template>
+  <IconMessage
+    v-if="namespaceFilterRequired"
+    :vertical="true"
+    :subtle="false"
+    icon="icon-filter_alt"
+  >
+    <template #message>
+      {{ t('resourceList.nsFiltering') }}
+    </template>
+  </IconMessage>
+  <IconMessage
+    v-else-if="paginationNsFilterRequired"
+    :vertical="true"
+    :subtle="false"
+    icon="icon-filter_alt"
+  >
+    <template #message>
+      {{ t('resourceList.nsFilteringGeneric') }}
+    </template>
+  </IconMessage>
+  <div
+    v-else
+    class="outlet"
+  >
+    <Masthead
+      v-if="showMasthead"
+      :type-display="customTypeDisplay"
+      :schema="schema"
+      :resource="resource"
+      :show-incremental-loading-indicator="showIncrementalLoadingIndicator"
+      :load-resources="loadResources"
+      :load-indeterminate="loadIndeterminate"
+    >
+      <template #extraActions>
+        <slot name="extraActions" />
+      </template>
+    </Masthead>
+    <!-- Extensions area -->
+    <ExtensionPanel
+      :resource="{}"
+      :type="extensionType"
+      :location="extensionLocation"
+    />
+
+    <div
+      v-if="hasListComponent"
+    >
+      <component
+        :is="listComponent"
+        :incremental-loading-indicator="showIncrementalLoadingIndicator"
+        :rows="rows"
+        v-bind="$data"
+      />
+    </div>
+    <ResourceTable
+      v-else
+      :schema="schema"
+      :rows="rows"
+      :alt-loading="canPaginate"
+      :loading="loading"
+      :headers="headers"
+      :group-by="groupBy"
+      :has-advanced-filtering="hasAdvancedFiltering"
+      :adv-filter-hide-labels-as-cols="advFilterHideLabelsAsCols"
+      :adv-filter-prevent-filtering-labels="advFilterPreventFilteringLabels"
+      :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
+      :external-pagination-enabled="canPaginate"
+      :external-pagination-result="paginationResult"
+      @pagination-changed="paginationChanged"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+    .header {
+      position: relative;
+    }
+    H2 {
+      position: relative;
+      margin: 0 0 20px 0;
+    }
+    .filter{
+      line-height: 45px;
+    }
+    .right-action {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+    }
+</style>

--- a/pkg/harvester/components/VersionSwitch.vue
+++ b/pkg/harvester/components/VersionSwitch.vue
@@ -1,0 +1,38 @@
+<script>
+import { serverVersion } from '@pkg/harvester/utils/server';
+
+export default {
+  name: 'VersionSwitch',
+
+  props: {
+    component: {
+      type:     String,
+      required: true,
+    }
+  },
+
+  data() {
+    const version = serverVersion(this.$store.getters);
+
+    let currentComponent = null;
+
+    try {
+      currentComponent = require(`./${ this.component }-${ version }.vue`).default;
+    } catch {
+      currentComponent = require(`./${ this.component }.vue`).default;
+    }
+
+    return { currentComponent };
+  },
+
+};
+</script>
+
+<template>
+  <div>
+    <component
+      :is="currentComponent"
+      v-bind="$attrs"
+    />
+  </div>
+</template>

--- a/pkg/harvester/detail/harvesterhci.io.volume.vue
+++ b/pkg/harvester/detail/harvesterhci.io.volume.vue
@@ -1,0 +1,8 @@
+<script>
+
+export default { name: 'HarvesterVolumeDetails' };
+</script>
+
+<template>
+  <span>volume details</span>
+</template>

--- a/pkg/harvester/detail/kubevirt.io.virtualmachine-v1.4.0/index.vue
+++ b/pkg/harvester/detail/kubevirt.io.virtualmachine-v1.4.0/index.vue
@@ -1,0 +1,8 @@
+<script>
+
+export default { name: 'HarvesterVMDetails' };
+</script>
+
+<template>
+  <span>pippo details</span>
+</template>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine-v1.4.0/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine-v1.4.0/index.vue
@@ -1,0 +1,8 @@
+<script>
+
+export default { name: 'HarvesterVMCreate' };
+</script>
+
+<template>
+  <span>pippo edit</span>
+</template>

--- a/pkg/harvester/list/kubevirt.io.virtualmachine-v1.4.0.vue
+++ b/pkg/harvester/list/kubevirt.io.virtualmachine-v1.4.0.vue
@@ -1,9 +1,7 @@
 <script>
 import ResourceTable from '@shell/components/ResourceTable';
 import { STATE, AGE, NAME, NAMESPACE } from '@shell/config/table-headers';
-import {
-  PVC, PV, NODE, POD, STORAGE_CLASS
-} from '@shell/config/types';
+import { PVC, PV, NODE, POD } from '@shell/config/types';
 
 import { allHash } from '@shell/utils/promise';
 import Loading from '@shell/components/Loading';
@@ -11,7 +9,6 @@ import { clone } from '@shell/utils/object';
 import { HCI } from '../types';
 import HarvesterVmState from '../formatters/HarvesterVmState';
 import ConsoleBar from '../components/VMConsoleBar';
-import VersionSwitch from '../components/VersionSwitch';
 
 export const VM_HEADERS = [
   STATE,
@@ -62,8 +59,7 @@ export default {
     Loading,
     HarvesterVmState,
     ConsoleBar,
-    ResourceTable,
-    VersionSwitch
+    ResourceTable
   },
 
   props: {
@@ -83,7 +79,6 @@ export default {
       images:  this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.IMAGE }),
       restore: this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.RESTORE }),
       backups: this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.BACKUP }),
-      storage: this.$store.dispatch(`${ inStore }/findAll`, { type: STORAGE_CLASS }),
     };
 
     if (this.$store.getters[`${ inStore }/schemaFor`](HCI.RESOURCE_QUOTA)) {
@@ -199,53 +194,7 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else>
-    <ResourceTable
-      v-bind="$attrs"
-      :headers="headers"
-      default-sort-by="age"
-      :rows="rows"
-      :schema="schema"
-      :groupable="true"
-      key-field="_key"
-    >
-      <template
-        #cell:state="scope"
-        class="state-col"
-      >
-        <div class="state">
-          <HarvesterVmState
-            class="vmstate"
-            :row="scope.row"
-            :all-node-network="allNodeNetworks"
-            :all-cluster-network="allClusterNetworks"
-          />
-        </div>
-      </template>
-
-      <template #cell:name="scope">
-        <div class="name-console">
-          <router-link
-            v-if="scope.row.type !== HCI.VMI"
-            :to="scope.row.detailLocation"
-          >
-            {{ scope.row.metadata.name }}
-            <i
-              v-if="lockIconTooltipMessage(scope.row)"
-              v-tooltip="lockIconTooltipMessage(scope.row)"
-              class="icon icon-lock"
-              :class="{'green-icon': scope.row.encryptedVolumeType === 'all', 'yellow-icon': scope.row.encryptedVolumeType === 'partial'}"
-            />
-          </router-link>
-          <span v-else>
-            {{ scope.row.metadata.name }}
-          </span>
-          <ConsoleBar
-            :resource-type="scope.row"
-            class="console mr-10 ml-10"
-          />
-        </div>
-      </template>
-    </ResourceTable>
+    PIPPO
   </div>
 </template>
 

--- a/pkg/harvester/models/kubevirt.io.virtualmachine-v1.4.0.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine-v1.4.0.js
@@ -1,0 +1,1155 @@
+import { load } from 'js-yaml';
+import { omitBy, pickBy } from 'lodash';
+import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
+import { colorForState } from '@shell/plugins/dashboard-store/resource-class';
+import { POD, NODE, PVC } from '@shell/config/types';
+import { findBy } from '@shell/utils/array';
+import { parseSi } from '@shell/utils/units';
+import { get, set } from '@shell/utils/object';
+import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
+import { _CLONE } from '@shell/config/query-params';
+import { matchesSomeRegex } from '@shell/utils/string';
+import { LABELS_TO_IGNORE_REGEX } from '@shell/config/labels-annotations';
+import { parseVolumeClaimTemplates } from '@pkg/utils/vm';
+import { BACKUP_TYPE } from '../config/types';
+import { HCI } from '../types';
+import HarvesterResource from './harvester';
+
+export const OFF = 'Off';
+
+const VMI_WAITING_MESSAGE =
+  'The virtual machine is waiting for resources to become available.';
+const VM_ERROR = 'VM error';
+const STOPPING = 'Stopping';
+const UNSCHEDULABLE = 'Unschedulable';
+const WAITING = 'Waiting';
+const NOT_READY = 'Not Ready';
+const AGENT_CONNECTED = 'AgentConnected';
+
+const PAUSED = 'Paused';
+const PAUSED_VM_MODAL_MESSAGE =
+  'This VM has been paused. If you wish to unpause it, please click the Unpause button below. For further details, please check with your system administrator.';
+
+const POD_STATUS_NOT_SCHEDULABLE = 'POD_NOT_SCHEDULABLE';
+const POD_STATUS_CONTAINER_FAILING = 'POD_CONTAINER_FAILING';
+// eslint-disable-next-line no-unused-vars
+const POD_STATUS_NOT_READY = 'POD_NOT_READY';
+
+const POD_STATUS_FAILED = 'POD_FAILED';
+const POD_STATUS_CRASHLOOP_BACKOFF = 'POD_CRASHLOOP_BACKOFF';
+const POD_STATUS_UNKNOWN = 'POD_STATUS_UNKNOWN';
+
+const POD_STATUS_ALL_ERROR = [
+  POD_STATUS_NOT_SCHEDULABLE,
+  POD_STATUS_CONTAINER_FAILING,
+  POD_STATUS_FAILED,
+  POD_STATUS_CRASHLOOP_BACKOFF,
+  POD_STATUS_UNKNOWN
+];
+
+const POD_STATUS_COMPLETED = 'POD_STATUS_COMPLETED';
+const POD_STATUS_SUCCEEDED = 'POD_STATUS_SUCCEEDED';
+const POD_STATUS_RUNNING = 'POD_STATUS_RUNNING';
+
+const POD_STATUS_ALL_READY = [
+  POD_STATUS_RUNNING,
+  POD_STATUS_COMPLETED,
+  POD_STATUS_SUCCEEDED
+];
+
+const RunStrategy = {
+  Always:         'Always',
+  RerunOnFailure: 'RerunOnFailure',
+  Halted:         'Halted',
+  Manual:         'Manual'
+};
+
+const StateChangeRequest = {
+  Start: 'Start',
+  Stop:  'Stop'
+};
+
+const STARTING_MESSAGE =
+  'This virtual machine will start shortly. Preparing storage, networking, and compute resources.';
+
+const VMIPhase = {
+  Pending:    'Pending',
+  Scheduling: 'Scheduling',
+  Scheduled:  'Scheduled',
+  Running:    'Running',
+  Succeeded:  'Succeeded',
+  Failed:     'Failed',
+  Unknown:    'Unknown'
+};
+
+let productInStore;
+
+const IgnoreMessages = ['pod has unbound immediate PersistentVolumeClaims'];
+
+export default class VirtVm extends HarvesterResource {
+  get availableActions() {
+    const out = super._availableActions;
+
+    const clone = out.find((action) => action.action === 'goToClone');
+
+    if (clone) {
+      clone.action = 'goToCloneVM';
+    }
+
+    return [
+      {
+        action:   'stopVM',
+        enabled:  !!this.actions?.stop,
+        icon:     'icon icon-close',
+        label:    this.t('harvester.action.stop'),
+        bulkable: true
+      },
+      {
+        action:   'forceStop',
+        enabled:  !!this.actions?.forceStop,
+        icon:     'icon icon-close',
+        label:    this.t('harvester.action.forceStop'),
+        bulkable: true
+      },
+      {
+        action:  'pauseVM',
+        enabled: !!this.actions?.pause,
+        icon:    'icon icon-pause',
+        label:   this.t('harvester.action.pause')
+      },
+      {
+        action:  'unpauseVM',
+        enabled: !!this.actions?.unpause,
+        icon:    'icon icon-spinner',
+        label:   this.t('harvester.action.unpause')
+      },
+      {
+        action:   'restartVM',
+        enabled:  !!this.actions?.restart,
+        icon:     'icon icon-refresh',
+        label:    this.t('harvester.action.restart'),
+        bulkable: true
+      },
+      {
+        action:  'softrebootVM',
+        enabled: !!this.actions?.softreboot,
+        icon:    'icon icon-pipeline',
+        label:   this.t('harvester.action.softreboot')
+      },
+      {
+        action:   'startVM',
+        enabled:  !!this.actions?.start,
+        icon:     'icon icon-play',
+        label:    this.t('harvester.action.start'),
+        bulkable: true
+      },
+      {
+        action:  'backupVM',
+        enabled: !!this.actions?.backup,
+        icon:    'icon icon-backup',
+        label:   this.t('harvester.action.backup')
+      },
+      {
+        action:  'takeVMSnapshot',
+        enabled: !!this.actions?.backup,
+        icon:    'icon icon-snapshot',
+        label:   this.t('harvester.action.vmSnapshot')
+      },
+      {
+        action:  'editVMQuota',
+        enabled: !!this.actions?.updateResourceQuota && !!this.actions.deleteResourceQuota,
+        icon:    'icon icon-storage',
+        label:   this.t('harvester.action.editVMQuota')
+      },
+      {
+        action:  'createSchedule',
+        enabled: true,
+        icon:    'icon icon-history',
+        label:   this.t('harvester.action.createSchedule')
+      },
+      {
+        action:  'restoreVM',
+        enabled: !!this.actions?.restore,
+        icon:    'icon icon-backup-restore',
+        label:   this.t('harvester.action.restore')
+      },
+      {
+        action:  'ejectCDROM',
+        enabled: !!this.actions?.ejectCdRom,
+        icon:    'icon icon-delete',
+        label:   this.t('harvester.action.ejectCDROM')
+      },
+      {
+        action:  'migrateVM',
+        enabled: !!this.actions?.migrate,
+        icon:    'icon icon-copy',
+        label:   this.t('harvester.action.migrate')
+      },
+      {
+        action:  'abortMigrationVM',
+        enabled: !!this.actions?.abortMigration,
+        icon:    'icon icon-close',
+        label:   this.t('harvester.action.abortMigration')
+      },
+      {
+        action:  'addHotplug',
+        enabled: !!this.actions?.addVolume,
+        icon:    'icon icon-plus',
+        label:   this.t('harvester.action.addHotplug')
+      },
+      {
+        action:  'createTemplate',
+        enabled: !!this.actions?.createTemplate,
+        icon:    'icon icon-copy',
+        label:   this.t('harvester.action.createTemplate')
+      },
+      {
+        action:  'openLogs',
+        enabled: !!this.podResource,
+        icon:    'icon icon-fw icon-chevron-right',
+        label:   this.t('harvester.action.viewlogs'),
+        total:   1
+      },
+      ...out
+    ];
+  }
+
+  get productInStore() {
+    if (!productInStore) {
+      productInStore = this.$rootGetters['currentProduct'].inStore;
+    }
+
+    return productInStore;
+  }
+
+  applyDefaults(resources = this, realMode) {
+    const spec = {
+      runStrategy: 'RerunOnFailure',
+      template:    {
+        metadata: { annotations: {} },
+        spec:     {
+          domain: {
+            machine: { type: '' },
+            cpu:     {
+              cores:   null,
+              sockets: 1,
+              threads: 1
+            },
+            devices: {
+              inputs: [
+                {
+                  bus:  'usb',
+                  name: 'tablet',
+                  type: 'tablet'
+                }
+              ],
+              interfaces: [
+                {
+                  masquerade: {},
+                  model:      'virtio',
+                  name:       'default'
+                }
+              ],
+              disks: []
+            },
+            resources: {
+              limits: {
+                memory: null,
+                cpu:    ''
+              }
+            },
+            features: { acpi: { enabled: true } }
+          },
+          evictionStrategy: 'LiveMigrateIfPossible',
+          hostname:         '',
+          networks:         [
+            {
+              name: 'default',
+              pod:  {}
+            }
+          ],
+          volumes:  [],
+          affinity: {},
+        }
+      }
+    };
+
+    if (realMode !== _CLONE) {
+      this.metadata['annotations'] = { [HCI_ANNOTATIONS.VOLUME_CLAIM_TEMPLATE]: '[]' };
+      this['spec'] = spec;
+    }
+  }
+
+  cleanForNew() {
+    this.$dispatch(`cleanForNew`, this);
+
+    this.spec.template.spec.hostname = '';
+    const interfaces = this.spec.template.spec.domain.devices?.interfaces || [];
+
+    for (let i = 0; i < interfaces.length; i++) {
+      if (interfaces[i].macAddress) {
+        interfaces[i].macAddress = '';
+      }
+    }
+
+    // delete, spec?.dataSource:  The original data should not be saved when clone template
+    const deleteDataSource = this.volumeClaimTemplates.map((volume) => {
+      if (volume?.spec?.dataSource) {
+        delete volume.spec.dataSource;
+      }
+
+      return volume;
+    });
+
+    this.metadata.annotations[HCI_ANNOTATIONS.VOLUME_CLAIM_TEMPLATE] = JSON.stringify(deleteDataSource);
+  }
+
+  restartVM() {
+    this.doActionGrowl('restart', {});
+  }
+
+  softrebootVM() {
+    this.doActionGrowl('softreboot', {});
+  }
+
+  openLogs() {
+    this.$dispatch(
+      'wm/open',
+      {
+        id:        `${ this.id }-logs`,
+        label:     this.nameDisplay,
+        icon:      'file',
+        component: 'ContainerLogs',
+        attrs:     {
+          pod:              this.podResource,
+          initialContainer: this.podResource.metadata.annotations['kubectl.kubernetes.io/default-container']
+        }
+      },
+      { root: true }
+    );
+  }
+
+  createSchedule(resources = this) {
+    const router = this.currentRouter();
+
+    router.push({
+      name:   `${ HARVESTER_PRODUCT }-c-cluster-resource-create`,
+      params: { resource: HCI.SCHEDULE_VM_BACKUP },
+      query:  { vmNamespace: this.metadata.namespace, vmName: this.metadata.name }
+    });
+  }
+
+  backupVM(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      component: 'HarvesterBackupModal'
+    });
+  }
+
+  takeVMSnapshot(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      component: 'HarvesterVMSnapshotDialog'
+    });
+  }
+
+  editVMQuota(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      snapshotSizeQuota: this.snapshotSizeQuota,
+      component:         'HarvesterQuotaDialog'
+    });
+  }
+
+  unplugVolume(diskName) {
+    const resources = this;
+
+    this.$dispatch('promptModal', {
+      resources,
+      diskName,
+      component: 'HarvesterUnplugVolume'
+    });
+  }
+
+  restoreVM(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      component: 'HarvesterRestoreDialog'
+    });
+  }
+
+  get machineType() {
+    return this.spec?.template?.spec?.domain?.machine?.type || '';
+  }
+
+  get realAttachNodeName() {
+    const vmi = this.$getters['byId'](HCI.VMI, this.id);
+    const nodeName = vmi?.status?.nodeName;
+    const node = this.$getters['byId'](NODE, nodeName);
+
+    return node?.nameDisplay || '';
+  }
+
+  get nodeName() {
+    const vmi = this.$getters['byId'](HCI.VMI, this.id);
+    const nodeName = vmi?.status?.nodeName;
+    const node = this.$getters['byId'](NODE, nodeName);
+
+    return node?.id;
+  }
+
+  pauseVM() {
+    this.doActionGrowl('pause', {});
+  }
+
+  goToCloneVM(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      component: 'CloneVmDialog'
+    });
+  }
+
+  unpauseVM() {
+    this.doActionGrowl('unpause', {});
+  }
+
+  stopVM() {
+    this.doActionGrowl('stop', {});
+  }
+
+  forceStop() {
+    this.doActionGrowl('forceStop', {});
+  }
+
+  startVM() {
+    this.doActionGrowl('start', {});
+  }
+
+  migrateVM(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      component: 'HarvesterMigrationDialog'
+    });
+  }
+
+  ejectCDROM(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      component: 'HarvesterEjectCDROMDialog'
+    });
+  }
+
+  abortMigrationVM() {
+    this.doActionGrowl('abortMigration', {});
+  }
+
+  createTemplate(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      component: 'HarvesterCloneTemplate'
+    });
+  }
+
+  addHotplug(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      component: 'HarvesterAddHotplugModal'
+    });
+  }
+
+  get networksName() {
+    const interfaces = this.spec.template.spec.domain.devices?.interfaces || [];
+
+    return interfaces.map((I) => I.name);
+  }
+
+  get isOff() {
+    return !this.isVMExpectedRunning ? { status: OFF } : null;
+  }
+
+  get isWaitingForVMI() {
+    if (this && this.isVMExpectedRunning && !this.isVMCreated) {
+      return { status: WAITING, message: VMI_WAITING_MESSAGE };
+    }
+
+    return null;
+  }
+
+  get isCpuPinning() {
+    return this.spec?.template?.spec?.domain?.cpu?.dedicatedCpuPlacement === true;
+  }
+
+  get isVMExpectedRunning() {
+    if (!this?.spec) {
+      return false;
+    }
+    const { running = null, runStrategy = null } = this.spec;
+    const conditions = this?.status?.conditions || [];
+
+    if (running) {
+      return true;
+    }
+
+    if (runStrategy !== null) {
+      let changeRequests;
+
+      switch (runStrategy) {
+      case RunStrategy.Halted:
+        return false;
+      case RunStrategy.Always:
+        return true;
+      case RunStrategy.RerunOnFailure:
+        if (
+          this.status?.printableStatus === 'ErrorUnschedulable' &&
+            conditions.find(
+              (C) => C.message && C.message.includes(IgnoreMessages)
+            )
+        ) {
+          return true;
+        }
+
+        return ['Starting', 'Running'].includes(this.status?.printableStatus);
+      case RunStrategy.Manual:
+      default:
+        changeRequests = new Set(
+          (this.status?.stateChangeRequests || []).map(
+            (chRequest) => chRequest?.action
+          )
+        );
+
+        if (changeRequests.has(StateChangeRequest.Stop)) {
+          return false;
+        }
+        if (changeRequests.has(StateChangeRequest.Start)) {
+          return true;
+        }
+
+        if (changeRequests.size === 0) {
+          return ['Starting', 'Running'].includes(
+            this.status?.printableStatus
+          );
+        }
+
+        return this.isVMCreated; // if there is no change request we can assume created is representing running (current and expected)
+      }
+    }
+
+    return false;
+  }
+
+  get podResource() {
+    const inStore = this.productInStore;
+
+    const vmiResource = this.$rootGetters[`${ inStore }/byId`](HCI.VMI, this.id);
+    const podList = this.$rootGetters[`${ inStore }/all`](POD);
+
+    return podList.find((P) => {
+      return (
+        vmiResource?.metadata?.name &&
+        vmiResource?.metadata?.name === P.metadata?.ownerReferences?.[0].name
+      );
+    });
+  }
+
+  get isPaused() {
+    const conditions = this.vmi?.status?.conditions || [];
+    const isPause = conditions.filter((cond) => cond.type === PAUSED).length > 0;
+
+    return isPause ? {
+      status:  PAUSED,
+      message: PAUSED_VM_MODAL_MESSAGE
+    } : null;
+  }
+
+  get isVMError() {
+    const conditions = get(this, 'status.conditions');
+    const vmFailureCond = findBy(conditions, 'type', 'Failure');
+
+    if (vmFailureCond) {
+      return {
+        status:          VM_ERROR,
+        detailedMessage: vmFailureCond.message
+      };
+    }
+
+    return null;
+  }
+
+  get nsResourceQuota() {
+    const inStore = this.productInStore;
+    const allResQuotas = this.$rootGetters[`${ inStore }/all`](HCI.RESOURCE_QUOTA);
+
+    return allResQuotas.find( (RQ) => RQ.namespace === this.metadata.namespace);
+  }
+
+  get snapshotSizeQuota() {
+    return this.nsResourceQuota?.spec?.snapshotLimit?.vmTotalSnapshotSizeQuota?.[this.metadata.name];
+  }
+
+  get vmi() {
+    const inStore = this.productInStore;
+
+    const vmis = this.$rootGetters[`${ inStore }/all`](HCI.VMI);
+
+    return vmis.find((VMI) => VMI.id === this.id);
+  }
+
+  get encryptedVolumeType() {
+    const inStore = this.productInStore;
+    const pvcs = this.$rootGetters[`${ inStore }/all`](PVC);
+
+    const volumeClaimNames = this.spec.template.spec.volumes?.map((v) => v.persistentVolumeClaim?.claimName).filter((v) => !!v) || [];
+    const volumes = pvcs.filter((pvc) => volumeClaimNames.includes(pvc.metadata.name));
+
+    if (volumes.every((vol) => vol.isEncrypted)) {
+      return 'all';
+    } else if (volumes.some((vol) => vol.isEncrypted)) {
+      return 'partial';
+    } else {
+      return 'none';
+    }
+  }
+
+  get isError() {
+    const conditions = get(this.vmi, 'status.conditions');
+    const vmiFailureCond = findBy(conditions, 'type', 'Failure');
+
+    if (vmiFailureCond) {
+      return { status: 'VMI error', detailedMessage: vmiFailureCond.message };
+    }
+
+    if ((this.vmi || this.isVMCreated) && this.podResource) {
+      // const podStatus = this.podResource.getPodStatus;
+      // if (POD_STATUS_ALL_ERROR.includes(podStatus?.status)) {
+      //   return {
+      //     ...podStatus,
+      //     status: 'LAUNCHER_POD_ERROR',
+      //     pod:    this.podResource,
+      //   };
+      // }
+    }
+
+    return this?.vmi?.status?.phase;
+  }
+
+  get isRunning() {
+    const conditions = get(this.vmi, 'status.conditions');
+    const isVMIReady = findBy(conditions, 'type', 'Ready')?.status === 'True';
+
+    if (this.vmi?.status?.phase === VMIPhase.Running && isVMIReady) {
+      return { status: VMIPhase.Running };
+    }
+
+    return null;
+  }
+
+  get isNotReady() {
+    const conditions = get(this.vmi, 'status.conditions');
+    const VMIReadyCondition = findBy(conditions, 'type', 'Ready');
+
+    if (
+      VMIReadyCondition?.status === 'False' &&
+      this.vmi?.status?.phase === VMIPhase.Running
+    ) {
+      return { status: NOT_READY };
+    }
+
+    return null;
+  }
+
+  get isBeingStopped() {
+    if (this && !this.isVMExpectedRunning && this.isVMCreated && this.vmi?.status?.phase !== VMIPhase.Succeeded) {
+      return { status: STOPPING };
+    }
+
+    return null;
+  }
+
+  get isStarting() {
+    if (this.isVMExpectedRunning && this.isVMCreated) {
+      // created but not yet ready
+      if (this.podResource) {
+        const podStatus = this.podResource.getPodStatus;
+
+        if (!POD_STATUS_ALL_READY.includes(podStatus?.status)) {
+          return {
+            ...podStatus,
+            status:          'Starting',
+            message:         STARTING_MESSAGE,
+            detailedMessage: podStatus?.message,
+            pod:             this.podResource
+          };
+        }
+      }
+
+      return {
+        status:  'Starting',
+        message: STARTING_MESSAGE,
+        pod:     this.podResource
+      };
+    }
+
+    return null;
+  }
+
+  get isUnschedulable() {
+    if (this.isBeingStopped || this.isStarting) {
+      const condition = this.status?.conditions?.find((c) => c.reason === UNSCHEDULABLE);
+
+      if (!!condition) {
+        return {
+          status:  UNSCHEDULABLE,
+          message: condition.message || 'VM is unschedulable',
+        };
+      }
+    }
+
+    return null;
+  }
+
+  get isTerminating() {
+    return !!this?.metadata?.deletionTimestamp;
+  }
+
+  get otherState() {
+    const state = (this.vmi &&
+      [VMIPhase.Scheduling, VMIPhase.Scheduled].includes(
+        this.vmi?.status?.phase
+      ) && {
+      status:  'Starting',
+      message: STARTING_MESSAGE
+    }) ||
+      (this.vmi &&
+        this.vmi.status?.phase === VMIPhase.Pending && {
+        status:  'VMI_WAITING',
+        message: VMI_WAITING_MESSAGE
+      }) ||
+      (this.vmi &&
+        this.vmi?.status?.phase === VMIPhase.Failed && { status: 'VMI_ERROR' }) ||
+      (this.isVMExpectedRunning &&
+        !this.isVMCreated && { status: 'Pending' }) || { status: 'UNKNOWN' };
+
+    return state;
+  }
+
+  get isVMCreated() {
+    return !!this?.status?.created;
+  }
+
+  get getDataVolumeTemplates() {
+    return get(this, 'spec.volumeClaimTemplates') === null ? [] : this.spec.volumeClaimTemplates;
+  }
+
+  get restoreResource() {
+    const id = `${ this.metadata.namespace }/${ get(
+      this,
+      `metadata.annotations."${ HCI_ANNOTATIONS.RESTORE_NAME }"`
+    ) }`;
+
+    const inStore = this.productInStore;
+
+    const allRestore = this.$rootGetters[`${ inStore }/all`](HCI.RESTORE);
+
+    const res = allRestore.find((O) => O.id === id);
+
+    if (res) {
+      const allBackups = this.$rootGetters[`${ inStore }/all`](HCI.BACKUP);
+
+      res.fromSnapshot = !!allBackups
+        .filter((b) => b.spec?.type !== BACKUP_TYPE.BACKUP)
+        .find((s) => s.id === `${ res.spec?.virtualMachineBackupNamespace }/${ res.spec?.virtualMachineBackupName }`);
+    }
+
+    return res;
+  }
+
+  get restoreProgress() {
+    if (this.isVMError || this.isTerminating) {
+      return {};
+    }
+
+    const status = this.restoreResource?.status;
+
+    if (status !== undefined) {
+      return {
+        type:       'restore',
+        percentage: status?.progress || 0,
+        details:    { volumes: status?.restores || [] }
+      };
+    }
+
+    return {};
+  }
+
+  get restoreState() {
+    if (!this.restoreResource) {
+      return true;
+    }
+
+    return this.restoreResource?.isComplete;
+  }
+
+  get actualState() {
+    if (!this.restoreState) {
+      return 'Restoring';
+    }
+
+    if (this.isTerminating) {
+      return 'Terminating';
+    }
+
+    if (
+      !!this?.vmi?.migrationState &&
+      this.vmi.migrationState.status !== 'Failed'
+    ) {
+      return this.vmi.migrationState.status;
+    }
+
+    const state =
+      this.isUnschedulable?.status ||
+      this.isPaused?.status ||
+      this.isVMError?.status ||
+      this.isBeingStopped?.status ||
+      this.isOff?.status ||
+      this.isError?.status ||
+      this.isRunning?.status ||
+      this.isNotReady?.status ||
+      this.isStarting?.status ||
+      this.isWaitingForVMI?.state ||
+      this.otherState?.status;
+
+    return state;
+  }
+
+  get warningMessage() {
+    if (this.metadata?.annotations[HCI_ANNOTATIONS.VM_INSUFFICIENT]) {
+      return {
+        message:    this.metadata?.annotations[HCI_ANNOTATIONS.VM_INSUFFICIENT],
+        canDismiss: true,
+      };
+    }
+
+    const conditions = get(this, 'status.conditions');
+    const vmFailureCond = findBy(conditions, 'type', 'Failure');
+
+    if (vmFailureCond) {
+      return {
+        status:  VM_ERROR,
+        message: vmFailureCond.message
+      };
+    }
+
+    const vmiConditions = get(this.vmi, 'status.conditions');
+    const vmiFailureCond = findBy(vmiConditions, 'type', 'Failure');
+
+    if (vmiFailureCond) {
+      return { status: 'VMI error', detailedMessage: vmiFailureCond.message };
+    }
+
+    if ((this.vmi || this.isVMCreated) && this.podResource) {
+      const podStatus = this.podResource.getPodStatus;
+
+      if (POD_STATUS_ALL_ERROR.includes(podStatus?.status)) {
+        return {
+          ...podStatus,
+          status: 'LAUNCHER_POD_ERROR',
+          pod:    this.podResource
+        };
+      }
+    }
+
+    return null;
+  }
+
+  get migrationMessage() {
+    if (
+      !!this?.vmi?.migrationState &&
+      this.vmi.migrationState.status === 'Failed'
+    ) {
+      return {
+        ...this.actualState,
+        message: this.t('harvester.modal.migration.failedMessage')
+      };
+    }
+
+    return null;
+  }
+
+  get stateDisplay() {
+    return this.actualState;
+  }
+
+  get stateColor() {
+    const state = this.actualState;
+
+    return colorForState(state);
+  }
+
+  get networkIps() {
+    let networkData = '';
+    const out = [];
+    const arrVolumes = this.spec.template?.spec?.volumes || [];
+
+    arrVolumes.forEach((V) => {
+      if (V.cloudInitNoCloud) {
+        networkData = V.cloudInitNoCloud.networkData;
+      }
+    });
+
+    try {
+      const newInitScript = load(networkData);
+
+      if (newInitScript?.config && Array.isArray(newInitScript.config)) {
+        const config = newInitScript.config;
+
+        config.forEach((O) => {
+          if (O?.subnets && Array.isArray(O.subnets)) {
+            const subnets = O.subnets;
+
+            subnets.forEach((S) => {
+              if (S.address) {
+                out.push(S.address);
+              }
+            });
+          }
+        });
+      }
+    } catch (err) {}
+
+    return out;
+  }
+
+  get warningCount() {
+    return this.resourcesStatus.warningCount;
+  }
+
+  get errorCount() {
+    return this.resourcesStatus.errorCount;
+  }
+
+  get resourcesStatus() {
+    const inStore = this.productInStore;
+    const vmList = this.$rootGetters[`${ inStore }/all`](HCI.VM);
+    let warningCount = 0;
+    let errorCount = 0;
+
+    vmList.forEach((vm) => {
+      const status = vm.actualState;
+
+      if (status === VM_ERROR) {
+        errorCount += 1;
+      } else if (
+        status === 'Stopping' ||
+        status === 'Waiting' ||
+        status === 'Pending' ||
+        status === 'Starting' ||
+        status === 'Terminating'
+      ) {
+        warningCount += 1;
+      }
+    });
+
+    return {
+      warningCount,
+      errorCount
+    };
+  }
+
+  get volumeClaimTemplates() {
+    return parseVolumeClaimTemplates(this);
+  }
+
+  get persistentVolumeClaimName() {
+    const volumes = this.spec.template.spec.volumes || [];
+
+    return volumes
+      .map((O) => {
+        return O?.persistentVolumeClaim?.claimName;
+      })
+      .filter((name) => !!name);
+  }
+
+  get rootImageId() {
+    let imageId = '';
+    const inStore = this.productInStore;
+    const pvcs = this.$rootGetters[`${ inStore }/all`](PVC) || [];
+
+    const volumes = this.spec.template.spec.volumes || [];
+
+    const firstVolumeName = volumes[0]?.persistentVolumeClaim?.claimName;
+    const isNoExistingVolume = this.volumeClaimTemplates.find((volume) => {
+      return firstVolumeName === volume?.metadata?.name;
+    });
+
+    if (!isNoExistingVolume) {
+      const existingVolume = pvcs.find(
+        (P) => P.id === `${ this.metadata.namespace }/${ firstVolumeName }`
+      );
+
+      if (existingVolume) {
+        return existingVolume?.metadata?.annotations?.[
+          'harvesterhci.io/imageId'
+        ];
+      }
+    }
+
+    this.volumeClaimTemplates.find((volume) => {
+      imageId = volume?.metadata?.annotations?.['harvesterhci.io/imageId'];
+
+      return !!imageId;
+    });
+
+    return imageId;
+  }
+
+  get restoreName() {
+    return (
+      get(this, `metadata.annotations."${ HCI_ANNOTATIONS.RESTORE_NAME }"`) || ''
+    );
+  }
+
+  get customValidationRules() {
+    const rules = [
+      {
+        nullable:       false,
+        path:           'metadata.name',
+        required:       true,
+        minLength:      1,
+        maxLength:      63,
+        translationKey: 'harvester.fields.name'
+      },
+      {
+        nullable:       false,
+        path:           'spec.template.spec.domain.cpu.cores',
+        min:            1,
+        required:       true,
+        translationKey: 'harvester.fields.cpu'
+      },
+      {
+        nullable:       false,
+        path:           'spec.template.spec.domain.resources.limits.memory',
+        required:       true,
+        translationKey: 'harvester.fields.memory'
+      },
+      {
+        nullable:   false,
+        path:       'spec.template.spec',
+        validators: ['vmNetworks']
+      },
+      {
+        nullable:   false,
+        path:       'spec',
+        validators: [`vmDisks`]
+      }
+    ];
+
+    return rules;
+  }
+
+  get attachNetwork() {
+    const networks = this.spec?.template?.spec?.networks || [];
+    const hasMultus = networks.find((N) => N.multus);
+
+    return !!hasMultus;
+  }
+
+  get memorySort() {
+    const memory =
+      this?.spec?.template?.spec?.domain?.resources?.requests?.memory || 0;
+
+    const formatSize = parseSi(memory);
+
+    return parseInt(formatSize);
+  }
+
+  get ingoreVMMessage() {
+    const ignoreConditions = [
+      {
+        name:    'unavailable',
+        error:   false,
+        vmState: this.actualState === PAUSED
+      }
+    ];
+
+    const state = this.metadata?.state;
+
+    return (
+      ignoreConditions.find(
+        (condition) => condition.name === state?.name &&
+          condition.error === state?.error &&
+          condition.vmState
+      ) ||
+      IgnoreMessages.find((M) => super.stateDescription?.includes(M)) ||
+      this.isOff
+    );
+  }
+
+  get stateDescription() {
+    return this.ingoreVMMessage ? '' : super.stateDescription;
+  }
+
+  get displayMemory() {
+    return (
+      this.spec.template.spec.domain.resources?.limits?.memory ||
+      this.spec.template.spec.domain.resources?.requests?.memory
+    );
+  }
+
+  get isQemuInstalled() {
+    const conditions = this.vmi?.status?.conditions || [];
+    const qemu = conditions.find((cond) => cond.type === AGENT_CONNECTED);
+
+    return qemu?.status === 'True';
+  }
+
+  get warnDeletionMessage() {
+    return this.t('harvester.virtualMachine.promptRemove.tips');
+  }
+
+  get instanceLabels() {
+    const all = this.spec?.template?.metadata?.labels || {};
+
+    return omitBy(all, (value, key) => {
+      return matchesSomeRegex(key, LABELS_TO_IGNORE_REGEX);
+    });
+  }
+
+  get hostDevices() {
+    return this.spec?.template?.spec?.domain?.devices?.hostDevices || [];
+  }
+
+  get provisionedVGpus() {
+    try {
+      const deviceAllocationDetails = JSON.parse(this.metadata?.annotations[HCI_ANNOTATIONS.VM_DEVICE_ALLOCATION_DETAILS] || '{}');
+
+      return deviceAllocationDetails?.gpus || {};
+    } catch (error) {
+      return {};
+    }
+  }
+
+  setInstanceLabels(val) {
+    if ( !this.spec?.template?.metadata?.labels ) {
+      set(this, 'spec.template.metadata.labels', {});
+    }
+
+    const all = this.spec.template.metadata.labels || {};
+    const wasIgnored = pickBy(all, (value, key) => {
+      return matchesSomeRegex(key, LABELS_TO_IGNORE_REGEX);
+    });
+
+    this.spec.template.metadata['labels'] = { ...wasIgnored, ...val };
+  }
+
+  get pippo() {
+    // return this.$rootGetters['harvester/byId'](HCI.SETTING, 'server-version');
+
+    console.log(this.$rootGetters);
+
+    return this.$rootGetters['harvester/byId'](HCI.SETTING, 'server-version');
+  }
+
+  get rootGetters() {
+    return this.$rootGetters;
+  }
+}

--- a/pkg/harvester/pages/c/_cluster/_resource/_id.vue
+++ b/pkg/harvester/pages/c/_cluster/_resource/_id.vue
@@ -1,5 +1,5 @@
 <script>
-import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+import ResourceDetail from '@pkg/harvester/components/ResourceDetail/index.vue';
 
 export default {
   name:       'HarvesterResourcedId',

--- a/pkg/harvester/pages/c/_cluster/_resource/_namespace/_id.vue
+++ b/pkg/harvester/pages/c/_cluster/_resource/_namespace/_id.vue
@@ -1,5 +1,5 @@
 <script>
-import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+import ResourceDetail from '@pkg/harvester/components/ResourceDetail/index.vue';
 
 export default {
   name:       'HarvesterResourcedNamespaceId',

--- a/pkg/harvester/pages/c/_cluster/_resource/create.vue
+++ b/pkg/harvester/pages/c/_cluster/_resource/create.vue
@@ -1,5 +1,5 @@
 <script>
-import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+import ResourceDetail from '@pkg/harvester/components/ResourceDetail/index.vue';
 
 export default {
   name:       'HarvesterResourceCreate',

--- a/pkg/harvester/pages/c/_cluster/_resource/index.vue
+++ b/pkg/harvester/pages/c/_cluster/_resource/index.vue
@@ -1,5 +1,5 @@
 <script>
-import ResourceList from '@shell/components/ResourceList/index.vue';
+import ResourceList from '@pkg/harvester/components/ResourceList/index.vue';
 
 export default {
   name:       'HarvesterResourcedList',

--- a/pkg/harvester/store/harvester-store/getters.ts
+++ b/pkg/harvester/store/harvester-store/getters.ts
@@ -141,4 +141,107 @@ export default {
   
     return lookup(state.config.namespace, obj?.type, obj?.metadata?.name, rootState) || Resource;
   },
+
+  getCustomList(state, getters, rootState, rootGetters) {
+    return (resource) => {
+
+      const version = serverVersion(rootGetters);
+
+      if (version) {
+        const componentVersion = `${ resource }-${ version }`;
+
+        const hasVersionComponent = rootGetters['type-map/hasCustomList'](componentVersion);
+
+        if (hasVersionComponent) {
+          return componentVersion;
+        }
+      }
+
+      if (rootGetters['type-map/hasCustomList'](resource)) {
+        return resource;
+      }
+
+      return null;
+    }
+  },
+
+  hasCustomDetail(state, getters, rootState, rootGetters) {
+    return (resource, id) => {
+
+      const version = serverVersion(rootGetters);
+
+      if (version) {
+        const componentVersion = `${ resource }-${ version }`;
+
+        const hasVersionComponent = rootGetters['type-map/hasCustomDetail'](componentVersion, id);
+
+        if (hasVersionComponent) {
+          return componentVersion;
+        }
+      }
+
+      if (rootGetters['type-map/hasCustomDetail'](resource, id)) {
+        return resource;
+      }
+
+      return null;
+    }
+  },
+
+  hasCustomEdit(state, getters, rootState, rootGetters) {
+    return (resource, id) => {
+
+      const version = serverVersion(rootGetters);
+
+      if (version) {
+        const componentVersion = `${ resource }-${ version }`;
+
+        const hasVersionComponent = rootGetters['type-map/hasCustomEdit'](componentVersion, id);
+
+        if (hasVersionComponent) {
+          return componentVersion;
+        }
+      }
+
+      if (rootGetters['type-map/hasCustomEdit'](resource, id)) {
+        return resource;
+      }
+
+      return null;
+    }
+  },
+
+  importDetail(state, getters, rootState, rootGetters) {
+    return (resource, id) => {
+
+      const version = serverVersion(rootGetters);
+
+      if (version) {
+        const componentVersion = `${ resource }-${ version }`;
+
+        if (rootGetters['type-map/hasCustomDetail'](componentVersion, id)) {
+          return rootGetters['type-map/importDetail'](componentVersion, id);
+        }
+      }
+
+      return rootGetters['type-map/importDetail'](resource, id);
+    }
+  },
+
+  importEdit(state, getters, rootState, rootGetters) {
+    return (resource, id) => {
+
+      const version = serverVersion(rootGetters);
+
+      if (version) {
+        const componentVersion = `${ resource }-${ version }`;
+
+        if (rootGetters['type-map/hasCustomEdit'](componentVersion, id)) {
+          return rootGetters['type-map/importEdit'](componentVersion, id);
+        }
+      }
+
+      return rootGetters['type-map/importEdit'](resource, id);
+    }
+  },
 };

--- a/pkg/harvester/store/harvester-store/getters.ts
+++ b/pkg/harvester/store/harvester-store/getters.ts
@@ -7,6 +7,9 @@ import {
 import { MANAGEMENT } from '@shell/config/types';
 import { sortBy } from '@shell/utils/sort';
 import { filterBy } from '@shell/utils/array';
+import Resource from '@shell/plugins/dashboard-store/resource-class';
+import { lookup } from '@shell/plugins/dashboard-store/model-loader';
+import { serverVersion } from '@pkg/harvester/utils/server';
 
 export default {
   namespaceFilterOptions: (state: any, getters: any, rootState: any, rootGetters: any) => ({
@@ -123,5 +126,19 @@ export default {
     const clusterId = currentCluster.id;
 
     return projectsInAllClusters.filter((project: any) => project.spec.clusterName === clusterId && project.nameDisplay !== 'System');
-  }
+  },
+
+  classify: (state, getters, rootState, rootGetters) => (obj) => {
+    const version = serverVersion(rootGetters);
+
+    const modelVersion = version ? `${ obj?.type }-${ version }` : obj?.type;
+
+    const model = lookup(state.config.namespace, modelVersion, obj?.metadata?.name, rootState);
+
+    if (model) {
+      return model;
+    }
+  
+    return lookup(state.config.namespace, obj?.type, obj?.metadata?.name, rootState) || Resource;
+  },
 };

--- a/pkg/harvester/utils/server.js
+++ b/pkg/harvester/utils/server.js
@@ -1,0 +1,17 @@
+import semver from 'semver';
+import { HCI } from '../types';
+
+export function serverVersion(getters) {
+  if (process.env.VUE_APP_SERVER_VERSION) {
+    return process.env.VUE_APP_SERVER_VERSION;
+  }
+
+  try {
+    const v = getters['harvester/byId'](HCI.SETTING, 'server-version')?.value;
+
+    return `v-${semver.major(v)}.${semver.minor(v)}.${semver.patch(v)}`;
+  } catch (error) {}
+
+  return '';
+}
+

--- a/pkg/harvester/utils/server.js
+++ b/pkg/harvester/utils/server.js
@@ -9,9 +9,8 @@ export function serverVersion(getters) {
   try {
     const v = getters['harvester/byId'](HCI.SETTING, 'server-version')?.value;
 
-    return `v-${semver.major(v)}.${semver.minor(v)}.${semver.patch(v)}`;
+    return `v-${ semver.major(v) }.${ semver.minor(v) }.${ semver.patch(v) }`;
   } catch (error) {}
 
   return '';
 }
-


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Implementing custom components and store functions to support multiple server versions.

Usage:

- Define a component in` list/edit/details/models` directory, where the root path is the resource name and the suffix is the server version that we want to support.

  example:
    - default component, supports `latest` server: `pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue`
    - v1.3.0 component, support server v1.3: `pkg/harvester/edit/kubevirt.io.virtualmachine-v1.3.0/index.vue`
    
- The server version can be specified with the `VUE_APP_SERVER_VERSION` env variable:
  ```
  VUE_APP_SERVER_VERSION=v1.4.0 RANCHER_ENV=harvester API=192.168.0.131 yarn dev
  ```
- If `VUE_APP_SERVER_VERSION` is null, the UI takes the server version from the settings (prod build).


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


