### PR TITLE
Prevent display lock icon if this.volumes is empty array

### DIFF
--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -640,6 +640,10 @@ export default class VirtVm extends HarvesterResource {
   }
 
   get encryptedVolumeType() {
+    if (!this.volumes || this.volumes.length === 0) {
+      return 'none';
+    }
+
     if (this.volumes.every((vol) => vol.isEncrypted)) {
       return 'all';
     } else if (this.volumes.some((vol) => vol.isEncrypted)) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
There is a sudden display lock icon when initially creating a VM with non-encrypted image.

The root cause is `array.every()` return `true` while `this.volumes` is an empty array. See in https://262.ecma-international.org/6.0/#sec-array.prototype.every  (`In particular, for an empty array, it returns true`)



```
this.volumes // []

this.volumes.every((vol) => vol.isEncrypted) // true
```

<img width="1496" alt="Screenshot 2025-02-05 at 8 42 19 AM" src="https://github.com/user-attachments/assets/7fcf9be6-afe8-43a8-a5c0-49270d1e7bcc" />


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Yu-Jack 

### Related Issue #
[#7510](https://github.com/harvester/harvester/issues/7510)

### Test screenshot/video
Tested with encrpyted and non-encrypted images are all good.
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/9015a4bc-92fd-4f72-8d6f-999b0581d076" />



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


