### PR TITLE
feat: add support for persistent TPM in VMs

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -47,7 +47,8 @@ const featuresV142 = [
 
 // TODO: add v1.5.0 official release note
 const featuresV150 = [
-  ...featuresV142
+  ...featuresV142,
+  'VMPersistentState'
 ];
 
 export const RELEASE_FEATURES = {

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -48,7 +48,7 @@ const featuresV142 = [
 // TODO: add v1.5.0 official release note
 const featuresV150 = [
   ...featuresV142,
-  'VMPersistentState'
+  'tpmPersistentState'
 ];
 
 export const RELEASE_FEATURES = {

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -466,11 +466,11 @@ export default {
         />
 
         <Checkbox
-          v-if="value.persistentStateFeatureEnabled && tpmEnabled"
-          v-model:value="persistentStateEnabled"
+          v-if="value.tpmPersistentStateFeatureEnabled && tpmEnabled"
+          v-model:value="tpmPersistentStateEnabled"
           class="check"
           type="checkbox"
-          :label="t('harvester.virtualMachine.advancedOptions.persistentState')"
+          :label="t('harvester.virtualMachine.advancedOptions.tpmPersistentState')"
           :mode="mode"
         />
 

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -466,6 +466,15 @@ export default {
         />
 
         <Checkbox
+          v-if="tpmEnabled"
+          v-model:value="persistentStateEnabled"
+          class="check"
+          type="checkbox"
+          :label="t('harvester.virtualMachine.advancedOptions.persistentState')"
+          :mode="mode"
+        />
+
+        <Checkbox
           v-model:value="efiEnabled"
           class="check"
           type="checkbox"
@@ -480,16 +489,6 @@ export default {
           type="checkbox"
           :label="t('harvester.virtualMachine.secureBoot')"
           :mode="mode"
-        />
-
-        <Checkbox
-          v-if="tpmEnabled || efiEnabled"
-          class="check"
-          type="checkbox"
-          :label="t('harvester.virtualMachine.advancedOptions.persistentState')"
-          :mode="mode"
-          :value="true"
-          :disabled="true"
         />
       </Tab>
     </Tabbed>

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -466,7 +466,7 @@ export default {
         />
 
         <Checkbox
-          v-if="tpmEnabled"
+          v-if="value.persistentStateFeatureEnabled && tpmEnabled"
           v-model:value="persistentStateEnabled"
           class="check"
           type="checkbox"

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -481,6 +481,16 @@ export default {
           :label="t('harvester.virtualMachine.secureBoot')"
           :mode="mode"
         />
+
+        <Checkbox
+          v-if="tpmEnabled || efiEnabled"
+          class="check"
+          type="checkbox"
+          :label="t('harvester.virtualMachine.advancedOptions.persistentState')"
+          :mode="mode"
+          :value="true"
+          :disabled="true"
+        />
       </Tab>
     </Tabbed>
   </CruResource>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -874,11 +874,11 @@ export default {
         />
 
         <Checkbox
-          v-if="value.persistentStateFeatureEnabled && tpmEnabled"
-          v-model:value="persistentStateEnabled"
+          v-if="value.tpmPersistentStateFeatureEnabled && tpmEnabled"
+          v-model:value="tpmPersistentStateEnabled"
           class="check"
           type="checkbox"
-          :label="t('harvester.virtualMachine.advancedOptions.persistentState')"
+          :label="t('harvester.virtualMachine.advancedOptions.tpmPersistentState')"
           :mode="mode"
         />
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -874,6 +874,15 @@ export default {
         />
 
         <Checkbox
+          v-if="tpmEnabled"
+          v-model:value="persistentStateEnabled"
+          class="check"
+          type="checkbox"
+          :label="t('harvester.virtualMachine.advancedOptions.persistentState')"
+          :mode="mode"
+        />
+
+        <Checkbox
           v-model:value="efiEnabled"
           class="check"
           type="checkbox"
@@ -888,16 +897,6 @@ export default {
           type="checkbox"
           :label="t('harvester.virtualMachine.secureBoot')"
           :mode="mode"
-        />
-
-        <Checkbox
-          v-if="tpmEnabled || efiEnabled"
-          class="check"
-          type="checkbox"
-          :label="t('harvester.virtualMachine.advancedOptions.persistentState')"
-          :mode="mode"
-          :value="true"
-          :disabled="true"
         />
 
         <Banner

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -874,7 +874,7 @@ export default {
         />
 
         <Checkbox
-          v-if="tpmEnabled"
+          v-if="value.persistentStateFeatureEnabled && tpmEnabled"
           v-model:value="persistentStateEnabled"
           class="check"
           type="checkbox"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -889,6 +889,17 @@ export default {
           :label="t('harvester.virtualMachine.secureBoot')"
           :mode="mode"
         />
+
+        <Checkbox
+          v-if="tpmEnabled || efiEnabled"
+          class="check"
+          type="checkbox"
+          :label="t('harvester.virtualMachine.advancedOptions.persistentState')"
+          :mode="mode"
+          :value="true"
+          :disabled="true"
+        />
+
         <Banner
           v-if="showCpuPinningBanner"
           color="warning"

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -594,6 +594,7 @@ harvester:
     enableUsb: Enable USB Tablet
     advancedOptions:
       tpm: Enable TPM
+      persistentState: Persistent State
       cpuManager:
         prefix: You must enable CPU Manager for at least one node in
         middle: 'host page'

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -594,7 +594,7 @@ harvester:
     enableUsb: Enable USB Tablet
     advancedOptions:
       tpm: Enable TPM
-      persistentState: Persistent State
+      tpmPersistentState: TPM Persistent State
       cpuManager:
         prefix: You must enable CPU Manager for at least one node in
         middle: 'host page'

--- a/pkg/harvester/mixins/harvester-vm/impl.js
+++ b/pkg/harvester/mixins/harvester-vm/impl.js
@@ -137,7 +137,11 @@ export default {
     },
 
     isTpmEnabled(spec) {
-      return !!spec?.template?.spec?.domain?.devices?.tpm ;
+      return !!spec?.template?.spec?.domain?.devices?.tpm;
+    },
+
+    isPersistentStateEnabled(spec) {
+      return !!spec?.template?.spec?.domain?.devices?.tpm?.persistent;
     },
 
     isSecureBoot(spec) {

--- a/pkg/harvester/mixins/harvester-vm/impl.js
+++ b/pkg/harvester/mixins/harvester-vm/impl.js
@@ -140,7 +140,7 @@ export default {
       return !!spec?.template?.spec?.domain?.devices?.tpm;
     },
 
-    isPersistentStateEnabled(spec) {
+    isTPMPersistentStateEnabled(spec) {
       return !!spec?.template?.spec?.domain?.devices?.tpm?.persistent;
     },
 

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -164,7 +164,7 @@ export default {
       accessCredentials:             [],
       efiEnabled:                    false,
       tpmEnabled:                    false,
-      persistentStateEnabled:        false,
+      tpmPersistentStateEnabled:     false,
       secureBoot:                    false,
       userDataTemplateId:            '',
       saveUserDataAsClearText:       false,
@@ -368,7 +368,7 @@ export default {
       const installAgent = this.hasInstallAgent(userData, osType, true);
       const efiEnabled = this.isEfiEnabled(spec);
       const tpmEnabled = this.isTpmEnabled(spec);
-      const persistentStateEnabled = this.isPersistentStateEnabled(spec);
+      const tpmPersistentStateEnabled = this.isTPMPersistentStateEnabled(spec);
       const secureBoot = this.isSecureBoot(spec);
       const cpuPinning = this.isCpuPinning(spec);
 
@@ -401,7 +401,7 @@ export default {
       this['installUSBTablet'] = installUSBTablet;
       this['efiEnabled'] = efiEnabled;
       this['tpmEnabled'] = tpmEnabled;
-      this['persistentStateEnabled'] = persistentStateEnabled;
+      this['tpmPersistentStateEnabled'] = tpmPersistentStateEnabled;
       this['secureBoot'] = secureBoot;
       this['cpuPinning'] = cpuPinning;
 
@@ -1424,8 +1424,8 @@ export default {
       }
     },
 
-    setPersistentStateEnabled(persistentStateEnabled) {
-      if (persistentStateEnabled) {
+    setTPMPersistentStateEnabled(tpmPersistentStateEnabled) {
+      if (tpmPersistentStateEnabled) {
         set(this.spec.template.spec.domain.devices, 'tpm', { persistent: true });
       } else {
         set(this.spec.template.spec.domain.devices, 'tpm', {});
@@ -1555,8 +1555,8 @@ export default {
       this.setTPM(val);
     },
 
-    persistentStateEnabled(val) {
-      this.setPersistentStateEnabled(val);
+    tpmPersistentStateEnabled(val) {
+      this.setTPMPersistentStateEnabled(val);
     },
 
     installAgent: {

--- a/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
@@ -273,7 +273,7 @@ export default class HciVmTemplateVersion extends HarvesterResource {
     this.spec.vm.spec.template.metadata['labels'] = { ...wasIgnored, ...val };
   }
 
-  get persistentStateFeatureEnabled() {
-    return this.$rootGetters['harvester-common/getFeatureEnabled']('VMPersistentState');
+  get tpmPersistentStateFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('tpmPersistentState');
   }
 }

--- a/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
@@ -272,4 +272,8 @@ export default class HciVmTemplateVersion extends HarvesterResource {
 
     this.spec.vm.spec.template.metadata['labels'] = { ...wasIgnored, ...val };
   }
+
+  get persistentStateFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('VMPersistentState');
+  }
 }

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -1175,6 +1175,10 @@ export default class VirtVm extends HarvesterResource {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('volumeEncryption');
   }
 
+  get persistentStateFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('VMPersistentState');
+  }
+
   setInstanceLabels(val) {
     if ( !this.spec?.template?.metadata?.labels ) {
       set(this, 'spec.template.metadata.labels', {});

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -1175,8 +1175,8 @@ export default class VirtVm extends HarvesterResource {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('volumeEncryption');
   }
 
-  get persistentStateFeatureEnabled() {
-    return this.$rootGetters['harvester-common/getFeatureEnabled']('VMPersistentState');
+  get tpmPersistentStateFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('tpmPersistentState');
   }
 
   setInstanceLabels(val) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Add `Persistent State` checkbox to VM advanced options.
- The `Persistent State` checkbox is only visible when `Enable TPM` is enabled
- User are allow to enable or disable the checkbox
- It adds `persistent: true` to the TPM block if `Enable TPM` is checked

Ref: https://github.com/harvester/harvester/issues/6731#issuecomment-2550189771

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[FEATURE] Add support for persistent TPM in VMs #6731](https://github.com/harvester/harvester/issues/6731#issuecomment-2550189771)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Enable `Enable TPM`, then verify that the `Persistent State` checkbox is visible
- Enable `Persistent State`, then click `Edit as YAML`, confirm that `persistent: true` is added to TPM block
```
spec:
  template:
    spec:
      domain:
        devices:
          tpm:
            persistent: true
```
- Uncheck and verify `persistent: true` is removed
- The same behavior applies to the Create Template page.

https://github.com/user-attachments/assets/e3595fb3-71f1-4af8-8776-2b037326ceb3

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
https://kubevirt.io/user-guide/compute/persistent_tpm_and_uefi_state/
