### PR TITLE
fix: cluster member role user should not be able to delete node on Harvester Hosts page

### DIFF
--- a/pkg/harvester/list/harvesterhci.io.host.vue
+++ b/pkg/harvester/list/harvesterhci.io.host.vue
@@ -3,7 +3,7 @@ import ResourceTable from '@shell/components/ResourceTable';
 import Loading from '@shell/components/Loading';
 import { STATE, NAME, AGE } from '@shell/config/table-headers';
 import {
-  CAPI, METRIC, NODE, SCHEMA, LONGHORN, POD, MANAGEMENT, NORMAN
+  CAPI, METRIC, NODE, SCHEMA, LONGHORN, POD
 } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
 import metricPoller from '@shell/mixins/metric-poller';
@@ -62,41 +62,7 @@ export default {
       _hash.machines = this.$store.dispatch(`${ inStore }/findAll`, { type: CAPI.MACHINE });
     }
 
-    if (
-      this.$store.getters['rancher/schemaFor'](NORMAN.PRINCIPAL) &&
-      this.$store.getters['rancher/schemaFor'](NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING)
-    ) {
-      _hash.normanPrincipal = this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL });
-      _hash.clusterRoleTemplateBinding = this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING });
-    }
-
     const hash = await allHash(_hash);
-
-    // Remove delete action if current user role is cluster member
-    if (hash.normanPrincipal && hash.clusterRoleTemplateBinding) {
-      const role = hash.clusterRoleTemplateBinding.find(
-        (template) => template.userPrincipalName === hash.normanPrincipal[0]?.id
-      );
-      const isClusterMember = role?.roleTemplateName === 'cluster-member';
-
-      if (isClusterMember) {
-        hash.nodes = hash.nodes.map((node) => {
-          const updatedActions = node.availableActions.map((action) => {
-            return action.action === 'promptRemove' ? { ...action, enabled: false } : action;
-          });
-
-          // keep availableActions non-enumerable
-          Object.defineProperty(node, 'availableActions', {
-            value:        updatedActions,
-            writable:     true,
-            enumerable:   false,
-            configurable: true,
-          });
-
-          return node;
-        });
-      }
-    }
 
     this.rows = hash.nodes;
   },

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -1,7 +1,5 @@
 import pickBy from 'lodash/pickBy';
-import {
-  CAPI, LONGHORN, POD, NODE, NORMAN
-} from '@shell/config/types';
+import { CAPI, LONGHORN, POD, NODE } from '@shell/config/types';
 import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations.js';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import { clone } from '@shell/utils/object';
@@ -469,35 +467,10 @@ export default class HciNode extends HarvesterResource {
     return parseSi(this.reserved.memory || '0');
   }
 
-  // returns the user role, either 'cluster-owner' or 'cluster-member'
-  async _getRoleTemplateId() {
-    try {
-      const templates = await this.$dispatch('rancher/findAll', { type: NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING }, { root: true });
-      const currentUser = this.$rootGetters['rancher/all'](NORMAN.PRINCIPAL)?.[0];
-      const userRole = templates.find((template) => template.userPrincipalId === currentUser?.id);
-
-      return userRole?.roleTemplateId || 'cluster-member';
-    } catch (error) {
-      return 'cluster-member';
-    }
-  }
-
   get canDelete() {
     const nodes = this.$rootGetters['harvester/all'](NODE) || [];
-    const isSingleNode = nodes.length === 1;
 
-    if (isSingleNode) return false;
-
-    // access control is unavailable in standalone harvester
-    if (this.$rootGetters['isStandaloneHarvester']) return true;
-
-    if (this._canDelete === undefined) {
-      return this._getRoleTemplateId().then((id) => {
-        this._canDelete = id === 'cluster-owner';
-      });
-    }
-
-    return this._canDelete;
+    return nodes.length > 1 && super.canDelete;
   }
 
   get vlanStatuses() {

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -1,5 +1,7 @@
 import pickBy from 'lodash/pickBy';
-import { CAPI, LONGHORN, POD, NODE, NORMAN } from '@shell/config/types';
+import {
+  CAPI, LONGHORN, POD, NODE, NORMAN
+} from '@shell/config/types';
 import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations.js';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import { clone } from '@shell/utils/object';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
For security concern, cluster member role user should not be able to delete node on Harvester Hosts page.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] Cluster member role user should not be able to delete node on Harvester Hosts page on Rancher managed Harvester #7255](https://github.com/harvester/harvester/issues/7255)

### Test screenshots/videos
<!-- Attach screenshots or videos of the changes. Include comparisons if necessary. -->

#### Multi-node
- **Log in as `admin`:**  
  ![Integration - Admin (Multi-Node)](https://github.com/user-attachments/assets/c16418f2-7ac3-447b-b064-760b795f8ca8)

- **Log in as `project-member`:**  
  ![Integration - Member (Multi-Node)](https://github.com/user-attachments/assets/7336a52a-f4c3-4e38-8b46-c1503b82ac22)

- **Standalone mode (only `admin` login available):**  
  ![Standalone Mode](https://github.com/user-attachments/assets/12d97681-9037-441a-8470-d7574e44b780)

#### Single-node
- **Integration mode:**  
  ![Integration - Single Node](https://github.com/user-attachments/assets/7c2c2a56-850d-4436-9e0d-2215a3fc0122)

- **Standalone mode:**  
![single-standalone](https://github.com/user-attachments/assets/4018b1f6-c9da-4cd2-9cac-4aab1fae5b1a)

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Test with `API=https://rancher.192.168.0.141.sslip.io yarn dev`

