### PR TITLE
Fix sshkey is not added to cloud init user data immediately

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineSSHKey.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineSSHKey.vue
@@ -6,8 +6,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import ModalWithCard from '@shell/components/ModalWithCard';
 
-import { clone } from '@shell/utils/object';
-import { _VIEW } from '@shell/config/query-params';
+import { _VIEW, _EDIT } from '@shell/config/query-params';
 
 import { NAMESPACE } from '@shell/config/types';
 import { HCI } from '../../types';
@@ -91,6 +90,9 @@ export default {
     },
 
     sshOption() {
+      if (this.mode === _VIEW || this.mode === _EDIT) {
+        return [];
+      }
       const out = this.$store.getters['harvester/all'](HCI.SSH).map( (O) => {
         return {
           label: O.id,
@@ -126,10 +128,9 @@ export default {
       this.checkedSsh = neu;
     },
 
-    checkedSsh(val, old) {
-      if ( val.includes(_NEW)) {
-        this['checkedSsh'] = old;
-        this.update();
+    checkedSsh(val) {
+      // if click on Create a New...
+      if (val.includes(_NEW)) {
         this.show();
       }
     }
@@ -175,6 +176,7 @@ export default {
 
       if (res.id) {
         this.checkedSsh.push(`${ this.namespace }/${ this.sshName }`);
+        this.update();
       }
     },
 
@@ -232,7 +234,9 @@ export default {
     },
 
     update() {
-      this.$emit('update:sshKey', clone(this.checkedSsh));
+      const sshKeys = this.checkedSsh.filter((key) => key !== _NEW);
+
+      this.$emit('update:sshKey', sshKeys);
     },
   }
 };
@@ -243,13 +247,13 @@ export default {
     <LabeledSelect
       v-model:value="checkedSsh"
       :label="t('harvester.virtualMachine.input.sshKey')"
-      :taggable="true"
+      :taggable="!disabled"
       :mode="mode"
       :multiple="true"
       :searchable="searchable"
       :disabled="disabled"
       :options="sshOption"
-      @input="update"
+      @update:value="update"
     />
 
     <ModalWithCard

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -579,7 +579,7 @@ export default {
           :create-namespace="true"
           :namespace="value.metadata.namespace"
           :mode="mode"
-          :disabled="isWindows"
+          :disabled="isWindows || isEdit"
           @update:sshKey="updateSSHKey"
           @register-after-hook="registerAfterHook"
         />

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -900,8 +900,8 @@ export default {
     },
 
     /**
-     * Generate user data yaml which is decide by the "Install guest agent",
-     * "OS type", "SSH Keys" and user input.
+     * Generate user data yaml which is decided by the
+     * "Install guest agent", "OS type", "SSH keys" and user input.
      * @param config
      */
     getUserData(config) {
@@ -1218,7 +1218,6 @@ export default {
 
       let secret = this.getSecret(vm.spec);
 
-      // const userData = this.getUserData({ osType: this.osType, installAgent: this.installAgent });
       if (!secret && this.isEdit && this.secretRef) {
         // When editing the vm, if the userData and networkData are deleted, we also need to clean up the secret values
         secret = this.secretRef;
@@ -1620,9 +1619,13 @@ export default {
     },
 
     sshKey(neu, old) {
+      // refresh yaml editor to get the latest userScript
+      this.userScript = this.getUserData({ installAgent: this.installAgent, osType: this.osType });
+      this.refreshYamlEditor();
+
       const _diff = difference(old, neu);
 
-      if (_diff.length && this.isEdit) {
+      if (_diff.length > 0 && this.isCreate) {
         this.deleteSSHFromUserData(_diff);
       }
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Original [fix PR](https://github.com/harvester/harvester-ui-extension/pull/127) has side effect causes ssh key doens't fill-in cloud init user data.

This PR fixes below issues 
- Immediately add `ssh_authorized_keys` to user data when choosing / removing the key.
- Disable modify sshkey in VM edit page since cloud init script only runs when VM first boot.
- Create sshkey during VM creation is good.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
- https://github.com/harvester/harvester/issues/7544
- https://github.com/harvester/harvester/issues/7632

### Test screenshot/video

**Add SSHKey during VM creation**

https://github.com/user-attachments/assets/3746ba4c-e43f-41e0-8ae1-b969b47fac64



**Create new sshkey during VM creation**


https://github.com/user-attachments/assets/f2c583fd-6588-4f80-a668-0c6a2eee05c5



**Edit VM disable ssh key**

https://github.com/user-attachments/assets/fb07c280-9f95-44ee-bd2b-7cf1ceb36599



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


