### PR TITLE
fix: encrypt option can only choose encrypted storage class when creating VM image

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
@@ -24,6 +24,7 @@ const CLONE = 'clone';
 const DOWNLOAD = 'download';
 const UPLOAD = 'upload';
 const rawORqcow2 = 'raw_qcow2';
+const LONGHORN = 'longhorn';
 
 export default {
   name: 'EditImage',
@@ -61,9 +62,7 @@ export default {
       storageClasses: this.$store.dispatch(`${ inStore }/findAll`, { type: STORAGE_CLASS }),
     });
 
-    const defaultStorage = this.$store.getters[`${ inStore }/all`](STORAGE_CLASS).find((s) => s.isDefault);
-
-    this['storageClassName'] = this.storageClassName || defaultStorage?.metadata?.name || 'longhorn';
+    this['storageClassName'] = this.storageClassName || this.defaultStorageClassName();
     this.images = this.$store.getters[`${ inStore }/all`](HCI.IMAGE);
 
     const { securityParameters } = this.value.spec;
@@ -144,9 +143,22 @@ export default {
       ];
     },
 
-    storageClassOptions() {
+    encryptedStorageClasses() {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const storages = this.$store.getters[`${ inStore }/all`](STORAGE_CLASS);
+
+      return storages.filter((s) => s.isEncrypted);
+    },
+
+    nonEncryptedStorageClasses() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+      const storages = this.$store.getters[`${ inStore }/all`](STORAGE_CLASS);
+
+      return storages.filter((s) => !s.isEncrypted);
+    },
+
+    storageClassOptions() {
+      const storages = this.value.spec?.securityParameters?.cryptoOperation === ENCRYPT ? this.encryptedStorageClasses : this.nonEncryptedStorageClasses;
 
       return storages
         .filter((s) => !s.parameters?.backingImage && s.provisioner !== LVM_DRIVER) // Lvm storage is not supported.
@@ -239,6 +251,13 @@ export default {
         this.$refs.file.value = null;
       }
     },
+    'value.spec.securityParameters.cryptoOperation'() {
+      if (this.value.spec?.securityParameters?.cryptoOperation === ENCRYPT) {
+        this.storageClassName = this.encryptedStorageClasses[0]?.name || LONGHORN;
+      } else { // URL / FILE / DECRYPT should use default storage class
+        this.storageClassName = this.defaultStorageClassName();
+      }
+    }
   },
 
   methods: {
@@ -385,6 +404,14 @@ export default {
           return str.toLowerCase().includes(os.value.toLowerCase()) ? os.value : false;
         }
       });
+    },
+
+    defaultStorageClassName() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+      const defaultStorage = this.$store.getters[`${ inStore }/all`](STORAGE_CLASS).find((s) => s.isDefault);
+
+      // if default sc is encrypted, use longhorn as default
+      return defaultStorage.isEncrypted ? LONGHORN : defaultStorage?.metadata?.name;
     }
   },
 };

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
@@ -61,7 +61,6 @@ export default {
       images:         this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.IMAGE }),
       storageClasses: this.$store.dispatch(`${ inStore }/findAll`, { type: STORAGE_CLASS }),
     });
-
     this['storageClassName'] = this.storageClassName || this.defaultStorageClassName();
     this.images = this.$store.getters[`${ inStore }/all`](HCI.IMAGE);
 
@@ -253,7 +252,7 @@ export default {
     },
     'value.spec.securityParameters.cryptoOperation'() {
       if (this.value.spec?.securityParameters?.cryptoOperation === ENCRYPT) {
-        this.storageClassName = this.encryptedStorageClasses[0]?.name || LONGHORN;
+        this.storageClassName = this.encryptedStorageClasses[0]?.name || '';
       } else { // URL / FILE / DECRYPT should use default storage class
         this.storageClassName = this.defaultStorageClassName();
       }
@@ -409,6 +408,10 @@ export default {
     defaultStorageClassName() {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const defaultStorage = this.$store.getters[`${ inStore }/all`](STORAGE_CLASS).find((s) => s.isDefault);
+
+      if (!defaultStorage) {
+        return LONGHORN;
+      }
 
       // if default sc is encrypted, use longhorn as default
       return defaultStorage.isEncrypted ? LONGHORN : defaultStorage?.metadata?.name;

--- a/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
+++ b/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
@@ -58,6 +58,10 @@ export default class HciStorageClass extends StorageClass {
     return key ? this.$rootGetters['i18n/t'](key) : this.provisioner;
   }
 
+  get isEncrypted() {
+    return this.parameters?.encrypted === 'true';
+  }
+
   get isLonghornV2() {
     return this.provisioner === LONGHORN_DRIVER && this.longhornVersion === DATA_ENGINE_V2;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- when choosing encrypt option, user can only choose encrypted storage class in create VM image page.
- If default storage class set to encrypted sc, use longhorn as fallback.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/6792

### Test screenshot/video


https://github.com/user-attachments/assets/82803329-3aff-45d1-ab55-c71141aa2e26




