### PR TITLE
fix: VM Snapshot and Backup List Views Fail to Load After Creation

### DIFF
--- a/pkg/harvester/models/harvesterhci.io.virtualmachinebackup.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachinebackup.js
@@ -132,7 +132,7 @@ export default class HciVmBackup extends HarvesterResource {
   }
 
   get sourceSchedule() {
-    return this.metadata?.annotations[HCI_ANNOTATIONS.SVM_BACKUP_ID];
+    return this.metadata?.annotations?.[HCI_ANNOTATIONS.SVM_BACKUP_ID];
   }
 
   get attachVM() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The VM snapshot and backup list views fail to load and display properly when an error occurs

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] VM Snapshot and Backup List Views Fail to Load After Creation #7295](https://github.com/harvester/harvester/issues/7295)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Create a secret
- Create a VM and then delete the secret
- Create a VM backup or snapshot
- Navigate to the VM backup or snapshot page, and the list should display correctly

**VM backup**
![Screenshot 2025-01-21 at 2 15 12 PM (2)](https://github.com/user-attachments/assets/e8aad359-3524-4c6f-b3ef-10b908afea6f)

**VM snapshot**
![Screenshot 2025-01-21 at 2 15 14 PM (2)](https://github.com/user-attachments/assets/98d22ea7-f0b1-4a36-8ab8-68a1a4db7b54)


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Test with `https://10.115.252.72/`

