### PR TITLE
fix: failed to resume /active vm schedule job

### DIFF
--- a/pkg/harvester/models/harvesterhci.io.schedulevmbackup.js
+++ b/pkg/harvester/models/harvesterhci.io.schedulevmbackup.js
@@ -1,6 +1,4 @@
 import HarvesterResource from './harvester';
-import { get } from '@shell/utils/object';
-import { findBy } from '@shell/utils/array';
 import { colorForState, stateDisplay, STATES } from '@shell/plugins/dashboard-store/resource-class';
 import { _CREATE } from '@shell/config/query-params';
 import { ucFirst, escapeHtml } from '@shell/utils/string';
@@ -67,14 +65,7 @@ export default class ScheduleVmBackup extends HarvesterResource {
   }
 
   get state() {
-    const conditions = get(this, 'status.conditions');
-    const isSuspended = findBy(conditions, 'type', 'BackupSuspend')?.status === 'True';
-
-    if (isSuspended) {
-      return STATES.suspended.label;
-    }
-
-    return this.metadata.state.name;
+    return this.status?.suspended === true ? STATES.suspended.label : STATES.active.label;
   }
 
   get stateDescription() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

There is a sudden `harvesterhci.io.schedulevmbackup` websocket changes data object missing `metadata.state.name`. 


See 
<img width="1486" alt="Screenshot 2025-01-08 at 2 55 06 PM" src="https://github.com/user-attachments/assets/8b22d1af-dacc-4b60-add1-193eaede802c" />


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @WebberHuang1118 

### Related Issue #
https://github.com/harvester/harvester/issues/7174

### Test screenshot/video


https://github.com/user-attachments/assets/a4b0be35-c064-495b-b14e-36756fae3513




### Extra technical notes summary
After synced with @WebberHuang1118 , we can consume `status.suspended = true` to determine schedule job is suspended or not. There is no other status for schedule job so far. 

We can enhance get state() if backend has other status in the future.


<img width="1496" alt="Screenshot 2025-01-08 at 3 49 15 PM" src="https://github.com/user-attachments/assets/c8d5e924-24ad-41c1-b2c4-4b15f63c3b8f" />


see HEP : https://github.com/harvester/harvester/blob/master/enhancements/20240611-vm-schedule-backup.md#crd
```
status.suspended presents if the schedule is suspended
```