### PR TITLE
fix: failed to display storage class key/value pairs when edit config on Rancher managed Harvester

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
@@ -10,17 +10,6 @@ import { clone } from '@shell/utils/object';
 import { uniq } from '@shell/utils/array';
 import { DATA_ENGINE_V1 } from '../../../models/harvester/persistentvolumeclaim';
 
-// UI components for Longhorn storage class parameters
-const DEFAULT_PARAMETERS = [
-  'numberOfReplicas',
-  'staleReplicaTimeout',
-  'diskSelector',
-  'nodeSelector',
-  'migratable',
-  'encrypted',
-  'dataEngine',
-];
-
 const {
   CSI_PROVISIONER_SECRET_NAME,
   CSI_PROVISIONER_SECRET_NAMESPACE,
@@ -141,11 +130,17 @@ export default {
       get() {
         const parameters = clone(this.value?.parameters) || {};
 
-        DEFAULT_PARAMETERS.forEach((key) => {
-          delete parameters[key];
-        });
+        // UI components for Longhorn storage class parameters
+        const defaultParameters = [
+          'numberOfReplicas',
+          'staleReplicaTimeout',
+          'diskSelector',
+          'nodeSelector',
+          'migratable',
+          ...(this.value.volumeEncryptionFeatureEnabled ? ['encrypted', 'dataEngine'] : []),
+        ];
 
-        Object.values(CSI_SECRETS).forEach((key) => {
+        [...defaultParameters, ...Object.values(CSI_SECRETS)].forEach((key) => {
           delete parameters[key];
         });
 
@@ -311,16 +306,16 @@ export default {
         </LabeledSelect>
       </div>
     </div>
+    <div class="row mt-20">
+      <RadioGroup
+        v-model:value="value.parameters.migratable"
+        name="layer3NetworkMode"
+        :label="t('harvester.storage.parameters.migratable.label')"
+        :mode="mode"
+        :options="migratableOptions"
+      />
+    </div>
     <template v-if="value.volumeEncryptionFeatureEnabled">
-      <div class="row mt-20">
-        <RadioGroup
-          v-model:value="value.parameters.migratable"
-          name="layer3NetworkMode"
-          :label="t('harvester.storage.parameters.migratable.label')"
-          :mode="mode"
-          :options="migratableOptions"
-        />
-      </div>
       <div class="row mt-20">
         <RadioGroup
           v-model:value="volumeEncryption"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Key/value parameters are not visible for newly created storage classes in Harvester v1.3.2.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] Failed to display storage class key/value pairs when edit config on Rancher managed Harvester #7230](https://github.com/harvester/harvester/issues/7230)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
1. Open Advanced -> Storage class
2. Create a new storage class
3. Edit config of the created storage class
4. Observe the key/value parameters

https://github.com/user-attachments/assets/bdfc4243-7a7b-4e91-983d-8a9953048ee6

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Test with
- Harvester (v1.3.2): https://192.168.0.131/ 
- Rancher (v2.10.1-alpha1): https://rancher.192.168.0.141.sslip.io/ 