### PR TITLE
Add VlanL2Network / UntaggedNetwork types in network-storage setting

### DIFF
--- a/pkg/harvester/components/settings/storage-network.vue
+++ b/pkg/harvester/components/settings/storage-network.vue
@@ -100,7 +100,7 @@ export default {
     networkTypes() {
       const types = [L2VLAN];
 
-      if (this.unTaggedNetworkSettingEnabled) {
+      if (this.untaggedNetworkSettingEnabled) {
         types.push(UNTAGGED);
       }
 
@@ -112,8 +112,8 @@ export default {
       return docLink(DOC.STORAGE_NETWORK_EXAMPLE, version);
     },
 
-    unTaggedNetworkSettingEnabled() {
-      return this.$store.getters['harvester-common/getFeatureEnabled']('unTaggedNetworkSetting');
+    untaggedNetworkSettingEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('untaggedNetworkSetting');
     },
 
     clusterNetworkOptions() {

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -48,7 +48,8 @@ const featuresV142 = [
 // TODO: add v1.5.0 official release note
 const featuresV150 = [
   ...featuresV142,
-  'tpmPersistentState'
+  'tpmPersistentState',
+  'unTaggedNetworkSetting'
 ];
 
 export const RELEASE_FEATURES = {

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -49,7 +49,7 @@ const featuresV142 = [
 const featuresV150 = [
   ...featuresV142,
   'tpmPersistentState',
-  'unTaggedNetworkSetting'
+  'untaggedNetworkSetting'
 ];
 
 export const RELEASE_FEATURES = {

--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -65,7 +65,9 @@ export const HCI_ALLOWED_SETTINGS = {
   [HCI_SETTING.SUPPORT_BUNDLE_EXPIRATION]:              {},
   [HCI_SETTING.SUPPORT_BUNDLE_NODE_COLLECTION_TIMEOUT]: { featureFlag: 'supportBundleNodeCollectionTimeoutSetting' },
   [HCI_SETTING.SUPPORT_BUNDLE_IMAGE]:                   { kind: 'json', from: 'import' },
-  [HCI_SETTING.STORAGE_NETWORK]:                        { kind: 'custom', from: 'import' },
+  [HCI_SETTING.STORAGE_NETWORK]:                        {
+    kind: 'custom', from: 'import', canReset: true
+  },
   [HCI_SETTING.VM_FORCE_RESET_POLICY]:                  { kind: 'json', from: 'import' },
   [HCI_SETTING.SSL_CERTIFICATES]:                       { kind: 'json', from: 'import' },
   [HCI_SETTING.SSL_PARAMETERS]:                         {

--- a/pkg/harvester/config/types.js
+++ b/pkg/harvester/config/types.js
@@ -2,3 +2,8 @@ export const BACKUP_TYPE = {
   BACKUP:   'backup',
   SNAPSHOT: 'snapshot'
 };
+
+export const NETWORK_TYPE = {
+  L2VLAN:   'L2VlanNetwork',
+  UNTAGGED: 'UntaggedNetwork'
+};

--- a/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
@@ -11,6 +11,9 @@ import { HCI as HCI_LABELS_ANNOTATIONS } from '@pkg/harvester/config/labels-anno
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { allHash } from '@shell/utils/promise';
 import { HCI } from '../types';
+import { NETWORK_TYPE } from '../config/types';
+
+const { L2VLAN, UNTAGGED } = NETWORK_TYPE;
 
 const AUTO = 'auto';
 const MANUAL = 'manual';
@@ -48,7 +51,7 @@ export default {
       config.bridge = config.bridge.slice(0, -3);
     }
 
-    const type = this.value.vlanType || 'L2VlanNetwork' ;
+    const type = this.value.vlanType || L2VLAN ;
 
     return {
       config,
@@ -101,15 +104,15 @@ export default {
     },
 
     networkType() {
-      return ['L2VlanNetwork', 'UntaggedNetwork'];
+      return [L2VLAN, UNTAGGED];
     },
 
     isUntaggedNetwork() {
       if (this.isView) {
-        return this.value.vlanType === 'UntaggedNetwork';
+        return this.value.vlanType === UNTAGGED;
       }
 
-      return this.type === 'UntaggedNetwork';
+      return this.type === UNTAGGED;
     }
   },
 

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1027,7 +1027,7 @@ harvester:
         invalid: '"Exclude list" is invalid.'
         addIp: Add Exclude IP
       warning: 'WARNING: <br/> Any change to storage-network requires shutting down all virtual machines before applying this setting. <br/> Users have to ensure the cluster network is configured and VLAN Configuration will cover all nodes and ensure the network connectivity is working and expected in all nodes.'
-      tip: 'Specify an IP range in the IPv4 CIDR format. <code>Number of IPs Required = Number of Nodes * 4 + Number of Disks * 2 + Number of Images to Download/Upload </code>. For more information about storage network settings, see the <a href="{url}" target="_blank">documentation</a>.'
+      tip: 'Specify an IP range in the IPv4 CIDR format. <code>Number of IPs Required = Number of Nodes * 2 + Number of Disks * 2 + Number of Images to Download/Upload </code>. For more information about storage network settings, see the <a href="{url}" target="_blank">documentation</a>.'
     vmForceDeletionPolicy:
       period: Period
     ratio : Ratio

--- a/pkg/harvester/models/k8s.cni.cncf.io.networkattachmentdefinition.js
+++ b/pkg/harvester/models/k8s.cni.cncf.io.networkattachmentdefinition.js
@@ -1,5 +1,8 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { HCI } from '@shell/config/labels-annotations';
+import { NETWORK_TYPE } from '../config/types';
+
+const { UNTAGGED } = NETWORK_TYPE;
 
 export default class NetworkAttachmentDef extends SteveModel {
   applyDefaults() {
@@ -42,7 +45,7 @@ export default class NetworkAttachmentDef extends SteveModel {
   }
 
   get vlanId() {
-    return this.vlanType === 'UntaggedNetwork' ? 'N/A' : this.parseConfig.vlan;
+    return this.vlanType === UNTAGGED ? 'N/A' : this.parseConfig.vlan;
   }
 
   get customValidationRules() {
@@ -65,7 +68,7 @@ export default class NetworkAttachmentDef extends SteveModel {
     const route = annotations[HCI.NETWORK_ROUTE];
     let config = {};
 
-    if (this.vlanType === 'UntaggedNetwork') {
+    if (this.vlanType === UNTAGGED) {
       return 'N/A';
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
 - Add `unTaggedNetworkSetting` feature flag for v1.5.0 release.
 - Add `VlanL2Network` / `UntaggedNetwork` types in network-storage setting
     - VlanL2Network : vlan ID : 1 ~ 4094 (can't given 0)
     - UntaggedNetwork : won't bring vlan key, backend will default use vlanID 0 
- Filter out `mgmt` cluster network when user choose UntagggedNetwork.
- Allow user to click `use default value` to disable the setting
- Fix the number of IP formula


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @starbops , @rrajendran17 

### Related Issue #
- https://github.com/harvester/harvester/issues/6501
- https://github.com/harvester/harvester/issues/7330

### Test screenshot/video

https://github.com/user-attachments/assets/81490066-93c7-4925-82e7-aae0d912132b



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


