### PR TITLE
chore: bump release version to v1.0.3

### DIFF
--- a/pkg/harvester/package.json
+++ b/pkg/harvester/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvester",
   "description": "Rancher UI Extension for Harvester",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": false,
   "rancher": {
     "annotations": {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
QA is verifying `v1.0.3-rc2`, this PR bumps release version to v1.0.3.

We can release offical v1.0.3 to `gh-pages` branch with Harvester v1.4.1 release.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


