### PR TITLE
Disable cluster link if harvester version lower than v1.3.0

### DIFF
--- a/pkg/harvester/components/UpgradeInfo.vue
+++ b/pkg/harvester/components/UpgradeInfo.vue
@@ -21,7 +21,7 @@ export default {
     },
 
     upgradeLink() {
-      const version = this.$rootGetters['harvester-common/getServerVersion']();
+      const version = this.$store.getters['harvester-common/getServerVersion']();
 
       return docLink(DOC.UPGRADE_URL, version);
     }

--- a/pkg/harvester/components/UpgradeInfo.vue
+++ b/pkg/harvester/components/UpgradeInfo.vue
@@ -21,7 +21,9 @@ export default {
     },
 
     upgradeLink() {
-      return docLink(DOC.UPGRADE_URL, this.$store.getters);
+      const version = this.$rootGetters['harvester-common/getServerVersion']();
+
+      return docLink(DOC.UPGRADE_URL, version);
     }
   },
 };

--- a/pkg/harvester/components/settings/storage-network.vue
+++ b/pkg/harvester/components/settings/storage-network.vue
@@ -88,7 +88,7 @@ export default {
 
   computed: {
     storageNetworkExampleLink() {
-      const version = this.$rootGetters['harvester-common/getServerVersion']();
+      const version = this.$store.getters['harvester-common/getServerVersion']();
 
       return docLink(DOC.STORAGE_NETWORK_EXAMPLE, version);
     },

--- a/pkg/harvester/components/settings/storage-network.vue
+++ b/pkg/harvester/components/settings/storage-network.vue
@@ -88,7 +88,9 @@ export default {
 
   computed: {
     storageNetworkExampleLink() {
-      return docLink(DOC.STORAGE_NETWORK_EXAMPLE, this.$store.getters);
+      const version = this.$rootGetters['harvester-common/getServerVersion']();
+
+      return docLink(DOC.STORAGE_NETWORK_EXAMPLE, version);
     },
     clusterNetworkOptions() {
       const inStore = this.$store.getters['currentProduct'].inStore;

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -1,16 +1,18 @@
 // https://github.com/harvester/dashboard/releases/tag/v1.3.0
-const featuresV130 = [];
+const featuresV130 = [
+  'supportHarvesterClusterVersion'
+];
 
 // https://github.com/harvester/dashboard/releases/tag/v1.3.1
 const featuresV131 = [
+  ...featuresV130,
   'autoRotateRke2CertsSetting',
   'supportBundleNodeCollectionTimeoutSetting'
 ];
 
 // https://github.com/harvester/dashboard/releases/tag/v1.3.2
 const featuresV132 = [
-  'autoRotateRke2CertsSetting',
-  'supportBundleNodeCollectionTimeoutSetting',
+  ...featuresV131,
   'kubeconfigDefaultTokenTTLMinutesSetting',
 ];
 
@@ -21,9 +23,7 @@ const featuresV132 = [
 // https://github.com/harvester/dashboard/releases/tag/v1.4.0-rc2
 // https://github.com/harvester/dashboard/releases/tag/v1.4.0-rc1
 const featuresV140 = [
-  'autoRotateRke2CertsSetting',
-  'supportBundleNodeCollectionTimeoutSetting',
-  'kubeconfigDefaultTokenTTLMinutesSetting',
+  ...featuresV132,
   'cpuPinning',
   'usbPassthrough',
   'volumeEncryption',

--- a/pkg/harvester/config/harvester-manager.js
+++ b/pkg/harvester/config/harvester-manager.js
@@ -53,7 +53,15 @@ export function init($plugin, store) {
     STATE,
     NAME_COL,
     {
+      name:     'harvesterVersion',
+      sort:     'harvesterVersion',
+      labelKey: 'harvesterManager.tableHeaders.harvesterVersion',
+      value:    'HarvesterVersion',
+      getValue: (row) => row.harvesterVersion
+    },
+    {
       ...VERSION,
+      labelKey: 'harvesterManager.tableHeaders.kubernetesVersion',
       value:    'kubernetesVersion',
       getValue: (row) => row.kubernetesVersion
     },

--- a/pkg/harvester/edit/harvesterhci.io.host/HarvesterKsmtuned.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/HarvesterKsmtuned.vue
@@ -91,7 +91,9 @@ export default {
     },
 
     ksmtunedLink() {
-      return docLink(DOC.KSMTUNED_MODE, this.$store.getters);
+      const version = this.$rootGetters['harvester-common/getServerVersion']();
+
+      return docLink(DOC.KSMTUNED_MODE, version);
     }
   },
 

--- a/pkg/harvester/edit/harvesterhci.io.host/HarvesterKsmtuned.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/HarvesterKsmtuned.vue
@@ -91,7 +91,7 @@ export default {
     },
 
     ksmtunedLink() {
-      const version = this.$rootGetters['harvester-common/getServerVersion']();
+      const version = this.$store.getters['harvester-common/getServerVersion']();
 
       return docLink(DOC.KSMTUNED_MODE, version);
     }

--- a/pkg/harvester/edit/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester/edit/harvesterhci.io.management.cluster.vue
@@ -113,6 +113,12 @@ export default {
     @finish="saveOverride"
     @error="e=>errors = e"
   >
+    <Banner
+      v-if="isCreate"
+      color="info"
+    >
+      {{ t('harvesterManager.cluster.supportMessage') }}
+    </Banner>>
     <div class="mt-20">
       <NameNsDescription
         v-if="!isView"

--- a/pkg/harvester/edit/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester/edit/harvesterhci.io.management.cluster.vue
@@ -115,10 +115,10 @@ export default {
   >
     <Banner
       v-if="isCreate"
-      color="info"
+      color="warning"
     >
       {{ t('harvesterManager.cluster.supportMessage') }}
-    </Banner>>
+    </Banner>
     <div class="mt-20">
       <NameNsDescription
         v-if="!isView"

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -5,7 +5,7 @@ harvesterManager:
     none: There are no Harvester Clusters
     learnMore: Learn more about Harvester from the <a target="_blank" href="https://harvesterhci.io/" rel="noopener noreferrer nofollow">Harvester Web Site</a> or read the the <a target="_blank" href="https://docs.harvesterhci.io/" rel="noopener noreferrer nofollow">Harvester Docs</a>
     description: Harvester is a modern Hyperconverged infrastructure (HCI) solution built for bare metal servers using enterprise-grade open source technologies including Kubernetes, Kubevirt and Longhorn.
-    supportMessage: Harvester UI Extension only supports Harvester cluster version >= 1.3.0
+    supportMessage: Harvester ui extension only supports Harvester cluster version greater or equal to 1.3.0
   plugins:
     loadError: Error loading harvester plugin
   rke:

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1,5 +1,8 @@
 harvesterManager:
   manage: Manage
+  tableHeaders:
+    kubernetesVersion: Kubernetes Version
+    harvesterVersion: Harvester Version
   cluster:
     label: Harvester Clusters
     none: There are no Harvester Clusters

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -5,6 +5,7 @@ harvesterManager:
     none: There are no Harvester Clusters
     learnMore: Learn more about Harvester from the <a target="_blank" href="https://harvesterhci.io/" rel="noopener noreferrer nofollow">Harvester Web Site</a> or read the the <a target="_blank" href="https://docs.harvesterhci.io/" rel="noopener noreferrer nofollow">Harvester Docs</a>
     description: Harvester is a modern Hyperconverged infrastructure (HCI) solution built for bare metal servers using enterprise-grade open source technologies including Kubernetes, Kubevirt and Longhorn.
+    supportMessage: Harvester UI Extension only supports Harvester cluster version >= 1.3.0
   plugins:
     loadError: Error loading harvester plugin
   rke:

--- a/pkg/harvester/list/harvesterhci.io.host.vue
+++ b/pkg/harvester/list/harvesterhci.io.host.vue
@@ -167,7 +167,7 @@ export default {
     },
 
     consoleDocLink() {
-      const version = this.$rootGetters['harvester-common/getServerVersion']();
+      const version = this.$store.getters['harvester-common/getServerVersion']();
 
       return docLink(DOC.CONSOLE_URL, version);
     }

--- a/pkg/harvester/list/harvesterhci.io.host.vue
+++ b/pkg/harvester/list/harvesterhci.io.host.vue
@@ -167,7 +167,9 @@ export default {
     },
 
     consoleDocLink() {
-      return docLink(DOC.CONSOLE_URL, this.$store.getters);
+      const version = this.$rootGetters['harvester-common/getServerVersion']();
+
+      return docLink(DOC.CONSOLE_URL, version);
     }
   },
   methods: {

--- a/pkg/harvester/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester/list/harvesterhci.io.management.cluster.vue
@@ -83,6 +83,7 @@ export default {
           if (row.isReady) {
             row.setSupportedHarvesterVersion();
           }
+
           return row;
         });
     },

--- a/pkg/harvester/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester/list/harvesterhci.io.management.cluster.vue
@@ -87,6 +87,16 @@ export default {
   },
 
   methods: {
+    disableClusterLink(row) {
+      // eslint-disable-next-line no-console
+      console.log('🚀 ~ disableClusterLink ~ row:', row);
+      if (!row.isSupportedHarvesterVersion) {
+        return true;
+      }
+
+      return this.navigating ? true : null;
+    },
+
     async goToCluster(row) {
       const timeout = setTimeout(() => {
         // Don't show loading indicator for quickly fetched plugins
@@ -148,7 +158,7 @@ export default {
             <a
               v-if="row.isReady"
               class="link"
-              :disabled="navigating ? true : null"
+              :disabled="disableClusterLink(row)"
               @click="goToCluster(row)"
             >{{ row.nameDisplay }}</a>
             <span v-else>

--- a/pkg/harvester/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester/list/harvesterhci.io.management.cluster.vue
@@ -87,16 +87,6 @@ export default {
   },
 
   methods: {
-    disableClusterLink(row) {
-      // eslint-disable-next-line no-console
-      console.log('🚀 ~ disableClusterLink ~ row:', row);
-      if (!row.isSupportedHarvesterVersion) {
-        return true;
-      }
-
-      return this.navigating ? true : null;
-    },
-
     async goToCluster(row) {
       const timeout = setTimeout(() => {
         // Don't show loading indicator for quickly fetched plugins
@@ -156,9 +146,9 @@ export default {
         <td>
           <span class="cluster-link">
             <a
-              v-if="row.isReady"
+              v-if="row.isReady && row.isSupportedHarvesterVersion"
               class="link"
-              :disabled="disableClusterLink(row)"
+              :disabled="navigating ? true : null"
               @click="goToCluster(row)"
             >{{ row.nameDisplay }}</a>
             <span v-else>

--- a/pkg/harvester/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester/list/harvesterhci.io.management.cluster.vue
@@ -31,7 +31,6 @@ export default {
 
   async fetch() {
     const inStore = this.$store.getters['currentProduct'].inStore;
-
     const hash = await allHash({
       hciClusters:  this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.CLUSTER }),
       mgmtClusters: this.$store.dispatch(`${ inStore }/findAll`, { type: MANAGEMENT.CLUSTER })
@@ -39,6 +38,25 @@ export default {
 
     this.hciClusters = hash.hciClusters;
     this.mgmtClusters = hash.mgmtClusters;
+
+    for (const cluster of this.mgmtClusters) {
+      const clusterId = cluster.id;
+
+      if (clusterId === 'local') {
+        continue;
+      }
+      if (clusterId) {
+        try {
+          const settingUrl = `/k8s/clusters/${ clusterId }/v1/harvester/${ HCI.SETTING }s?exclude=metadata.managedFields`;
+
+          const r = await this.$store.dispatch('request', { url: settingUrl, method: 'get' });
+
+          console.log('🚀 ~ fetch ~r  = ', r);
+        } catch (e) {
+          console.info(`Failed to fetch harvester setting from ${ clusterId }, error=${ e }`); // eslint-disable-line no-console
+        }
+      }
+    }
   },
 
   data() {

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -15,7 +15,6 @@ import { ucFirst } from '@shell/utils/string';
 import HarvesterResource from '../harvester';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 import { HCI } from '../../types';
-import { featureEnabled } from '../../utils/feature-flags';
 
 const ALLOW_SYSTEM_LABEL_KEYS = [
   'topology.kubernetes.io/zone',
@@ -371,7 +370,7 @@ export default class HciNode extends HarvesterResource {
   }
 
   get cpuPinningFeatureEnabled() {
-    return featureEnabled(this.$rootGetters, 'cpuPinning');
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('cpuPinning');
   }
 
   get isCPUManagerEnabled() {

--- a/pkg/harvester/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester/models/harvesterhci.io.management.cluster.js
@@ -2,7 +2,8 @@ import ProvCluster from '@shell/models/provisioning.cattle.io.cluster';
 import { DEFAULT_WORKSPACE, HCI, MANAGEMENT } from '@shell/config/types';
 import { HARVESTER_NAME, HARVESTER_NAME as VIRTUAL } from '@shell/config/features';
 import { SETTING } from '@shell/config/settings';
-
+import semver from 'semver';
+import { serverVersion } from '../utils/feature-flags';
 export default class HciCluster extends ProvCluster {
   get stateObj() {
     return this._stateObj;
@@ -27,6 +28,26 @@ export default class HciCluster extends ProvCluster {
 
   get canEdit() {
     return false;
+  }
+
+  get stateDescription() {
+    if (!this.isSupportedHarvesterVersion) {
+      return this.t('harvesterManager.cluster.supportMessage');
+    }
+
+    return '';
+  }
+
+  /**
+   * harvester ui extension only supports harvester cluster version >= 1.3.0
+   */
+  get isSupportedHarvesterVersion() {
+    const version = serverVersion(this.$rootGetters);
+
+    // eslint-disable-next-line no-console
+    console.log('🚀 ~ HciCluster ~ getisSupportedHarvesterVersion ~ version:', version);
+
+    return semver.gte(version, '1.3.0');
   }
 
   /**

--- a/pkg/harvester/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester/models/harvesterhci.io.management.cluster.js
@@ -4,8 +4,14 @@ import { HARVESTER_NAME, HARVESTER_NAME as VIRTUAL } from '@shell/config/feature
 import { SETTING } from '@shell/config/settings';
 import semver from 'semver';
 import { serverVersion } from '../utils/feature-flags';
+import { colorForState, stateDisplay, STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+
 export default class HciCluster extends ProvCluster {
   get stateObj() {
+    if (!this.isSupportedHarvesterVersion) {
+      return { error: true, message: this.t('harvesterManager.cluster.supportMessage') };
+    }
+
     return this._stateObj;
   }
 
@@ -30,12 +36,20 @@ export default class HciCluster extends ProvCluster {
     return false;
   }
 
-  get stateDescription() {
+  get stateColor() {
     if (!this.isSupportedHarvesterVersion) {
-      return this.t('harvesterManager.cluster.supportMessage');
+      return colorForState(STATES_ENUM.DENIED);
     }
 
-    return '';
+    return colorForState(this.state);
+  }
+
+  get stateDisplay() {
+    if (!this.isSupportedHarvesterVersion) {
+      return stateDisplay(STATES_ENUM.DENIED);
+    }
+
+    return stateDisplay(this.state);
   }
 
   /**

--- a/pkg/harvester/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester/models/harvesterhci.io.management.cluster.js
@@ -5,10 +5,12 @@ import { SETTING } from '@shell/config/settings';
 import { colorForState, stateDisplay, STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 
 export default class HciCluster extends ProvCluster {
-  _isSupportedHarvester = undefined;
-
   get isSupportedHarvester() {
     return this._isSupportedHarvester === undefined ? true : this._isSupportedHarvester;
+  }
+
+  get harvesterVersion() {
+    return this._harvesterVersion;
   }
 
   get stateObj() {
@@ -212,8 +214,10 @@ export default class HciCluster extends ProvCluster {
     try {
       const setting = await this.$dispatch('request', { url: `${ url }/${ HCI.SETTING }s/server-version` });
 
+      this._harvesterVersion = setting?.value;
       this._isSupportedHarvester = this.$rootGetters['harvester-common/getFeatureEnabled']('supportHarvesterClusterVersion', setting?.value);
     } catch (error) {
+      console.error('unable to get harvester version from settings/server-version', error); // eslint-disable-line no-console
     }
   }
 }

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -13,7 +13,6 @@ import { parseVolumeClaimTemplates } from '@pkg/utils/vm';
 import { BACKUP_TYPE } from '../config/types';
 import { HCI } from '../types';
 import HarvesterResource from './harvester';
-import { featureEnabled } from '../utils/feature-flags';
 
 export const OFF = 'Off';
 
@@ -481,7 +480,7 @@ export default class VirtVm extends HarvesterResource {
   }
 
   get cpuPinningFeatureEnabled() {
-    return featureEnabled(this.$rootGetters, 'cpuPinning');
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('cpuPinning');
   }
 
   get isCpuPinning() {

--- a/pkg/harvester/pages/c/_cluster/support/index.vue
+++ b/pkg/harvester/pages/c/_cluster/support/index.vue
@@ -76,7 +76,9 @@ export default {
     },
 
     rancherIntegrationLink() {
-      return docLink(DOC.RANCHER_INTEGRATION_URL, this.$store.getters);
+      const version = this.$rootGetters['harvester-common/getServerVersion']();
+
+      return docLink(DOC.RANCHER_INTEGRATION_URL, version);
     },
   },
 

--- a/pkg/harvester/pages/c/_cluster/support/index.vue
+++ b/pkg/harvester/pages/c/_cluster/support/index.vue
@@ -76,7 +76,7 @@ export default {
     },
 
     rancherIntegrationLink() {
-      const version = this.$rootGetters['harvester-common/getServerVersion']();
+      const version = this.$store.getters['harvester-common/getServerVersion']();
 
       return docLink(DOC.RANCHER_INTEGRATION_URL, version);
     },

--- a/pkg/harvester/store/harvester-common.js
+++ b/pkg/harvester/store/harvester-common.js
@@ -1,7 +1,7 @@
 import Parse from 'url-parse';
 import { HCI } from '../types';
 import { PRODUCT_NAME } from '../config/harvester';
-import { featureEnabled } from '../utils/feature-flags';
+import { featureEnabled, featureVersion } from '../utils/feature-flags';
 
 const state = function() {
   return {
@@ -71,8 +71,16 @@ const getters = {
     return (name) => state.uploadingImageError[name];
   },
 
-  getFeatureEnabled: (_state, _getters, _rootState, rootGetters) => (feature) => {
-    return featureEnabled(rootGetters, feature);
+  getServerVersion: (_state, _getters, _rootState, rootGetters) => () => {
+    const serverVersion = rootGetters['harvester/byId'](HCI.SETTING, 'server-version')?.value;
+
+    return featureVersion(serverVersion);
+  },
+
+  getFeatureEnabled: (_state, _getters, _rootState, rootGetters) => (feature, version) => {
+    const serverVersion = version || rootGetters['harvester/byId'](HCI.SETTING, 'server-version')?.value;
+
+    return featureEnabled(feature, serverVersion);
   },
 
   getHarvesterClusterUrl: (state, getters, rootState, rootGetters) => (url) => {

--- a/pkg/harvester/store/harvester-common.js
+++ b/pkg/harvester/store/harvester-common.js
@@ -1,7 +1,7 @@
 import Parse from 'url-parse';
 import { HCI } from '../types';
 import { PRODUCT_NAME } from '../config/harvester';
-import { featureEnabled, featureVersion } from '../utils/feature-flags';
+import { featureEnabled, getVersion } from '../utils/feature-flags';
 
 const state = function() {
   return {
@@ -74,7 +74,7 @@ const getters = {
   getServerVersion: (_state, _getters, _rootState, rootGetters) => () => {
     const serverVersion = rootGetters['harvester/byId'](HCI.SETTING, 'server-version')?.value;
 
-    return featureVersion(serverVersion);
+    return getVersion(serverVersion);
   },
 
   getFeatureEnabled: (_state, _getters, _rootState, rootGetters) => (feature, version) => {

--- a/pkg/harvester/utils/feature-flags.js
+++ b/pkg/harvester/utils/feature-flags.js
@@ -1,24 +1,19 @@
 import semver from 'semver';
-import { HCI } from '../types';
 import { RELEASE_FEATURES } from '../config/feature-flags';
 
-export const docLink = (suffix, getter) => {
-  const v = serverVersion(getter);
-
-  const docVersion = `v${ semver.major(v) }.${ semver.minor(v) }`;
+export const docLink = (suffix, version) => {
+  const docVersion = `v${ semver.major(version) }.${ semver.minor(version) }`;
 
   return `https://docs.harvesterhci.io/${ docVersion }${ suffix }`;
 };
 
-export function serverVersion(getters) {
+export function featureVersion(v) {
   // e.g v1.4.0
   if (process.env.VUE_APP_SERVER_VERSION) {
     return process.env.VUE_APP_SERVER_VERSION;
   }
 
   try {
-    const v = getters['harvester/byId'](HCI.SETTING, 'server-version')?.value;
-
     return `v${ semver.major(v) }.${ semver.minor(v) }.${ semver.patch(v) }`;
   } catch (error) {
     // fallback to the latest version
@@ -26,8 +21,8 @@ export function serverVersion(getters) {
   }
 }
 
-export const featureEnabled = (getters, featureKey) => {
-  const version = serverVersion(getters);
+export const featureEnabled = (featureKey, serverVersion) => {
+  const version = featureVersion(serverVersion);
   const releasedFeatures = RELEASE_FEATURES[version] || [];
 
   return releasedFeatures.includes(featureKey);

--- a/pkg/harvester/utils/feature-flags.js
+++ b/pkg/harvester/utils/feature-flags.js
@@ -7,7 +7,7 @@ export const docLink = (suffix, version) => {
   return `https://docs.harvesterhci.io/${ docVersion }${ suffix }`;
 };
 
-export function featureVersion(v) {
+export function getVersion(v) {
   // e.g v1.4.0
   if (process.env.VUE_APP_SERVER_VERSION) {
     return process.env.VUE_APP_SERVER_VERSION;
@@ -22,7 +22,7 @@ export function featureVersion(v) {
 }
 
 export const featureEnabled = (featureKey, serverVersion) => {
-  const version = featureVersion(serverVersion);
+  const version = getVersion(serverVersion);
   const releasedFeatures = RELEASE_FEATURES[version] || [];
 
   return releasedFeatures.includes(featureKey);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

- Disable cluster link in Virtualization Management page if harvester version is lower than v1.3.0
- Show supported warning banner in import harvester cluster page
- Show imported harvester version in table column.
- Refactor doc link based on `harvester-common/getServerVersion`

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/6971

### Test screenshot/video

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/7e314a08-9bb8-4a88-8926-5f68a72a9786">

<img width="1494" alt="Screenshot 2024-11-11 at 5 26 25 PM" src="https://github.com/user-attachments/assets/4c201524-2512-44da-9afb-4fe8ce512c30">


