### PR TITLE
fix: resume schedule job error

### DIFF
--- a/pkg/harvester/models/harvesterhci.io.schedulevmbackup.js
+++ b/pkg/harvester/models/harvesterhci.io.schedulevmbackup.js
@@ -64,6 +64,10 @@ export default class ScheduleVmBackup extends HarvesterResource {
     }
   }
 
+  get stateObj() {
+    return this?.metadata?.state || {};
+  }
+
   get state() {
     return this.status?.suspended === true ? STATES.suspended.label : STATES.active.label;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary


fix: resume schedule job error (see https://github.com/harvester/harvester/issues/7174#issuecomment-2586229116)

Due to there is sudden no [this.metedata](https://github.com/rancher/dashboard/blob/938b866e002fa2ba85462cd3a5a15e8bf42a0b87/shell/components/SortableTable/index.vue#L1491), customize schedule job stateObj().

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7174

### Test screenshot/video

https://github.com/user-attachments/assets/5f6622fc-4f77-467e-bff0-c0a5a024c2fc


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


