### PR TITLE
Limit harvester-ui-extension to install on Rancher 2.11.0+

### DIFF
--- a/pkg/harvester/package.json
+++ b/pkg/harvester/package.json
@@ -7,7 +7,7 @@
     "annotations": {
       "catalog.cattle.io/display-name": "Harvester",
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.10.1-0",
+      "catalog.cattle.io/rancher-version": ">= 2.11.0-0",
       "catalog.cattle.io/ui-extensions-version": ">= 3.0.0 < 4.0.0"
     }
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Update `catalog.cattle.io/rancher-version` to >=2.11.0. 

With PR merged, all v1.5.0 release artifacts won't show on Rancher 2.10.0. Only show on Rancher 2.11.0+

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
`v1.5.0-rc2` is an example build in my namespace : https://github.com/a110605/harvester-ui-extension/releases/tag/harvester-1.5.0-rc2

On Rancher 2.10.2
<img width="1473" alt="Screenshot 2025-02-21 at 3 48 02 PM" src="https://github.com/user-attachments/assets/f4a5ce3d-3e84-4d51-b2ad-a2d7f5265c85" />

On Rancher 2.11.0-alpha6
<img width="1488" alt="Screenshot 2025-02-21 at 3 51 29 PM" src="https://github.com/user-attachments/assets/b301a776-0e39-4a22-95d3-a11933dc5bba" />


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->



