### PR TITLE
feat: add confirmation pop-up for VM stop and pause actions

### DIFF
--- a/pkg/harvester/dialog/ConfirmExecutionDialog.vue
+++ b/pkg/harvester/dialog/ConfirmExecutionDialog.vue
@@ -1,0 +1,194 @@
+<script>
+import { mapState } from 'vuex';
+import { exceptionToErrorsArray } from '@shell/utils/error';
+import { alternateLabel } from '@shell/utils/platform';
+import AsyncButton from '@shell/components/AsyncButton';
+import { Banner } from '@components/Banner';
+import { Card } from '@components/Card';
+import { escapeHtml } from '@shell/utils/string';
+import CopyToClipboardText from '@shell/components/CopyToClipboardText';
+
+/**
+ * @name ConfirmExecutionDialog
+ * @description Dialog component to confirm the related resources before executing the action.
+ */
+export default {
+  name: 'ConfirmExecutionDialog',
+
+  emits: ['close'],
+
+  components: {
+    AsyncButton,
+    Banner,
+    Card,
+    CopyToClipboardText
+  },
+
+  props: {
+    /**
+     * @property resources to be deleted.
+     * @type {Resource[]} Array of the resource model's instance
+     */
+    resources: {
+      type:     Array,
+      required: true
+    }
+  },
+
+  data() {
+    return { errors: [], confirmName: '' };
+  },
+
+  computed: {
+    ...mapState('action-menu', ['modalData']),
+
+    warningMessageKey() {
+      return this.modalData.warningMessageKey;
+    },
+
+    names() {
+      return this.resources.map((obj) => obj.nameDisplay).slice(0, 5);
+    },
+
+    resourceNames() {
+      return this.names.reduce((res, name, i) => {
+        if (i >= 5) {
+          return res;
+        }
+        res += `<b>${ escapeHtml(name) }</b>`;
+        if (i === this.names.length - 1) {
+          res += this.plusMore;
+        } else {
+          res += i === this.resources.length - 2 ? ' and ' : ', ';
+        }
+
+        return res;
+      }, '');
+    },
+
+    nameToMatch() {
+      return this.resources[0].nameDisplay;
+    },
+
+    plusMore() {
+      const remaining = this.resources.length - this.names.length;
+
+      return this.t('dialog.confirmExecution.andOthers', { count: remaining });
+    },
+
+    type() {
+      const types = new Set(this.resources.reduce((array, each) => {
+        array.push(each.type);
+
+        return array;
+      }, []));
+
+      if (types.size > 1) {
+        return this.t('generic.resource', { count: this.resources.length });
+      }
+
+      const schema = this.resources[0]?.schema;
+
+      if ( !schema ) {
+        return `resource${ this.resources.length === 1 ? '' : 's' }`;
+      }
+
+      return this.$store.getters['type-map/labelFor'](schema, this.resources.length);
+    },
+
+    applyDisabled() {
+      return this.confirmName !== this.nameToMatch;
+    },
+
+    protip() {
+      return this.t('dialog.confirmExecution.protip', { alternateLabel });
+    },
+  },
+
+  methods: {
+    escapeHtml,
+
+    close() {
+      this.confirmName = '';
+      this.errors = [];
+      this.$emit('close');
+    },
+
+    async apply(buttonDone) {
+      try {
+        for (const resource of this.resources) {
+          await resource.doActionGrowl(this.modalData.action, {});
+        }
+        buttonDone(true);
+        this.close();
+      } catch (e) {
+        this.errors = exceptionToErrorsArray(e);
+        buttonDone(false);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <Card
+    class="prompt-related"
+    :show-highlight-border="false"
+  >
+    <template #title>
+      <h4 class="text-default-text">
+        {{ t('dialog.confirmExecution.title') }}
+      </h4>
+    </template>
+
+    <template #body>
+      <div class="pl-10 pr-10">
+        <span
+          v-clean-html="t(warningMessageKey, { type, names: resourceNames }, true)"
+        ></span>
+
+        <div class="mt-10 mb-10">
+          <span
+            v-clean-html="t('dialog.confirmExecution.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
+          ></span>
+        </div>
+        <div class="mb-10">
+          <CopyToClipboardText :text="nameToMatch" />
+        </div>
+        <input
+          id="confirm"
+          v-model="confirmName"
+          type="text"
+        />
+        <div class="text-info mt-20">
+          {{ protip }}
+        </div>
+        <Banner
+          v-for="(error, i) in errors"
+          :key="i"
+        />
+      </div>
+    </template>
+
+    <template #actions>
+      <button
+        class="btn role-secondary mr-10"
+        @click="close"
+      >
+        {{ t('generic.cancel') }}
+      </button>
+      <AsyncButton
+        mode="apply"
+        class="btn bg-error ml-10"
+        :disabled="applyDisabled"
+        @click="apply"
+      />
+    </template>
+  </Card>
+</template>
+
+<style lang='scss' scoped>
+  .actions {
+    text-align: right;
+  }
+</style>

--- a/pkg/harvester/dialog/ConfirmExecutionDialog.vue
+++ b/pkg/harvester/dialog/ConfirmExecutionDialog.vue
@@ -120,9 +120,7 @@ export default {
 </script>
 
 <template>
-  <Card
-    :show-highlight-border="false"
-  >
+  <Card :show-highlight-border="false">
     <template #title>
       <h4 class="text-default-text">
         {{ t('dialog.confirmExecution.title') }}
@@ -154,7 +152,7 @@ export default {
         </button>
         <AsyncButton
           mode="apply"
-          class="btn bg-error ml-10"
+          class="btn bg-primary ml-10"
           :disabled="applyDisabled"
           @click="apply"
         />
@@ -164,6 +162,10 @@ export default {
 </template>
 
 <style lang='scss' scoped>
+  .modal-container {
+    max-width: 400px;
+  }
+
   .actions {
     width: 100%;
     text-align: right;

--- a/pkg/harvester/dialog/ConfirmExecutionDialog.vue
+++ b/pkg/harvester/dialog/ConfirmExecutionDialog.vue
@@ -6,7 +6,6 @@ import AsyncButton from '@shell/components/AsyncButton';
 import { Banner } from '@components/Banner';
 import { Card } from '@components/Card';
 import { escapeHtml } from '@shell/utils/string';
-import CopyToClipboardText from '@shell/components/CopyToClipboardText';
 
 /**
  * @name ConfirmExecutionDialog
@@ -21,7 +20,6 @@ export default {
     AsyncButton,
     Banner,
     Card,
-    CopyToClipboardText
   },
 
   props: {
@@ -36,7 +34,7 @@ export default {
   },
 
   data() {
-    return { errors: [], confirmName: '' };
+    return { errors: [] };
   },
 
   computed: {
@@ -66,10 +64,6 @@ export default {
       }, '');
     },
 
-    nameToMatch() {
-      return this.resources[0].nameDisplay;
-    },
-
     plusMore() {
       const remaining = this.resources.length - this.names.length;
 
@@ -96,10 +90,6 @@ export default {
       return this.$store.getters['type-map/labelFor'](schema, this.resources.length);
     },
 
-    applyDisabled() {
-      return this.confirmName !== this.nameToMatch;
-    },
-
     protip() {
       return this.t('dialog.confirmExecution.protip', { alternateLabel });
     },
@@ -109,7 +99,6 @@ export default {
     escapeHtml,
 
     close() {
-      this.confirmName = '';
       this.errors = [];
       this.$emit('close');
     },
@@ -132,7 +121,6 @@ export default {
 
 <template>
   <Card
-    class="prompt-related"
     :show-highlight-border="false"
   >
     <template #title>
@@ -146,20 +134,6 @@ export default {
         <span
           v-clean-html="t(warningMessageKey, { type, names: resourceNames }, true)"
         ></span>
-
-        <div class="mt-10 mb-10">
-          <span
-            v-clean-html="t('dialog.confirmExecution.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
-          ></span>
-        </div>
-        <div class="mb-10">
-          <CopyToClipboardText :text="nameToMatch" />
-        </div>
-        <input
-          id="confirm"
-          v-model="confirmName"
-          type="text"
-        />
         <div class="text-info mt-20">
           {{ protip }}
         </div>
@@ -171,24 +145,27 @@ export default {
     </template>
 
     <template #actions>
-      <button
-        class="btn role-secondary mr-10"
-        @click="close"
-      >
-        {{ t('generic.cancel') }}
-      </button>
-      <AsyncButton
-        mode="apply"
-        class="btn bg-error ml-10"
-        :disabled="applyDisabled"
-        @click="apply"
-      />
+      <div class="actions">
+        <button
+          class="btn role-secondary"
+          @click="close"
+        >
+          {{ t('generic.cancel') }}
+        </button>
+        <AsyncButton
+          mode="apply"
+          class="btn bg-error ml-10"
+          :disabled="applyDisabled"
+          @click="apply"
+        />
+      </div>
     </template>
   </Card>
 </template>
 
 <style lang='scss' scoped>
   .actions {
+    width: 100%;
     text-align: right;
   }
 </style>

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -47,7 +47,6 @@ dialog:
       =1 { and <b>one other </b>}
       other { and <b>{count} other </b>}
       }
-    confirmName: "Enter <b>{nameToMatch}</b> below to confirm:"
     protip: "Tip: Hold the {alternateLabel} key while clicking action to bypass this confirmation"
     stop:
       message: "Are you sure you want to continue stop the {type} {names}?"

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -38,6 +38,22 @@ asyncButton:
     success: Restarted
     waiting: Restarting&hellip;
 
+dialog:
+  confirmExecution:
+    title: Are you sure?
+    andOthers: |-
+      {count, plural,
+      =0 {}
+      =1 { and <b>one other </b>}
+      other { and <b>{count} other </b>}
+      }
+    confirmName: "Enter <b>{nameToMatch}</b> below to confirm:"
+    protip: "Tip: Hold the {alternateLabel} key while clicking action to bypass this confirmation"
+    stop:
+      message: "Are you sure you want to continue stop the {type} {names}?"
+    pause:
+      message: "Are you sure you want to continue pause the {type} {names}?"
+
 harvester:
   productLabel: 'Harvester'
   modal:
@@ -861,14 +877,14 @@ harvester:
       doc: Read the <a href="{url}" target="_blank">documentation</a> before starting the upgrade process. Ensure that you complete procedures that are relevant to your environment and the version you are upgrading to.
       tip: Unmet system requirements and incorrectly performed procedures may cause complete upgrade failure and other issues that require manual workarounds.
       moreNotes: For more details about the release notes, please visit -
-     
+
   schedule:
     label: Virtual Machine Schedules
     createTitle: Create Schedule
     createButtonText: Create Schedule
     scheduleType: Virtual Machine Schedule Type
     cron: Cron Schedule
-    detail: 
+    detail:
       namespace: Namespace
       sourceVM: Source Virtual Machine
     tabs:
@@ -878,12 +894,12 @@ harvester:
     message:
       noSetting:
         suffix: before creating a backup schedule
-    retain: 
+    retain:
       label: Retain
       count: Count
-      tooltip: Number of up-to-date VM backups to retain. Maximum to 250, minimum to 2. 
+      tooltip: Number of up-to-date VM backups to retain. Maximum to 250, minimum to 2.
     maxFailure:
-      label: Max Failure 
+      label: Max Failure
       count: Count
       tooltip: Max number of consecutive failed backups that could be tolerated. If reach this threshold, Harvester controller will suspend the schedule job. This value should less than retain count
     virtualMachine:

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -102,11 +102,12 @@ export default class VirtVm extends HarvesterResource {
 
     return [
       {
-        action:   'stopVM',
-        enabled:  !!this.actions?.stop,
-        icon:     'icon icon-close',
-        label:    this.t('harvester.action.stop'),
-        bulkable: true
+        action:    'stopVM',
+        altAction: 'altStopVM',
+        enabled:   !!this.actions?.stop,
+        icon:      'icon icon-close',
+        label:     this.t('harvester.action.stop'),
+        bulkable:  true
       },
       {
         action:   'forceStop',
@@ -116,10 +117,11 @@ export default class VirtVm extends HarvesterResource {
         bulkable: true
       },
       {
-        action:  'pauseVM',
-        enabled: !!this.actions?.pause,
-        icon:    'icon icon-pause',
-        label:   this.t('harvester.action.pause')
+        action:    'pauseVM',
+        altAction: 'altPauseVM',
+        enabled:   !!this.actions?.pause,
+        icon:      'icon icon-pause',
+        label:     this.t('harvester.action.pause')
       },
       {
         action:  'unpauseVM',
@@ -402,7 +404,16 @@ export default class VirtVm extends HarvesterResource {
     return node?.id;
   }
 
-  pauseVM() {
+  pauseVM(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      action:            'pause',
+      warningMessageKey: 'dialog.confirmExecution.pause.message',
+      component:         'ConfirmExecutionDialog'
+    });
+  }
+
+  altPauseVM() {
     this.doActionGrowl('pause', {});
   }
 
@@ -417,7 +428,16 @@ export default class VirtVm extends HarvesterResource {
     this.doActionGrowl('unpause', {});
   }
 
-  stopVM() {
+  stopVM(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      action:            'stop',
+      warningMessageKey: 'dialog.confirmExecution.stop.message',
+      component:         'ConfirmExecutionDialog'
+    });
+  }
+
+  altStopVM() {
     this.doActionGrowl('stop', {});
   }
 

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -102,12 +102,13 @@ export default class VirtVm extends HarvesterResource {
 
     return [
       {
-        action:    'stopVM',
-        altAction: 'altStopVM',
-        enabled:   !!this.actions?.stop,
-        icon:      'icon icon-close',
-        label:     this.t('harvester.action.stop'),
-        bulkable:  true
+        action:     'stopVM',
+        altAction:  'altStopVM',
+        enabled:    !!this.actions?.stop,
+        icon:       'icon icon-close',
+        label:      this.t('harvester.action.stop'),
+        bulkable:   true,
+        bulkAction: 'stopVM',
       },
       {
         action:   'forceStop',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- A confirmation pop-up should display when the `Stop` or `Pause` action is clicked
- Mac users can bypass the confirmation pop-up by holding the `Command` key while clicking the action

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[ENHANCEMENT] Add confirmation pop-up for VM stop and pause actions #7382](https://github.com/harvester/harvester/issues/7382)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
Confirm pop-up for stop VM
![stop](https://github.com/user-attachments/assets/64164d83-352e-4d45-97e9-a930146c1ea0)

Confirm pop-up for stop multi VMs
![Screenshot 2025-01-20 at 12 17 52 PM (2)](https://github.com/user-attachments/assets/5a6a9129-623f-4b63-8b07-399ea1bf2b3a)

Confirm pop-up for pause VM
![pause](https://github.com/user-attachments/assets/52e68413-dd45-47dc-a114-d8094cb65549)

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

