### PR TITLE
Implement schedulingVMBackup feature flag

### DIFF
--- a/pkg/harvester/list/harvesterhci.io.virtualmachinebackup.vue
+++ b/pkg/harvester/list/harvesterhci.io.virtualmachinebackup.vue
@@ -124,12 +124,18 @@ export default {
           align:     'left',
           formatter: 'AttachVMWithName'
         },
-        {
+      ];
+
+      if (this.schedulingVMBackupFeatureEnabled) {
+        cols.push({
           name:      'backupCreatedFrom',
           labelKey:  'harvester.tableHeaders.vmSchedule',
           value:     'sourceSchedule',
           formatter: 'BackupCreatedFrom',
-        },
+        });
+      }
+
+      cols.push(...[
         {
           name:      'backupTarget',
           labelKey:  'tableHeaders.backupTarget',
@@ -144,7 +150,7 @@ export default {
           align:     'center',
           formatter: 'Checked',
         },
-      ];
+      ]);
 
       if (this.hasBackupProgresses) {
         cols.push({
@@ -155,9 +161,14 @@ export default {
           formatter: 'HarvesterBackupProgressBar',
         });
       }
+
       cols.push(AGE);
 
       return cols;
+    },
+
+    schedulingVMBackupFeatureEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('schedulingVMBackup');
     },
 
     hasBackupProgresses() {
@@ -244,7 +255,10 @@ export default {
       key-field="_key"
       default-sort-by="age"
     >
-      <template #more-header-middle>
+      <template
+        v-if="schedulingVMBackupFeatureEnabled"
+        #more-header-middle
+      >
         <FilterVMSchedule
           :rows="getRawRows"
           @change-rows="changeRows"

--- a/pkg/harvester/list/harvesterhci.io.vmsnapshot.vue
+++ b/pkg/harvester/list/harvesterhci.io.vmsnapshot.vue
@@ -58,7 +58,7 @@ export default {
 
   computed: {
     headers() {
-      return [
+      const cols = [
         STATE,
         NAME,
         NAMESPACE,
@@ -70,13 +70,19 @@ export default {
           sort:      'attachVM',
           formatter: 'AttachVMWithName'
         },
-        {
+      ];
+
+      if (this.schedulingVMBackupFeatureEnabled) {
+        cols.push({
           name:      'backupCreatedFrom',
           labelKey:  'harvester.tableHeaders.vmSchedule',
           value:     'sourceSchedule',
           sort:      'sourceSchedule',
           formatter: 'BackupCreatedFrom',
-        },
+        });
+      }
+
+      cols.push(...[
         {
           name:      'readyToUse',
           labelKey:  'tableHeaders.readyToUse',
@@ -86,7 +92,13 @@ export default {
           formatter: 'Checked',
         },
         AGE
-      ];
+      ]);
+
+      return cols;
+    },
+
+    schedulingVMBackupFeatureEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('schedulingVMBackup');
     },
 
     getRawRows() {
@@ -142,7 +154,10 @@ export default {
       key-field="_key"
       default-sort-by="age"
     >
-      <template #more-header-middle>
+      <template
+        v-if="schedulingVMBackupFeatureEnabled"
+        #more-header-middle
+      >
         <FilterVMSchedule
           :rows="getRawRows"
           @change-rows="changeRows"

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -168,7 +168,7 @@ export default class VirtVm extends HarvesterResource {
       },
       {
         action:  'createSchedule',
-        enabled: true,
+        enabled: this.schedulingVMBackupFeatureEnabled,
         icon:    'icon icon-history',
         label:   this.t('harvester.action.createSchedule')
       },
@@ -1145,6 +1145,10 @@ export default class VirtVm extends HarvesterResource {
     } catch (error) {
       return {};
     }
+  }
+
+  get schedulingVMBackupFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('schedulingVMBackup');
   }
 
   setInstanceLabels(val) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

- The Scheduling VMs Backup tab visibility depends on `ifHaveType: HCI.SCHEDULE_VM_BACKUP`

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Contributes to https://github.com/harvester/harvester/issues/6935
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


