### PR TITLE
feat: add EFI persistent state checkbox in VM advanced tab

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -49,6 +49,7 @@ const featuresV142 = [
 const featuresV150 = [
   ...featuresV142,
   'tpmPersistentState',
+  'efiPersistentState',
   'untaggedNetworkSetting',
   'skipSingleReplicaDetachedVol'
 ];

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -478,7 +478,16 @@ export default {
           v-model:value="efiEnabled"
           class="check"
           type="checkbox"
-          :label="t('harvester.virtualMachine.efiEnabled')"
+          :label="t('harvester.virtualMachine.advancedOptions.efiEnabled')"
+          :mode="mode"
+        />
+
+        <Checkbox
+          v-if="value.efiPersistentStateFeatureEnabled && efiEnabled"
+          v-model:value="efiPersistentStateEnabled"
+          class="check"
+          type="checkbox"
+          :label="t('harvester.virtualMachine.advancedOptions.efiPersistentState')"
           :mode="mode"
         />
 
@@ -487,7 +496,7 @@ export default {
           v-model:value="secureBoot"
           class="check"
           type="checkbox"
-          :label="t('harvester.virtualMachine.secureBoot')"
+          :label="t('harvester.virtualMachine.advancedOptions.secureBoot')"
           :mode="mode"
         />
       </Tab>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -886,7 +886,16 @@ export default {
           v-model:value="efiEnabled"
           class="check"
           type="checkbox"
-          :label="t('harvester.virtualMachine.efiEnabled')"
+          :label="t('harvester.virtualMachine.advancedOptions.efiEnabled')"
+          :mode="mode"
+        />
+
+        <Checkbox
+          v-if="value.efiPersistentStateFeatureEnabled && efiEnabled"
+          v-model:value="efiPersistentStateEnabled"
+          class="check"
+          type="checkbox"
+          :label="t('harvester.virtualMachine.advancedOptions.efiPersistentState')"
           :mode="mode"
         />
 
@@ -895,7 +904,7 @@ export default {
           v-model:value="secureBoot"
           class="check"
           type="checkbox"
-          :label="t('harvester.virtualMachine.secureBoot')"
+          :label="t('harvester.virtualMachine.advancedOptions.secureBoot')"
           :mode="mode"
         />
 

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -604,11 +604,12 @@ harvester:
         prefix: You must enable CPU Manager for at least one node in
         middle: 'host page'
         suffix: to enable CPU Pinning for VM
+      efiEnabled: Booting in EFI mode
+      efiPersistentState: EFI Persistent State
+      secureBoot: Secure Boot
     usbTip: Provides an absolute pointer device which often helps with getting a consistent mouse cursor position in VNC.
     sshTitle: Add Public SSH Key
     imageTip: An external URL to the .iso, .img, .qcow2 or .raw that the virtual machine should be created from.
-    efiEnabled: Booting in EFI mode
-    secureBoot: Secure Boot
     volume:
       dragTip: Drag and drop volumes, or use the volume's arrows, to change the boot order.
       volumeTip: The virtual machine only contains a CD-ROM volume. You may want to add additional disk volumes.

--- a/pkg/harvester/mixins/harvester-vm/impl.js
+++ b/pkg/harvester/mixins/harvester-vm/impl.js
@@ -144,6 +144,10 @@ export default {
       return !!spec?.template?.spec?.domain?.devices?.tpm?.persistent;
     },
 
+    isEFIPersistentStateEnabled(spec) {
+      return !!spec?.template?.spec?.domain?.firmware?.bootloader?.efi?.persistent;
+    },
+
     isSecureBoot(spec) {
       return !!spec?.template?.spec?.domain?.firmware?.bootloader?.efi?.secureBoot;
     },

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -1392,7 +1392,6 @@ export default {
     setBootMethod(boot = { efi: false, secureBoot: false, efiPersistentStateEnabled: false }) {
       if (boot.efi) {
         set(this.spec.template.spec.domain, 'firmware.bootloader.efi.secureBoot', boot.secureBoot);
-        set(this.spec.template.spec.domain, 'firmware.bootloader.efi.persistent', boot.efiPersistentStateEnabled);
       } else {
         delete this.spec.template.spec.domain['firmware'];
         delete this.spec.template.spec.domain.features['smm'];
@@ -1411,6 +1410,12 @@ export default {
             delete this.spec.template.spec.domain.features['smm'];
           }
         } catch (e) {}
+      }
+
+      if (boot.efiPersistentStateEnabled) {
+        set(this.spec.template.spec.domain, 'firmware.bootloader.efi.persistent', true);
+      } else {
+        delete this.spec.template.spec.domain.firmware.bootloader.efi['persistent'];
       }
     },
 

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -1422,19 +1422,11 @@ export default {
       }
     },
 
-    setTPM(tpmEnabled) {
+    setTPM({ tpmEnabled = false, tpmPersistentStateEnabled = false } = {}) {
       if (tpmEnabled) {
-        set(this.spec.template.spec.domain.devices, 'tpm', {});
+        set(this.spec.template.spec.domain.devices, 'tpm', tpmPersistentStateEnabled ? { persistent: true } : {});
       } else {
         delete this.spec.template.spec.domain.devices['tpm'];
-      }
-    },
-
-    setTPMPersistentStateEnabled(tpmPersistentStateEnabled) {
-      if (tpmPersistentStateEnabled) {
-        set(this.spec.template.spec.domain.devices, 'tpm', { persistent: true });
-      } else {
-        set(this.spec.template.spec.domain.devices, 'tpm', {});
       }
     },
 
@@ -1568,11 +1560,11 @@ export default {
     },
 
     tpmEnabled(val) {
-      this.setTPM(val);
+      this.setTPM({ tpmEnabled: val, tpmPersistentStateEnabled: this.tpmPersistentStateEnabled });
     },
 
     tpmPersistentStateEnabled(val) {
-      this.setTPMPersistentStateEnabled(val);
+      this.setTPM({ tpmEnabled: this.tpmEnabled, tpmPersistentStateEnabled: val });
     },
 
     installAgent: {

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -1389,7 +1389,9 @@ export default {
       }
     },
 
-    setBootMethod(boot = { efi: false, secureBoot: false, efiPersistentStateEnabled: false }) {
+    setBootMethod(boot = {
+      efi: false, secureBoot: false, efiPersistentStateEnabled: false
+    }) {
       if (boot.efi) {
         set(this.spec.template.spec.domain, 'firmware.bootloader.efi.secureBoot', boot.secureBoot);
       } else {

--- a/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
@@ -280,4 +280,8 @@ export default class HciVmTemplateVersion extends HarvesterResource {
   get tpmPersistentStateFeatureEnabled() {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('tpmPersistentState');
   }
+
+  get efiPersistentStateFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('efiPersistentState');
+  }
 }

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -1179,6 +1179,10 @@ export default class VirtVm extends HarvesterResource {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('tpmPersistentState');
   }
 
+  get efiPersistentStateFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('efiPersistentState');
+  }
+
   setInstanceLabels(val) {
     if ( !this.spec?.template?.metadata?.labels ) {
       set(this, 'spec.template.metadata.labels', {});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Add `EFI Persistent State` checkbox to VM advanced options.
- The `EFI Persistent State` checkbox is only visible when `Booting in EFI Mode` is enabled
- User are allow to enable or disable the checkbox
- It adds `persistent: true` to the EFI block if `EFI Persistent State` is checked

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @ibrokethecloud 

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[FEATURE][UI] Add EFI persisent state checkbox in VM advanced tab #7557](https://github.com/harvester/harvester/issues/7557)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

- Enable `Booting in EFI Mode`, then verify that the `EFI Persistent State` checkbox is visible
- Enable `EFI Persistent State`, then click `Edit as YAML`, confirm that `persistent: true` is added to EFI block
```
spec:
  template:
    spec:
      domain:
        firmware:
          bootloader:
            efi:
              persistent: true
```
- Uncheck and verify `persistent: true` is removed
- The same behavior applies to the Create Template page

https://github.com/user-attachments/assets/79aea38a-80f7-4041-ab88-33955f4194cb

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
https://kubevirt.io/user-guide/compute/persistent_tpm_and_uefi_state/
