### PR TITLE
fix: remove witness node in VM node scheduling tab

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -217,7 +217,7 @@ export default {
       const selectedVMNetworks = networkNames.map((name) => vmNetworks.find((n) => n.id === name)).filter((n) => n?.id);
       const clusterNetworks = uniq(selectedVMNetworks.map((n) => n.clusterNetworkResource?.id));
 
-      return nodes.filter((N) => !N.isUnSchedulable).map((node) => {
+      return nodes.filter((N) => !N.isUnSchedulable && N.isEtcd !== 'true').map((node) => {
         const requireLabelKeys = [];
         let isNetworkSchedule = true;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fix: remove witness node in VM node scheduling tab

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/6592

### Test screenshot/video
Harvester-node-1 is witness node.


<img width="1492" alt="Screenshot 2025-01-17 at 3 25 54 PM" src="https://github.com/user-attachments/assets/6328d1d1-88c7-4d86-8cc7-a3f093ab0d07" />

<img width="1495" alt="Screenshot 2025-01-17 at 3 25 47 PM" src="https://github.com/user-attachments/assets/26a3c8e0-3871-4de5-b85d-32fe165fd2cd" />


