### PR TITLE
Remove unused RANCHER_MANAGER_SUPPORT setting

### DIFF
--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -67,7 +67,6 @@ export const HCI_ALLOWED_SETTINGS = {
   [HCI_SETTING.SUPPORT_BUNDLE_IMAGE]:                   { kind: 'json', from: 'import' },
   [HCI_SETTING.STORAGE_NETWORK]:                        { kind: 'custom', from: 'import' },
   [HCI_SETTING.VM_FORCE_RESET_POLICY]:                  { kind: 'json', from: 'import' },
-  [HCI_SETTING.RANCHER_MANAGER_SUPPORT]:                { kind: 'boolean' },
   [HCI_SETTING.SSL_CERTIFICATES]:                       { kind: 'json', from: 'import' },
   [HCI_SETTING.SSL_PARAMETERS]:                         {
     kind: 'json', from: 'import', canReset: true


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Check with @Yu-Jack , the RANCHER_MANAGER_SUPPORT setting is not supported in backend. We can remove it from UI.

I encounter below errro when running

```
yarn publish-pkgs -f
```
<img width="1431" alt="Screenshot 2024-11-12 at 4 36 29 PM" src="https://github.com/user-attachments/assets/b7f72893-c352-4d12-a5a9-56886a2aa37b">


Backend PR: https://github.com/harvester/harvester/pull/4250

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


