### PR TITLE
chore: add v1.4.1 feature flag

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -17,12 +17,7 @@ const featuresV132 = [
   'improveMaintenanceMode',
 ];
 
-// TODO: change to https://github.com/harvester/dashboard/releases/tag/v1.4.0 after v1.4.0 release
-// https://github.com/harvester/dashboard/releases/tag/v1.4.0-rc5
-// https://github.com/harvester/dashboard/releases/tag/v1.4.0-rc4
-// https://github.com/harvester/dashboard/releases/tag/v1.4.0-rc3
-// https://github.com/harvester/dashboard/releases/tag/v1.4.0-rc2
-// https://github.com/harvester/dashboard/releases/tag/v1.4.0-rc1
+// https://github.com/harvester/dashboard/releases/tag/v1.4.0
 const featuresV140 = [
   ...featuresV132,
   'cpuPinning',
@@ -34,9 +29,16 @@ const featuresV140 = [
   'improveMaintenanceMode',
 ];
 
+// TODO: add v1.4.1 official release note
+// https://github.com/harvester/dashboard/releases/tag/v1.4.1-rc1
+const featuresV141 = [
+  ...featuresV140
+];
+
 export const RELEASE_FEATURES = {
   'v1.3.0': featuresV130,
   'v1.3.1': featuresV131,
   'v1.3.2': featuresV132,
   'v1.4.0': featuresV140,
+  'v1.4.1': featuresV141,
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
H. v1.4.1-rc1 is out. When you running harvester-ui-extension against v1.4.1, we need feature flag
chore: add v1.4.1 feature flag

Before this PR
<img width="1496" alt="Screenshot 2025-01-03 at 3 30 41 PM" src="https://github.com/user-attachments/assets/beb610bd-a054-4489-a9b5-6f97ead02cc8" />

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


