### PR TITLE
More third party storage UI change

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.storage/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/index.vue
@@ -23,10 +23,9 @@ import Tags from '../../components/DiskTags';
 import { DATA_ENGINE_V1, DATA_ENGINE_V2 } from '../../models/harvester/persistentvolumeclaim';
 import { LVM_DRIVER } from '../../models/harvester/storage.k8s.io.storageclass';
 
-const LONGHORN_V2_DATA_ENGINE = 'longhorn-system/v2-data-engine';
-
 export const LVM_TOPOLOGY_LABEL = 'topology.lvm.csi/node';
 
+const LONGHORN_V2_DATA_ENGINE = 'longhorn-system/v2-data-engine';
 const VOLUME_BINDING_MODE_IMMEDIATE = 'Immediate';
 const VOLUME_BINDING_MODE_WAIT = 'WaitForFirstConsumer';
 

--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v2.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v2.vue
@@ -63,7 +63,7 @@ export default {
         diskSelector:        null,
         nodeSelector:        null,
         encrypted:           'false',
-        migratable:          'false',
+        migratable:          this.value.thirdPartyStorageFeatureEnabled ? 'true' : 'false',
         dataEngine:          DATA_ENGINE_V2
       };
     }
@@ -318,7 +318,7 @@ export default {
         :label="t('harvester.storage.parameters.migratable.label')"
         :mode="mode"
         :options="migratableOptions"
-        :disabled="true"
+        :disabled="!value.thirdPartyStorageFeatureEnabled"
       />
     </div>
     <div class="row mt-20">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
StorageClass create page
- Set Longhorn v2 data engine migratable default to true because Longhorn v1.8 supports the live migration with v2 volume.

Volume list page
  - Volumes should support export image action even created by different storage class (Longhorn v1 / v2 / LVM).
  - Except LHv2 storage class, other volumes should support Take Snapshot action.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng 

### Related Issue #
https://github.com/harvester/harvester/issues/7572

### Test screenshot/video
**Volume actions**

https://github.com/user-attachments/assets/b82f0419-26ac-4971-9126-20b9e70467e9


**Create LHv2 SC**

https://github.com/user-attachments/assets/2c962e8d-cc83-43e1-a1dd-bd7dc022b0ca



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->





