### PR TITLE
Define Virtualization Management table headers

### DIFF
--- a/pkg/harvester/config/harvester-manager.js
+++ b/pkg/harvester/config/harvester-manager.js
@@ -1,7 +1,5 @@
 import { HCI, MANAGEMENT, CAPI } from '@shell/config/types';
 import { HARVESTER, MULTI_CLUSTER } from '@shell/store/features';
-import { STATE, NAME as NAME_COL, AGE, VERSION } from '@shell/config/table-headers';
-import { MACHINE_POOLS } from '../config/table-headers';
 import { allHash } from '@shell/utils/promise';
 import { BLANK_CLUSTER } from '@shell/store/store-types.js';
 
@@ -22,7 +20,6 @@ export function init($plugin, store) {
   const {
     product,
     basicType,
-    headers,
     spoofedType,
     configureType
   } = $plugin.DSL(store, NAME);
@@ -40,31 +37,7 @@ export function init($plugin, store) {
   });
 
   configureType(HCI.CLUSTER, { showListMasthead: false });
-  headers(HCI.CLUSTER, [
-    STATE,
-    NAME_COL,
-    {
-      name:     'harvesterVersion',
-      sort:     'harvesterVersion',
-      labelKey: 'harvesterManager.tableHeaders.harvesterVersion',
-      value:    'harvesterVersion',
-      getValue: (row) => row.harvesterVersion
-    },
-    {
-      ...VERSION,
-      labelKey: 'harvesterManager.tableHeaders.kubernetesVersion',
-      value:    'kubernetesVersion',
-      getValue: (row) => row.kubernetesVersion
-    },
-    MACHINE_POOLS,
-    AGE,
-    {
-      name:  'harvester',
-      label: ' ',
-      align: 'right',
-      width: 65,
-    },
-  ]);
+
   basicType([HCI.CLUSTER]);
   spoofedType({
     labelKey:   'harvesterManager.cluster.label',

--- a/pkg/harvester/config/harvester-manager.js
+++ b/pkg/harvester/config/harvester-manager.js
@@ -1,22 +1,13 @@
 import { HCI, MANAGEMENT, CAPI } from '@shell/config/types';
 import { HARVESTER, MULTI_CLUSTER } from '@shell/store/features';
 import { STATE, NAME as NAME_COL, AGE, VERSION } from '@shell/config/table-headers';
+import { MACHINE_POOLS } from '../config/table-headers';
 import { allHash } from '@shell/utils/promise';
 import { BLANK_CLUSTER } from '@shell/store/store-types.js';
 
 export const PRODUCT_NAME = 'harvester-manager';
 
 export const NAME = 'harvesterManager';
-
-const MACHINE_POOLS = {
-  name:     'summary',
-  labelKey: 'tableHeaders.machines',
-  sort:     false,
-  search:   false,
-  value:    'nodes.length',
-  align:    'center',
-  width:    100,
-};
 
 const harvesterClustersLocation = {
   name:   'c-cluster-product-resource',
@@ -56,7 +47,7 @@ export function init($plugin, store) {
       name:     'harvesterVersion',
       sort:     'harvesterVersion',
       labelKey: 'harvesterManager.tableHeaders.harvesterVersion',
-      value:    'HarvesterVersion',
+      value:    'harvesterVersion',
       getValue: (row) => row.harvesterVersion
     },
     {

--- a/pkg/harvester/config/table-headers.js
+++ b/pkg/harvester/config/table-headers.js
@@ -77,3 +77,14 @@ export const VM_SCHEDULE_TYPE = {
   sort:     'spec.vmbackup.type',
   align:    'center',
 };
+
+// The MACHINE_POOLS column in Virtualization Management list page
+export const MACHINE_POOLS = {
+  name:     'summary',
+  labelKey: 'tableHeaders.machines',
+  sort:     false,
+  search:   false,
+  value:    'nodes.length',
+  align:    'center',
+  width:    100,
+};

--- a/pkg/harvester/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester/list/harvesterhci.io.management.cluster.vue
@@ -8,6 +8,8 @@ import { HARVESTER_NAME as VIRTUAL } from '@shell/config/features';
 import { CAPI, HCI, MANAGEMENT } from '@shell/config/types';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import { allHash } from '@shell/utils/promise';
+import { STATE, NAME as NAME_COL, AGE, VERSION } from '@shell/config/table-headers';
+import { MACHINE_POOLS } from '../config/table-headers';
 
 export default {
   components: {
@@ -56,6 +58,34 @@ export default {
   },
 
   computed: {
+    headers() {
+      return [
+        STATE,
+        NAME_COL,
+        {
+          name:     'harvesterVersion',
+          sort:     'harvesterVersion',
+          labelKey: 'harvesterManager.tableHeaders.harvesterVersion',
+          value:    'harvesterVersion',
+          getValue: (row) => row.harvesterVersion
+        },
+        {
+          ...VERSION,
+          labelKey: 'harvesterManager.tableHeaders.kubernetesVersion',
+          value:    'kubernetesVersion',
+          getValue: (row) => row.kubernetesVersion
+        },
+        MACHINE_POOLS,
+        AGE,
+        {
+          name:  'harvester',
+          label: ' ',
+          align: 'right',
+          width: 65,
+        },
+      ];
+    },
+
     importLocation() {
       return {
         name:   'c-cluster-product-resource-create',
@@ -144,6 +174,7 @@ export default {
     <ResourceTable
       v-if="rows && rows.length"
       :schema="schema"
+      :headers="headers"
       :rows="rows"
       :is-creatable="true"
       :namespaced="false"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

We defined the Virtualization Management table's headers in `config/harvester-manager.js`.
That file is not used in prod builds, so we need to redefine the headers in the Virtualization Management component itself.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


