### PR TITLE
The hints on the branding page is using the wrong product name

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -54,6 +54,11 @@ dialog:
       message: "Are you sure you want to continue pause the {type} {names}?"
 
 harvester:
+  branding:
+    logos:
+      tip: 'Upload a logo to replace the Harvester logo in the top-level navigation header. Image height should be 21 pixels with a max width of 200 pixels. Max file size is 20KB. Accepted formats: JPEG, PNG, SVG.'
+    favicon:
+      tip: 'Upload an icon to replace the Harvester favicon in the browser tab. Max file size is 20KB'
   productLabel: 'Harvester'
   modal:
     backup:
@@ -1512,6 +1517,26 @@ harvester:
         label: Event
       pollingInterval:
         label: Polling Interval
+
+  affinity:
+    thisPodNamespace: This virtual machine's namespace
+    matchExpressions:
+      inNamespaces: "Workloads in these namespaces"
+    vmAffinityTitle: Virtual Machine Scheduling
+    namespaces:
+      placeholder: e.g. default,system,base
+      label: Namespaces
+    addLabel: Add Workload Selector
+    topologyKey:
+      placeholder: 'topology.kubernetes.io/zone'
+
+typeDescription:
+  # Map of
+  # type: Description to be shown on the top of list view describing the type.
+  #       Should fit on one line.
+  #       If you link to anything external, it MUST have
+  #       target="_blank" rel="noopener noreferrer nofollow"
+  harvester: "Branding allows administrators to globally re-brand the UI by customizing the Harvester product name, logos and color scheme."
 
 advancedSettings:
   experimental: 'Experimental features allow users to test and evaluate early-access functionality prior to official supported releases'

--- a/pkg/harvester/pages/c/_cluster/brand/index.vue
+++ b/pkg/harvester/pages/c/_cluster/brand/index.vue
@@ -164,7 +164,7 @@ export default {
     <h1 class="mb-20">
       {{ t('branding.label') }}
     </h1>
-    <TypeDescription resource="branding" />
+    <TypeDescription resource="harvester" />
     <div>
       <div class="row mb-20">
         <div class="col span-6">
@@ -180,7 +180,7 @@ export default {
         {{ t('branding.logos.label') }}
       </h3>
       <label class="text-label">
-        {{ t('branding.logos.tip', {}, true) }}
+        {{ t('harvester.branding.logos.tip', {}, true) }}
       </label>
       <div class="row mt-10 mb-20">
         <Checkbox
@@ -244,7 +244,7 @@ export default {
         {{ t('branding.favicon.label') }}
       </h3>
       <label class="text-label">
-        {{ t('branding.favicon.tip', {}, true) }}
+        {{ t('harvester.branding.favicon.tip', {}, true) }}
       </label>
       <div class="row mt-10 mb-20">
         <Checkbox


### PR DESCRIPTION
Cherry-pick from https://github.com/harvester/dashboard/pull/1276

The hints on the `Branding` page at `Advanced > Settings > UI > branding` are using the product name `Rancher` instead of `Harvester`.

Related to: https://github.com/harvester/harvester/issues/6341

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/6341

### Test screenshot/video
<img width="1492" alt="Screenshot 2025-02-11 at 11 11 55 AM" src="https://github.com/user-attachments/assets/7d978fd8-d8cf-4d38-972c-13aeda71cc56" />


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


