### PR TITLE
fix: unable to create new sshkey in VM create page

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineSSHKey.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineSSHKey.vue
@@ -249,7 +249,7 @@ export default {
       :searchable="searchable"
       :disabled="disabled"
       :options="sshOption"
-      @update:value="update"
+      @input="update"
     />
 
     <ModalWithCard


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

While @rancher/shell 3.0.1 is good, but [3.0.2-rc1](https://github.com/rancher/dashboard/commits/shell-pkg-v3.0.2-rc.1/shell/components/form/LabeledSelect.vue) has problem. 
Might related to https://github.com/rancher/dashboard/commit/bc003d36a04fd4ee66877686f129053d5c5e734d#diff-5316c4da698262a356a5f70f02f4d94b95c66b780cedf9cb04515deb011017d8 change.


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7544

### Test screenshot/video

https://github.com/user-attachments/assets/8b68392a-5ed9-497c-a1dd-a2dc5e8f65ee



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


