### PR TITLE
hide YAML tab in cloud template detail page

### DIFF
--- a/pkg/harvester/config/harvester-cluster.js
+++ b/pkg/harvester/config/harvester-cluster.js
@@ -474,6 +474,7 @@ export function init($plugin, store) {
     },
     exact: false
   });
+  configureType(TEMPLATE, { canYaml: false });
 
   configureType(HCI.SCHEDULE_VM_BACKUP, {
     showListMasthead: false, showConfigView: false, canYaml: false


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The YAML and CONFIG tabs should not display in cloud template detail page
### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/6872

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Extra technical notes summary
Before 

<img width="1493" alt="Screenshot 2024-11-13 at 2 55 08 PM" src="https://github.com/user-attachments/assets/c9ea901b-5ad8-40df-97a2-b6f02d4c4604">

After

<img width="1496" alt="Screenshot 2024-11-13 at 2 55 17 PM" src="https://github.com/user-attachments/assets/45b05839-3e01-42cb-a285-36afdf6d544b">


