### PR TITLE
Add refreshIntervalInSecond in 1.4.2 feature flag

### DIFF
--- a/pkg/harvester/components/settings/backup-target.vue
+++ b/pkg/harvester/components/settings/backup-target.vue
@@ -65,6 +65,10 @@ export default {
       }];
     },
 
+    refreshIntervalInSecondEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('refreshIntervalInSecond');
+    },
+
     isS3() {
       return this.parseDefaultValue.type === DEFAULT_TYPE;
     },
@@ -146,6 +150,7 @@ export default {
         @update:value="update"
       />
       <UnitInput
+        v-if="refreshIntervalInSecondEnabled"
         v-model:value="parseDefaultValue.refreshIntervalInSeconds"
         :suffix="parseDefaultValue.refreshIntervalInSeconds <= 1 ? 'Second' : 'Seconds'"
         :label="t('harvester.backup.refreshInterval.label')"
@@ -156,6 +161,7 @@ export default {
         @update:value="update"
       />
       <Tip
+        v-if="refreshIntervalInSecondEnabled"
         class="mb-20"
         icon="icon icon-info"
         :text="t('harvester.backup.refreshInterval.tip')"

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -42,7 +42,8 @@ const featuresV141 = [
 
 // TODO: add v1.4.2 official release note
 const featuresV142 = [
-  ...featuresV141
+  ...featuresV141,
+  'refreshIntervalInSecond'
 ];
 
 // TODO: add v1.5.0 official release note


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Add `refreshIntervalInSecond` feature flag to hide `Refresh Interval` field for harvester version < v1.4.2.


Note. this PR needs to backport to `release-harvester-v1.5` and `v1.0.4-rc1` branches.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @FrankYang0529 

### Related Issue #
https://github.com/harvester/harvester/issues/7693

### Test screenshot/video
v1.4.2+
<img width="1489" alt="Screenshot 2025-02-27 at 2 34 20 PM" src="https://github.com/user-attachments/assets/97af4153-63a3-4da5-a51d-50ef944ddc79" />



v1.4.1
<img width="1493" alt="Screenshot 2025-02-27 at 2 36 23 PM" src="https://github.com/user-attachments/assets/8576ad33-a574-457c-8602-bd183c1bd8ac" />

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


