### PR TITLE
add description formatter 

### DIFF
--- a/pkg/harvester/config/harvester-cluster.js
+++ b/pkg/harvester/config/harvester-cluster.js
@@ -31,7 +31,8 @@ import {
   FINGERPRINT,
   IMAGE_PROGRESS,
   SNAPSHOT_TARGET_VOLUME,
-  IMAGE_VIRTUAL_SIZE
+  IMAGE_VIRTUAL_SIZE,
+  HARVESTER_DESCRIPTION
 } from './table-headers';
 
 const TEMPLATE = HCI.VM_VERSION;
@@ -220,6 +221,7 @@ export function init($plugin, store) {
   headers(HCI.IMAGE, [
     STATE,
     NAME_COL,
+    HARVESTER_DESCRIPTION,
     NAMESPACE_COL,
     IMAGE_PROGRESS,
     IMAGE_DOWNLOAD_SIZE,

--- a/pkg/harvester/config/table-headers.js
+++ b/pkg/harvester/config/table-headers.js
@@ -1,6 +1,7 @@
 /**
  * Harvester
  */
+import { DESCRIPTION } from '@shell/config/table-headers';
 
 // image
 export const IMAGE_DOWNLOAD_SIZE = {
@@ -87,4 +88,10 @@ export const MACHINE_POOLS = {
   value:    'nodes.length',
   align:    'center',
   width:    100,
+};
+
+export const HARVESTER_DESCRIPTION = {
+  ...DESCRIPTION,
+  formatter: 'HarvesterDescription',
+  // width: 400
 };

--- a/pkg/harvester/formatters/HarvesterDescription.vue
+++ b/pkg/harvester/formatters/HarvesterDescription.vue
@@ -1,0 +1,38 @@
+<script>
+export default {
+  props: {
+    row: {
+      type:     Object,
+      required: true,
+    },
+  },
+  computed: {
+    descriptionText() {
+      return this.row?.description || '';
+    },
+  },
+};
+</script>
+
+<template>
+  <span
+    v-clean-tooltip="{content: descriptionText, skidding: -30, placement: 'top-start', popperClass: ['harvester-description-tooltip']}"
+    class="harvester-description-text"
+  >
+    {{ descriptionText }}
+  </span>
+</template>
+
+<style lang="scss">
+  .harvester-description-text {
+    display: block;
+    width: inherit;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .harvester-description-tooltip {
+    overflow-wrap: break-word;
+  }
+</style>

--- a/pkg/harvester/list/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/list/harvesterhci.io.virtualmachineimage.vue
@@ -25,6 +25,7 @@ export default {
   },
 
   data() {
+    console.log('rows=', this.rows)
     return {
       searchLabels: [],
       filterRows:   []


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

A quick DEMO in image page
<img width="1487" alt="Screenshot 2025-02-05 at 6 18 47 PM" src="https://github.com/user-attachments/assets/86321f88-1fc2-497a-a512-6793d9012556" />

In order to show description in namespace and project/namespace pages, we need port below HarvesterDescription.vue formatter to shell and bump the @rancher/shell

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


