### PR TITLE
fix: no progress circle on the top after triggering upgrade

### DIFF
--- a/pkg/harvester/index.ts
+++ b/pkg/harvester/index.ts
@@ -6,6 +6,7 @@ import harvesterCommonStore from './store/harvester-common';
 import harvesterStore from './store/harvester-store';
 import customValidators from './validators';
 import { PRODUCT_NAME } from './config/harvester';
+import { defineAsyncComponent } from 'vue';
 
 // Init the package
 export default function (plugin: IPlugin) {
@@ -20,7 +21,7 @@ export default function (plugin: IPlugin) {
 
   // Built-in icon
   plugin.metadata.icon = require('./icon.svg');
-  
+
   plugin.addProduct(require('./config/harvester-cluster'));
 
   plugin.addDashboardStore(harvesterCommonStore.config.namespace, harvesterCommonStore.specifics, harvesterCommonStore.config);
@@ -28,4 +29,8 @@ export default function (plugin: IPlugin) {
   plugin.validators = customValidators;
 
   plugin.addRoutes(extensionRoutes);
+
+  plugin.register('component', 'NavHeaderRight', defineAsyncComponent(() =>
+    import('./components/HarvesterUpgradeHeader.vue')
+  ));
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
It seems that the `HarvesterUpgradeHeader` hasn't been registered in the header.
Ref: https://github.com/harvester/dashboard/blob/master/pkg/harvester/index.ts#L25

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] No progress circle on the top after triggering upgrade #7578](https://github.com/harvester/harvester/issues/7578)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

- Follow the guideline to create an upgrade
https://docs.harvesterhci.io/v1.4/upgrade/index#prepare-an-air-gapped-upgrade
- Perform an upgrade and verify that the upgrade information appears in the header

![Screenshot 2025-02-17 at 3 17 41 PM (2)](https://github.com/user-attachments/assets/dfb94f47-d2c3-4e3f-902b-8aabbb659b92)

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


