### PR TITLE
hide v-dropdown arrow

### DIFF
--- a/pkg/harvester/components/FilterBySriov.vue
+++ b/pkg/harvester/components/FilterBySriov.vue
@@ -81,7 +81,7 @@ export default {
     </span>
 
     <v-dropdown
-      popper-class="filter-label"
+      popper-class="filter-parent-sriov"
       trigger="click"
       placement="bottom-end"
       :distance="20"
@@ -143,5 +143,12 @@ export default {
 
 .required {
   color: var(--error);
+}
+
+</style>
+
+<style lang="scss">
+.filter-parent-sriov .v-popper__arrow-container {
+  display: none;
 }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Change another way to hide v-dropdown arrow. Previous way does not work if user didn't enter images page.


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7040

### Test screenshot/video
Also fix the same issue in vGPU page
<img width="1496" alt="Screenshot 2024-11-26 at 5 43 56 PM" src="https://github.com/user-attachments/assets/0a70ca08-78bb-41ea-9be1-5fd379104111">


