### PR TITLE
fix: keep parent sriov filter result if pcidevices status change

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
@@ -95,7 +95,11 @@ export default {
     devices: {
       handler(v) {
         this.rows = v;
-        this.filterRows = this.rows;
+        if (this.parentSriov) {
+          this.filterRows = this.rows.filter((row) => row.labels[this.parentSriovLabel] === this.parentSriov);
+        } else {
+          this.filterRows = this.rows;
+        }
       },
       immediate: true,
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Port https://github.com/harvester/dashboard/pull/1247 into ui-extension

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/6660

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


