### PR TITLE
fix: missing label in VM scheduling tab

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -742,6 +742,9 @@ harvester:
     terminationGracePeriodSeconds:
       label: Termination Grace Period
     affinity:
+      addLabel: Add Workload Selector
+      topologyKey:
+        placeholder: 'topology.kubernetes.io/zone'
       thisPodNamespace: This virtual machine's namespace
       matchExpressions:
         inNamespaces: "Workloads in these namespaces"
@@ -1493,18 +1496,6 @@ harvester:
         label: Event
       pollingInterval:
         label: Polling Interval
-
-  affinity:
-    thisPodNamespace: This virtual machine's namespace
-    matchExpressions:
-      inNamespaces: "Workloads in these namespaces"
-    vmAffinityTitle: Virtual Machine Scheduling
-    namespaces:
-      placeholder: e.g. default,system,base
-      label: Namespaces
-    addLabel: Add Workload Selector
-    topologyKey:
-      placeholder: 'topology.kubernetes.io/zone'
 
 advancedSettings:
   experimental: 'Experimental features allow users to test and evaluate early-access functionality prior to official supported releases'

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -282,14 +282,14 @@ export default {
 
     affinityLabels() {
       return {
-        namespaceInputLabel:      this.t('harvester.affinity.namespaces.label'),
+        namespaceInputLabel:      this.t('harvester.virtualMachine.affinity.namespaces.label'),
         namespaceSelectionLabels: [
           this.t('harvester.virtualMachine.affinity.thisPodNamespace'),
           this.t('workload.scheduling.affinity.allNamespaces'),
           this.t('harvester.virtualMachine.affinity.matchExpressions.inNamespaces')
         ],
-        addLabel:               this.t('harvester.affinity.addLabel'),
-        topologyKeyPlaceholder: this.t('harvester.affinity.topologyKey.placeholder')
+        addLabel:               this.t('harvester.virtualMachine.affinity.addLabel'),
+        topologyKeyPlaceholder: this.t('harvester.virtualMachine.affinity.topologyKey.placeholder')
       };
     },
   },

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -282,7 +282,7 @@ export default {
 
     affinityLabels() {
       return {
-        namespaceInputLabel:      this.t('harvester.virtualMachine.affinity.namespaces.label'),
+        namespaceInputLabel:      this.t('harvester.affinity.namespaces.label'),
         namespaceSelectionLabels: [
           this.t('harvester.virtualMachine.affinity.thisPodNamespace'),
           this.t('workload.scheduling.affinity.allNamespaces'),

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -282,14 +282,14 @@ export default {
 
     affinityLabels() {
       return {
-        namespaceInputLabel:      this.t('harvesterManager.affinity.namespaces.label'),
+        namespaceInputLabel:      this.t('harvester.virtualMachine.affinity.namespaces.label'),
         namespaceSelectionLabels: [
-          this.t('harvesterManager.affinity.thisPodNamespace'),
+          this.t('harvester.virtualMachine.affinity.thisPodNamespace'),
           this.t('workload.scheduling.affinity.allNamespaces'),
-          this.t('harvesterManager.affinity.matchExpressions.inNamespaces')
+          this.t('harvester.virtualMachine.affinity.matchExpressions.inNamespaces')
         ],
-        addLabel:               this.t('harvesterManager.affinity.addLabel'),
-        topologyKeyPlaceholder: this.t('harvesterManager.affinity.topologyKey.placeholder')
+        addLabel:               this.t('harvester.affinity.addLabel'),
+        topologyKeyPlaceholder: this.t('harvester.affinity.topologyKey.placeholder')
       };
     },
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The  [harvester-manager](https://github.com/rancher/dashboard/tree/master/pkg/harvester-manager) source code was removed from ui-extension and move back to rancher/dashboard.

Change all translation keys in havester-ui-extension.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7322

### Test screenshot/video
<img width="1496" alt="Screenshot 2025-01-08 at 2 40 51 PM" src="https://github.com/user-attachments/assets/692ee32d-dc9e-4c0b-9f15-86a6d1e578c0" />


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


