### PR TITLE
fix: add missing wording in delete VM modal 

### DIFF
--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -1120,10 +1120,6 @@ export default class VirtVm extends HarvesterResource {
     return qemu?.status === 'True';
   }
 
-  get warnDeletionMessage() {
-    return this.t('harvester.virtualMachine.promptRemove.tips');
-  }
-
   get instanceLabels() {
     const all = this.spec?.template?.metadata?.labels || {};
 

--- a/pkg/harvester/promptRemove/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/promptRemove/kubevirt.io.virtualmachine.vue
@@ -4,6 +4,7 @@ import { isEmpty } from '@shell/utils/object';
 import Parse from 'url-parse';
 import { resourceNames } from '@shell/utils/string';
 import { HCI } from '../types';
+import { alternateLabel as alternateLabelButton } from '@shell/utils/platform';
 
 export default {
   name: 'HarvesterPromptRemove',
@@ -39,8 +40,9 @@ export default {
 
   data() {
     return {
-      checkedList: [],
-      checkAll:    true
+      checkedList:    [],
+      checkAll:       true,
+      alternateLabel: alternateLabelButton
     };
   },
 
@@ -138,44 +140,53 @@ export default {
 </script>
 
 <template>
-  <div class="mt-10">
-    {{ t('promptRemove.attemptingToRemove', {type}) }}
-    <span v-clean-html="resourceNames(names, plusMore, t)"></span>
-
+  <div>
     <div class="mt-10">
-      {{ t('harvester.virtualMachine.promptRemove.title') }}
-    </div>
-    <div v-if="value.length === 1">
-      <span
-        v-for="(name, i) in removeNameArr[value[0].id]"
-        :key="i"
-      >
-        <label class="checkbox-container mr-15"><input
-                                                  v-model="checkedList"
-                                                  type="checkbox"
-                                                  :label="name"
-                                                  :value="name"
-                                                />
+      {{ t('promptRemove.attemptingToRemove', {type}) }}
+      <span v-clean-html="resourceNames(names, plusMore, t)"></span>
+
+      <div class="mt-10">
+        {{ t('harvester.virtualMachine.promptRemove.title') }}
+      </div>
+      <div v-if="value.length === 1">
+        <span
+          v-for="(name, i) in removeNameArr[value[0].id]"
+          :key="i"
+        >
+          <label class="checkbox-container mr-15">
+            <input
+              v-model="checkedList"
+              type="checkbox"
+              :label="name"
+              :value="name"
+            />
+            <span
+              class="checkbox-custom mr-5"
+              role="checkbox"
+            />
+            {{ name }}
+          </label>
+        </span>
+      </div>
+      <div v-else>
+        <label class="checkbox-container mr-15">
+          <input
+            v-model="checkedList"
+            type="checkbox"
+          />
           <span
             class="checkbox-custom mr-5"
             role="checkbox"
           />
-          {{ name }}
+          {{ t('harvester.virtualMachine.promptRemove.deleteAll') }}
         </label>
-      </span>
+      </div>
     </div>
-
-    <div v-else>
-      <label class="checkbox-container mr-15"><input
-                                                v-model="checkAll"
-                                                type="checkbox"
-                                              />
-        <span
-          class="checkbox-custom mr-5"
-          role="checkbox"
-        />
-        {{ t('harvester.virtualMachine.promptRemove.deleteAll') }}
-      </label>
+    <div class="text-warning mb-10 mt-10">
+      {{ t('harvester.virtualMachine.promptRemove.tips') }}
+    </div>
+    <div class="text-info mt-20">
+      {{ t('promptRemove.protip', { alternateLabel }) }}
     </div>
   </div>
 </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Add missing wording in delete VM modal. 
The warning and info messages are put in `LabeledInput` in latest shell [PromptRemove.vue ](https://github.com/rancher/dashboard/blob/938b866e002fa2ba85462cd3a5a15e8bf42a0b87/shell/components/PromptRemove.vue#L398-L409).

So I added message in harvester custom promptRemove.


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7317

### Test screenshot/video
**Delete single VM**

<img width="1485" alt="Screenshot 2025-01-10 at 4 53 40 PM" src="https://github.com/user-attachments/assets/77159e43-39c9-43bd-8716-9cd957e280a5" />


**Delete multiple VM**
<img width="1450" alt="Screenshot 2025-01-10 at 5 01 34 PM" src="https://github.com/user-attachments/assets/4f256323-10fa-4cd6-874b-3731f126bf6f" />

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


