### PR TITLE
Introduce VM Pending status

### DIFF
--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -700,8 +700,25 @@ export default class VirtVm extends HarvesterResource {
     return null;
   }
 
-  get isBeingStopped() {
-    if (this && !this.isVMExpectedRunning && this.isVMCreated && this.vmi?.status?.phase !== VMIPhase.Succeeded) {
+  get isPending() {
+    if (this &&
+      !this.isVMExpectedRunning &&
+      this.isVMCreated &&
+      this.vmi?.status?.phase === VMIPhase.Pending
+    ) {
+      return { status: VMIPhase.Pending };
+    }
+
+    return null;
+  }
+
+  get isStopping() {
+    if (this &&
+      !this.isVMExpectedRunning &&
+      this.isVMCreated &&
+      this.vmi?.status?.phase !== VMIPhase.Succeeded &&
+      this.vmi?.status?.phase !== VMIPhase.Pending
+    ) {
       return { status: STOPPING };
     }
 
@@ -736,7 +753,7 @@ export default class VirtVm extends HarvesterResource {
   }
 
   get isUnschedulable() {
-    if (this.isBeingStopped || this.isStarting) {
+    if (this.isStopping || this.isStarting) {
       const condition = this.status?.conditions?.find((c) => c.reason === UNSCHEDULABLE);
 
       if (!!condition) {
@@ -852,7 +869,8 @@ export default class VirtVm extends HarvesterResource {
       this.isUnschedulable?.status ||
       this.isPaused?.status ||
       this.isVMError?.status ||
-      this.isBeingStopped?.status ||
+      this.isPending?.status ||
+      this.isStopping?.status ||
       this.isOff?.status ||
       this.isError?.status ||
       this.isRunning?.status ||


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The VM has long isStopping status when creaing VM from CDI image.

I found `vmi.status.phase` stands in `Pending` during CDI is copying the image.

This PR introduces `pending` status when vmi.status.phase is pending. 
 

<img width="1490" alt="Screenshot 2025-03-03 at 10 47 16 AM" src="https://github.com/user-attachments/assets/a7c5ad41-f71d-4860-a299-79a73a73c785" />

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Vicente-Cheng 

### Related Issue #
https://github.com/harvester/harvester/issues/7572#issuecomment-2670632307

### Test screenshot/video

https://github.com/user-attachments/assets/a66f3d47-b0fd-482f-b4b9-4e5d22dfa6f1




### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


