### PR TITLE
fix: failed to add label to image on the Rancher managed Harvester, display 0% progress

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
@@ -530,6 +530,7 @@ export default {
           :mode="mode"
           :pad-left="false"
           :read-allowed="false"
+          :value-can-be-empty="true"
           @focusKey="focusKey"
           @update:value="value.setLabels($event)"
         >
@@ -552,7 +553,7 @@ export default {
               autocorrect="off"
               autocapitalize="off"
               spellcheck="false"
-              @update:value="queueUpdate"
+              @input="queueUpdate"
             />
           </template>
         </KeyValue>

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
@@ -245,6 +245,8 @@ export default {
     async saveImage(buttonCb) {
       this.value.spec.displayName = (this.value.spec.displayName || '').trim();
 
+      if (this.isEdit) return await this.handleEditImage(buttonCb);
+
       if (this.value.spec.sourceType === UPLOAD && this.isCreate) {
         try {
           this.value.spec.url = '';
@@ -266,6 +268,23 @@ export default {
       } else {
         this.value.spec.url = this.value.spec.url?.trim() || '';
         this.save(buttonCb);
+      }
+    },
+
+    async handleEditImage(buttonCb) {
+      try {
+        const data = [{
+          op: 'replace', path: '/metadata/labels', value: this.value.metadata.labels
+        }, {
+          op: 'replace', path: '/metadata/annotations', value: this.value.metadata.annotations
+        }];
+
+        await this.value.patch(data);
+        buttonCb(true);
+        this.done();
+      } catch (e) {
+        this.errors = exceptionToErrorsArray(e);
+        buttonCb(false);
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
When access Harvester from Rancher virtualization management.
Should be able to add new label to image correctly.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] Failed to add label to image on the Rancher managed Harvester, display 0% progress #7172](https://github.com/harvester/harvester/issues/7172)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Create a image from URL
- Edit the image
- Add a new label with key pair
- Save and check the image status
- Check the label can be added correctly

https://github.com/user-attachments/assets/6051771d-2d5b-4b6e-97a0-739026a8e1c7

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


