### PR TITLE
Fix usb and pci devices unable to enable

### DIFF
--- a/pkg/harvester/models/devices.harvesterhci.io.pcideviceclaim.js
+++ b/pkg/harvester/models/devices.harvesterhci.io.pcideviceclaim.js
@@ -1,0 +1,11 @@
+import SteveModel from '@shell/plugins/steve/steve-class';
+
+/**
+ * Class representing PCI Device Claim resource.
+ * @extends SteveModal
+ */
+export default class PCIDeviceClaim extends SteveModel {
+  cleanForSave(data, _forNew) {
+    return data;
+  }
+}

--- a/pkg/harvester/models/devices.harvesterhci.io.usbdeviceclaim.js
+++ b/pkg/harvester/models/devices.harvesterhci.io.usbdeviceclaim.js
@@ -1,0 +1,11 @@
+import SteveModel from '@shell/plugins/steve/steve-class';
+
+/**
+ * Class representing USB Device Claim resource.
+ * @extends SteveModal
+ */
+export default class USBDeviceClaim extends SteveModel {
+  cleanForSave(data, _forNew) {
+    return data;
+  }
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The change in @rancher/shell [save()](https://github.com/rancher/dashboard/blob/master/shell/plugins/dashboard-store/resource-class.js#L1200) calls [cleanForSave()](https://github.com/rancher/dashboard/blob/master/shell/plugins/steve/steve-class.js#L56) to delete [metadata.ownerReferences](https://github.com/rancher/dashboard/blob/d240d2a300d0df2ae1d1cb348510862c71170eb7/shell/utils/create-yaml.js#L45)in API payload.


This PR adds workaround to add customized cleanForSave to avoid delete such field in payload.


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @ibrokethecloud 

### Related Issue #
https://github.com/harvester/harvester/issues/7354

### Test screenshot/video
**USB**

https://github.com/user-attachments/assets/2d716faa-e97f-459d-a2f1-b4ade917fa65



**PCIDevice**

https://github.com/user-attachments/assets/a162eae2-e83a-496d-ad1a-391a10c85217



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


