### PR TITLE
chore: add v1.5.0 and v1.3.3 feature flags

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -17,6 +17,12 @@ const featuresV132 = [
   'improveMaintenanceMode',
 ];
 
+// TODO: add v1.3.3 official release note
+// https://github.com/harvester/dashboard/releases/tag/v1.3.3-dev-20250105
+const featuresV133 = [
+  ...featuresV132,
+];
+
 // https://github.com/harvester/dashboard/releases/tag/v1.4.0
 const featuresV140 = [
   ...featuresV132,
@@ -35,10 +41,17 @@ const featuresV141 = [
   ...featuresV140
 ];
 
+// TODO: add v1.5.0 official release note
+const featuresV150 = [
+  ...featuresV141
+];
+
 export const RELEASE_FEATURES = {
   'v1.3.0': featuresV130,
   'v1.3.1': featuresV131,
   'v1.3.2': featuresV132,
+  'v1.3.3': featuresV133,
   'v1.4.0': featuresV140,
   'v1.4.1': featuresV141,
+  'v1.5.0': featuresV150
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

v1.3.3 sprint release ([release-v1.3.3-dev-20250105](https://github.com/harvester/harvester/tree/release-v1.3.3-dev-20250105)) is out. We need to support v1.3.3 cluster imported into Rancher 2.10.1.

Also v1.5.0 in the future.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:


