### PR TITLE
Hide non-longhorn volume external link

### DIFF
--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -349,6 +349,10 @@ export default class HciPv extends HarvesterResource {
     const { params } = this.currentRoute();
     const volumeName = this.spec?.volumeName;
 
+    if (!this.isLonghorn) {
+      return null;
+    }
+
     if (!volumeName) {
       return null;
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Hide external link if the volume provisoner is not longhorn.


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7572

### Test screenshot/video
<img width="1495" alt="Screenshot 2025-02-26 at 4 53 25 PM" src="https://github.com/user-attachments/assets/eb32ebba-7fd3-40b0-8a30-5a122d45cb2f" />

<img width="1495" alt="Screenshot 2025-02-26 at 4 53 29 PM" src="https://github.com/user-attachments/assets/30cc465e-bffb-425e-8b13-af84e36b1cbe" />

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


