### PR TITLE
fix: align all memory / storage / quota units to Gi/Mi

### DIFF
--- a/pkg/harvester/config/harvester-map.js
+++ b/pkg/harvester/config/harvester-map.js
@@ -1,3 +1,4 @@
+// TODO: delete this not used variable
 export const MemoryUnit = [{
   label: 'Mi',
   value: 'Mi'

--- a/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostBasic.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostBasic.vue
@@ -121,7 +121,7 @@ export default {
     memoryUnits() {
       const exponent = exponentNeeded(this.memoryTotal, 1024);
 
-      return `${ UNITS[exponent] }iB`;
+      return `${ UNITS[exponent] }i`;
     },
 
     nodeType() {

--- a/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostBasic.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostBasic.vue
@@ -4,6 +4,7 @@ import { formatSi, exponentNeeded, UNITS } from '@shell/utils/units';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import { LONGHORN, METRIC } from '@shell/config/types';
 import { Banner } from '@components/Banner';
+import { UNIT_SUFFIX } from '../../utils/unit';
 import HarvesterCPUUsed from '../../formatters/HarvesterCPUUsed';
 import HarvesterMemoryUsed from '../../formatters/HarvesterMemoryUsed';
 import HarvesterStorageUsed from '../../formatters/HarvesterStorageUsed';
@@ -121,7 +122,7 @@ export default {
     memoryUnits() {
       const exponent = exponentNeeded(this.memoryTotal, 1024);
 
-      return `${ UNITS[exponent] }i`;
+      return `${ UNITS[exponent] }${ UNIT_SUFFIX }`;
     },
 
     nodeType() {

--- a/pkg/harvester/detail/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/index.vue
@@ -9,7 +9,7 @@ import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
 import Loading from '@shell/components/Loading.vue';
 import SortableTable from '@shell/components/SortableTable';
 import Banner from '@components/Banner/Banner.vue';
-
+import { UNIT_SUFFIX } from '../../utils/unit';
 import metricPoller from '@shell/mixins/metric-poller';
 import {
   METRIC, NODE, LONGHORN, POD, EVENT
@@ -178,7 +178,7 @@ export default {
         minExponent:  3,
         maxExponent:  3,
         maxPrecision: 2,
-        suffix:       'i',
+        suffix:       UNIT_SUFFIX,
       };
 
       const longhornDisks = Object.keys(diskStatus).map((key) => {

--- a/pkg/harvester/detail/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/index.vue
@@ -178,7 +178,7 @@ export default {
         minExponent:  3,
         maxExponent:  3,
         maxPrecision: 2,
-        suffix:       'iB',
+        suffix:       'i',
       };
 
       const longhornDisks = Object.keys(diskStatus).map((key) => {

--- a/pkg/harvester/dialog/HarvesterQuotaDialog.vue
+++ b/pkg/harvester/dialog/HarvesterQuotaDialog.vue
@@ -5,6 +5,7 @@ import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
 import UnitInput from '@shell/components/form/UnitInput';
 import { exceptionToErrorsArray } from '@shell/utils/error';
+import { GIBIBYTE } from '../utils/unit';
 
 export default {
   name: 'HarvesterVMQuotaDialog',
@@ -29,6 +30,7 @@ export default {
 
   data() {
     return {
+      GIBIBYTE,
       totalSnapshotSize: '',
       errors:            []
     };
@@ -44,7 +46,6 @@ export default {
   },
 
   methods: {
-
     close() {
       this.totalSnapshotSize = '';
       this.$emit('close');
@@ -92,7 +93,7 @@ export default {
         :input-exponent="3"
         :increment="1024"
         :output-modifier="true"
-        suffix="Gi"
+        :suffix="GIBIBYTE"
         class="mb-20"
       />
     </template>

--- a/pkg/harvester/dialog/HarvesterQuotaDialog.vue
+++ b/pkg/harvester/dialog/HarvesterQuotaDialog.vue
@@ -92,7 +92,7 @@ export default {
         :input-exponent="3"
         :increment="1024"
         :output-modifier="true"
-        suffix="GiB"
+        suffix="Gi"
         class="mb-20"
       />
     </template>

--- a/pkg/harvester/edit/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/index.vue
@@ -185,7 +185,7 @@ export default {
         minExponent:  3,
         maxExponent:  3,
         maxPrecision: 2,
-        suffix:       'iB',
+        suffix:       'i',
       };
 
       const longhornDisks = Object.keys(diskStatus).map((key) => {
@@ -457,7 +457,7 @@ export default {
           const devPath = d.spec?.devPath;
           const deviceType = d.status?.deviceStatus?.details?.deviceType;
           const sizeBytes = d.status?.deviceStatus?.capacity?.sizeBytes;
-          const size = formatSi(sizeBytes, { increment: 1024 });
+          const size = formatSi(sizeBytes, { increment: 1024, suffix: 'i' });
           const parentDevice = d.status?.deviceStatus?.parentDevice;
           const isChildAdded = this.newDisks.find((newDisk) => newDisk.blockDevice?.status?.deviceStatus?.parentDevice === devPath);
           const name = d.displayName;

--- a/pkg/harvester/edit/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/index.vue
@@ -20,7 +20,7 @@ import Loading from '@shell/components/Loading.vue';
 import MessageLink from '@shell/components/MessageLink';
 import { ADD_ONS } from '@pkg/harvester/config/harvester-map';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '@pkg/harvester/config/harvester';
-
+import { UNIT_SUFFIX } from '../../utils/unit';
 import { _EDIT } from '@shell/config/query-params';
 import { sortBy } from '@shell/utils/sort';
 import { Banner } from '@components/Banner';
@@ -185,7 +185,7 @@ export default {
         minExponent:  3,
         maxExponent:  3,
         maxPrecision: 2,
-        suffix:       'i',
+        suffix:       UNIT_SUFFIX,
       };
 
       const longhornDisks = Object.keys(diskStatus).map((key) => {
@@ -457,7 +457,7 @@ export default {
           const devPath = d.spec?.devPath;
           const deviceType = d.status?.deviceStatus?.details?.deviceType;
           const sizeBytes = d.status?.deviceStatus?.capacity?.sizeBytes;
-          const size = formatSi(sizeBytes, { increment: 1024, suffix: 'i' });
+          const size = formatSi(sizeBytes, { increment: 1024, suffix: UNIT_SUFFIX });
           const parentDevice = d.status?.deviceStatus?.parentDevice;
           const isChildAdded = this.newDisks.find((newDisk) => newDisk.blockDevice?.status?.deviceStatus?.parentDevice === devPath);
           const name = d.displayName;

--- a/pkg/harvester/edit/harvesterhci.io.volume.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volume.vue
@@ -21,6 +21,7 @@ import { InterfaceOption, VOLUME_DATA_SOURCE_KIND } from '../config/harvester-ma
 import { HCI, VOLUME_SNAPSHOT } from '../types';
 import { LVM_DRIVER } from '../models/harvester/storage.k8s.io.storageclass';
 import { DATA_ENGINE_V2 } from '../models/harvester/persistentvolumeclaim';
+import { GIBIBYTE } from '../utils/unit';
 
 export default {
   name: 'HarvesterVolume',
@@ -86,6 +87,7 @@ export default {
       imageId,
       snapshots: [],
       images:    [],
+      GIBIBYTE
     };
   },
 
@@ -288,7 +290,7 @@ export default {
         const imageSize = Math.max(imageResource?.status?.size, imageResource?.status?.virtualSize);
 
         if (imageSize) {
-          this.storage = `${ Math.ceil(imageSize / 1024 / 1024 / 1024) }Gi`;
+          this.storage = `${ Math.ceil(imageSize / 1024 / 1024 / 1024) }${ GIBIBYTE }`;
         }
       }
       this.update();
@@ -377,7 +379,7 @@ export default {
           :disabled="value?.isLonghornV2 && isEdit"
           required
           class="mb-20"
-          suffix="Gi"
+          :suffix="GIBIBYTE"
           @update:value="update"
         />
 

--- a/pkg/harvester/edit/harvesterhci.io.volume.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volume.vue
@@ -377,6 +377,7 @@ export default {
           :disabled="value?.isLonghornV2 && isEdit"
           required
           class="mb-20"
+          suffix="Gi"
           @update:value="update"
         />
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
@@ -113,6 +113,7 @@ export default {
           :output-modifier="true"
           :disabled="disabled"
           required
+          suffix="Gi"
           class="mb-20"
           @update:value="change"
         />

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
@@ -1,6 +1,7 @@
 <script>
 import UnitInput from '@shell/components/form/UnitInput';
 import InputOrDisplay from '@shell/components/InputOrDisplay';
+import { GIBIBYTE } from '../../utils/unit';
 
 export default {
   name: 'HarvesterEditCpuMemory',
@@ -30,6 +31,7 @@ export default {
 
   data() {
     return {
+      GIBIBYTE,
       localCpu:    this.cpu,
       localMemory: this.memory
     };
@@ -63,7 +65,7 @@ export default {
       if (String(this.localMemory).includes('Gi')) {
         memory = this.localMemory;
       } else {
-        memory = `${ this.localMemory }Gi`;
+        memory = `${ this.localMemory }${ GIBIBYTE }`;
       }
       if (memory.includes('null')) {
         memory = null;
@@ -113,7 +115,7 @@ export default {
           :output-modifier="true"
           :disabled="disabled"
           required
-          suffix="Gi"
+          :suffix="GIBIBYTE"
           class="mb-20"
           @update:value="change"
         />

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineReserved.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineReserved.vue
@@ -47,6 +47,7 @@ export default {
     :input-exponent="2"
     :increment="1024"
     :output-modifier="true"
+    suffix="Mi"
     @update:value="change"
   />
 </template>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineReserved.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineReserved.vue
@@ -1,6 +1,6 @@
 <script>
 import UnitInput from '@shell/components/form/UnitInput';
-
+import { MEBIBYTE } from '../../utils/unit';
 export default {
   name: 'HarvesterReserved',
 
@@ -20,7 +20,7 @@ export default {
   },
 
   data() {
-    return { memory: this.reservedMemory };
+    return { MEBIBYTE, memory: this.reservedMemory };
   },
 
   watch: {
@@ -47,7 +47,7 @@ export default {
     :input-exponent="2"
     :increment="1024"
     :output-modifier="true"
-    suffix="Mi"
+    :suffix="MEBIBYTE"
     @update:value="change"
   />
 </template>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
@@ -11,6 +11,7 @@ import { _CREATE } from '@shell/config/query-params';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import { HCI } from '../../../../types';
 import { VOLUME_TYPE, InterfaceOption } from '../../../../config/harvester-map';
+import { GIBIBYTE } from '../../../../utils/unit';
 
 export default {
   name: 'HarvesterEditExisting',
@@ -59,6 +60,7 @@ export default {
     }
 
     return {
+      GIBIBYTE,
       VOLUME_TYPE,
       InterfaceOption,
       loading: false,
@@ -254,7 +256,7 @@ export default {
             :label="t('harvester.fields.size')"
             :mode="mode"
             :disabled="true"
-            suffix="Gi"
+            :suffix="GIBIBYTE"
             @update:value="update"
           />
         </InputOrDisplay>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
@@ -254,6 +254,7 @@ export default {
             :label="t('harvester.fields.size')"
             :mode="mode"
             :disabled="true"
+            suffix="Gi"
             @update:value="update"
           />
         </InputOrDisplay>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -129,13 +129,17 @@ export default {
     },
 
     imageVirtualSize() {
-      return this.selectedImage?.virtualSize;
+      if (this.selectedImage?.virtualSize) {
+        return this.selectedImage.virtualSize.replace(' ', '');
+      }
+
+      return '0';
     },
 
     diskSize() {
       const size = this.value?.size || '0';
 
-      return `${ size.replace('Gi', '') } GB`;
+      return size;
     },
 
     imageVirtualSizeInByte() {
@@ -332,7 +336,7 @@ export default {
             :mode="mode"
             :required="validateRequired"
             :disable="isLonghornV2"
-            suffix="GiB"
+            suffix="Gi"
             @update:value="update"
           />
         </InputOrDisplay>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -12,6 +12,7 @@ import { VOLUME_TYPE, InterfaceOption } from '../../../../config/harvester-map';
 import { _VIEW } from '@shell/config/query-params';
 import LabelValue from '@shell/components/LabelValue';
 import { ucFirst } from '@shell/utils/string';
+import { GIBIBYTE } from '../../../../utils/unit';
 
 export default {
   name: 'HarvesterEditVMImage',
@@ -67,6 +68,7 @@ export default {
 
   data() {
     return {
+      GIBIBYTE,
       VOLUME_TYPE,
       InterfaceOption,
       loading: false,
@@ -187,7 +189,7 @@ export default {
             minExponent: 3,
           });
 
-          this.value.size = `${ formatSize }Gi`;
+          this.value.size = `${ formatSize }${ GIBIBYTE }`;
         }
       },
       deep:      true,
@@ -229,7 +231,7 @@ export default {
         if (!isIsoImage) {
           imageSizeGiB = Math.max(imageSizeGiB, 10);
         }
-        this.value['size'] = `${ imageSizeGiB }Gi`;
+        this.value['size'] = `${ imageSizeGiB }${ GIBIBYTE }`;
       }
 
       this.update();
@@ -336,7 +338,7 @@ export default {
             :mode="mode"
             :required="validateRequired"
             :disable="isLonghornV2"
-            suffix="Gi"
+            :suffix="GIBIBYTE"
             @update:value="update"
           />
         </InputOrDisplay>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
@@ -258,6 +258,7 @@ export default {
             :required="validateRequired"
             :label="t('harvester.fields.size')"
             :disabled="isLonghornV2"
+            suffix="Gi"
             @update:value="update"
           />
         </InputOrDisplay>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
@@ -12,6 +12,7 @@ import LabelValue from '@shell/components/LabelValue';
 import { ucFirst } from '@shell/utils/string';
 import { LVM_DRIVER } from '../../../../models/harvester/storage.k8s.io.storageclass';
 import { DATA_ENGINE_V2 } from '../../../../models/harvester/persistentvolumeclaim';
+import { GIBIBYTE } from '../../../../utils/unit';
 
 export default {
   name: 'HarvesterEditVolume',
@@ -58,6 +59,7 @@ export default {
 
   data() {
     return {
+      GIBIBYTE,
       VOLUME_TYPE,
       InterfaceOption,
       loading: false,
@@ -140,7 +142,7 @@ export default {
             minExponent: 3,
           });
 
-          this.value.size = `${ formatSize }Gi`;
+          this.value.size = `${ formatSize }${ GIBIBYTE }`;
         }
       },
       deep:      true,
@@ -258,7 +260,7 @@ export default {
             :required="validateRequired"
             :label="t('harvester.fields.size')"
             :disabled="isLonghornV2"
-            suffix="Gi"
+            :suffix="GIBIBYTE"
             @update:value="update"
           />
         </InputOrDisplay>

--- a/pkg/harvester/formatters/HarvesterMemoryUsed.vue
+++ b/pkg/harvester/formatters/HarvesterMemoryUsed.vue
@@ -2,7 +2,7 @@
 import ConsumptionGauge from '@shell/components/ConsumptionGauge';
 import { METRIC, NODE } from '@shell/config/types';
 import { formatSi, exponentNeeded, UNITS, parseSi } from '@shell/utils/units';
-
+import { UNIT_SUFFIX } from '../utils/unit';
 export default {
   name:       'HarvesterMemoryUsed',
   components: { ConsumptionGauge },
@@ -51,7 +51,7 @@ export default {
     memoryUnits() {
       const exponent = exponentNeeded(this.memoryTotal, 1024);
 
-      return `${ UNITS[exponent] }i`;
+      return `${ UNITS[exponent] }${ UNIT_SUFFIX }`;
     },
 
     node() {

--- a/pkg/harvester/formatters/HarvesterMemoryUsed.vue
+++ b/pkg/harvester/formatters/HarvesterMemoryUsed.vue
@@ -51,7 +51,7 @@ export default {
     memoryUnits() {
       const exponent = exponentNeeded(this.memoryTotal, 1024);
 
-      return `${ UNITS[exponent] }iB`;
+      return `${ UNITS[exponent] }i`;
     },
 
     node() {

--- a/pkg/harvester/formatters/HarvesterStorageUsed.vue
+++ b/pkg/harvester/formatters/HarvesterStorageUsed.vue
@@ -2,6 +2,7 @@
 import ConsumptionGauge from '@shell/components/ConsumptionGauge';
 import { LONGHORN } from '@shell/config/types';
 import { formatSi, exponentNeeded, UNITS } from '@shell/utils/units';
+import { UNIT_SUFFIX } from '../utils/unit';
 
 export default {
   name:       'HarvesterStorageUsed',
@@ -75,13 +76,13 @@ export default {
     allocatedUnits() {
       const exponent = exponentNeeded(this.storageStats.total, 1024);
 
-      return `${ UNITS[exponent] }i`;
+      return `${ UNITS[exponent] }${ UNIT_SUFFIX }`;
     },
 
     usedUnits() {
       const exponent = exponentNeeded(this.storageStats.maximum, 1024);
 
-      return `${ UNITS[exponent] }i`;
+      return `${ UNITS[exponent] }${ UNIT_SUFFIX }`;
     },
 
     formatUsed() {

--- a/pkg/harvester/formatters/HarvesterStorageUsed.vue
+++ b/pkg/harvester/formatters/HarvesterStorageUsed.vue
@@ -75,13 +75,13 @@ export default {
     allocatedUnits() {
       const exponent = exponentNeeded(this.storageStats.total, 1024);
 
-      return `${ UNITS[exponent] }iB`;
+      return `${ UNITS[exponent] }i`;
     },
 
     usedUnits() {
       const exponent = exponentNeeded(this.storageStats.maximum, 1024);
 
-      return `${ UNITS[exponent] }iB`;
+      return `${ UNITS[exponent] }i`;
     },
 
     formatUsed() {

--- a/pkg/harvester/list/harvesterhci.io.dashboard.vue
+++ b/pkg/harvester/list/harvesterhci.io.dashboard.vue
@@ -25,6 +25,7 @@ import { isEmpty } from '@shell/utils/object';
 import { HCI } from '../types';
 import HarvesterUpgrade from '../components/HarvesterUpgrade';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
+import { UNIT_SUFFIX } from '../utils/unit';
 
 dayjs.extend(utc);
 dayjs.extend(minMax);
@@ -32,13 +33,13 @@ dayjs.extend(minMax);
 const PARSE_RULES = {
   format: {
     addSuffix:        true,
-    firstSuffix:      'B',
+    firstSuffix:      UNIT_SUFFIX,
     increment:        1024,
     maxExponent:      99,
     maxPrecision:     2,
     minExponent:      0,
     startingExponent: 0,
-    suffix:           'i',
+    suffix:           UNIT_SUFFIX,
   }
 };
 

--- a/pkg/harvester/list/harvesterhci.io.dashboard.vue
+++ b/pkg/harvester/list/harvesterhci.io.dashboard.vue
@@ -8,9 +8,7 @@ import Banner from '@components/Banner/Banner.vue';
 import MessageLink from '@shell/components/MessageLink';
 import SortableTable from '@shell/components/SortableTable';
 import { allHash, setPromiseResult } from '@shell/utils/promise';
-import {
-  parseSi, formatSi, exponentNeeded, UNITS, createMemoryValues
-} from '@shell/utils/units';
+import { parseSi, formatSi, exponentNeeded, UNITS } from '@shell/utils/units';
 import { REASON } from '@shell/config/table-headers';
 import {
   EVENT, METRIC, NODE, SERVICE, PVC, LONGHORN, POD, COUNT, NETWORK_ATTACHMENT
@@ -32,17 +30,15 @@ dayjs.extend(utc);
 dayjs.extend(minMax);
 
 const PARSE_RULES = {
-  memory: {
-    format: {
-      addSuffix:        true,
-      firstSuffix:      'B',
-      increment:        1024,
-      maxExponent:      99,
-      maxPrecision:     2,
-      minExponent:      0,
-      startingExponent: 0,
-      suffix:           'iB',
-    }
+  format: {
+    addSuffix:        true,
+    firstSuffix:      'B',
+    increment:        1024,
+    maxExponent:      99,
+    maxPrecision:     2,
+    minExponent:      0,
+    startingExponent: 0,
+    suffix:           'i',
   }
 };
 
@@ -402,13 +398,13 @@ export default {
     storageUsed() {
       const stats = this.storageStats;
 
-      return this.createMemoryValues(stats.maximum, stats.used);
+      return this.createDisplayValues(stats.maximum, stats.used);
     },
 
     storageAllocated() {
       const stats = this.storageStats;
 
-      return this.createMemoryValues(stats.total, stats.scheduled);
+      return this.createDisplayValues(stats.total, stats.scheduled);
     },
 
     vmEvents() {
@@ -454,7 +450,7 @@ export default {
         return total + node.memoryReserved;
       }, 0);
 
-      return createMemoryValues(this.memoryTotal, useful);
+      return this.createDisplayValues(this.memoryTotal, useful);
     },
 
     availableNodes() {
@@ -494,7 +490,7 @@ export default {
     },
 
     ramUsed() {
-      return createMemoryValues(this.memoryTotal, this.metricAggregations?.memory);
+      return this.createDisplayValues(this.memoryTotal, this.metricAggregations?.memory);
     },
 
     hasMetricNodeSchema() {
@@ -516,10 +512,12 @@ export default {
   },
 
   methods: {
-    createMemoryValues(total, useful) {
+    createDisplayValues(total, useful) {
       const parsedTotal = parseSi((total || '0').toString());
+
       const parsedUseful = parseSi((useful || '0').toString());
-      const format = this.createMemoryFormat(parsedTotal);
+      const format = this.createFormat(parsedTotal);
+
       const formattedTotal = formatSi(parsedTotal, format);
       let formattedUseful = formatSi(parsedUseful, {
         ...format,
@@ -538,24 +536,24 @@ export default {
         useful: Number(parsedUseful),
         formattedTotal,
         formattedUseful,
-        units:  this.createMemoryUnits(parsedTotal),
+        units:  this.createUnits(parsedTotal),
       };
     },
 
-    createMemoryFormat(n) {
-      const exponent = exponentNeeded(n, PARSE_RULES.memory.format.increment);
+    createFormat(n) {
+      const exponent = exponentNeeded(n, PARSE_RULES.format.increment);
 
       return {
-        ...PARSE_RULES.memory.format,
+        ...PARSE_RULES.format,
         maxExponent: exponent,
         minExponent: exponent,
       };
     },
 
-    createMemoryUnits(n) {
-      const exponent = exponentNeeded(n, PARSE_RULES.memory.format.increment);
+    createUnits(n) {
+      const exponent = exponentNeeded(n, PARSE_RULES.format.increment);
 
-      return `${ UNITS[exponent] }${ PARSE_RULES.memory.format.suffix }`;
+      return `${ UNITS[exponent] }${ PARSE_RULES.format.suffix }`;
     },
 
     async fetchClusterResources(type, opt = {}, store) {

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -25,6 +25,7 @@ import { HCI_SETTING } from '../../config/settings';
 import { HCI } from '../../types';
 import { parseVolumeClaimTemplates } from '../../utils/vm';
 import impl, { QGA_JSON, USB_TABLET } from './impl';
+import { GIBIBYTE } from '../../utils/unit';
 
 const LONGHORN_V2_DATA_ENGINE = 'longhorn-system/v2-data-engine';
 
@@ -448,7 +449,7 @@ export default {
           if (!isIsoImage) {
             imageSizeGiB = Math.max(imageSizeGiB, 10);
           }
-          size = `${ imageSizeGiB }Gi`;
+          size = `${ imageSizeGiB }${ GIBIBYTE }`;
         }
 
         out.push({
@@ -558,7 +559,7 @@ export default {
             volumeName,
             container,
             accessMode,
-            size:       `${ formatSize }Gi`,
+            size:       `${ formatSize }${ GIBIBYTE }`,
             volumeMode: volumeMode || this.customVolumeMode,
             image,
             type,
@@ -973,7 +974,7 @@ export default {
 
     parseVolumeClaimTemplate(R, dataVolumeName) {
       if (!String(R.size).includes('Gi') && R.size) {
-        R.size = `${ R.size }Gi`;
+        R.size = `${ R.size }${ GIBIBYTE }`;
       }
 
       const out = {

--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -12,6 +12,7 @@ import { HCI } from '../types';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
 import HarvesterResource from './harvester';
 import { CSI_SECRETS } from '@pkg/harvester/config/harvester-map';
+import { UNIT_SUFFIX } from '../utils/unit';
 
 const {
   CSI_PROVISIONER_SECRET_NAME,
@@ -243,8 +244,8 @@ export default class HciVmImage extends HarvesterResource {
     return formatSi(size, {
       increment:    1024,
       maxPrecision: 2,
-      suffix:       'i',
-      firstSuffix:  'i',
+      suffix:       UNIT_SUFFIX,
+      firstSuffix:  UNIT_SUFFIX,
     });
   }
 
@@ -258,8 +259,8 @@ export default class HciVmImage extends HarvesterResource {
     return formatSi(virtualSize, {
       increment:    1024,
       maxPrecision: 2,
-      suffix:       'i',
-      firstSuffix:  'i',
+      suffix:       UNIT_SUFFIX,
+      firstSuffix:  UNIT_SUFFIX,
     });
   }
 

--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -243,8 +243,8 @@ export default class HciVmImage extends HarvesterResource {
     return formatSi(size, {
       increment:    1024,
       maxPrecision: 2,
-      suffix:       'B',
-      firstSuffix:  'B',
+      suffix:       'i',
+      firstSuffix:  'i',
     });
   }
 
@@ -258,8 +258,8 @@ export default class HciVmImage extends HarvesterResource {
     return formatSi(virtualSize, {
       increment:    1024,
       maxPrecision: 2,
-      suffix:       'B',
-      firstSuffix:  'B',
+      suffix:       'i',
+      firstSuffix:  'i',
     });
   }
 

--- a/pkg/harvester/utils/unit.js
+++ b/pkg/harvester/utils/unit.js
@@ -1,0 +1,3 @@
+export const UNIT_SUFFIX = 'i';
+export const GIBIBYTE = 'Gi';
+export const MEBIBYTE = 'Mi';

--- a/pkg/harvester/validators/vm.js
+++ b/pkg/harvester/validators/vm.js
@@ -88,7 +88,7 @@ export function vmDisks(spec, getters, errors, validatorArgs, displayKey, value)
       }
 
       if (typeValue?.spec?.resources?.requests?.storage && !/^([0-9][0-9]{0,8})[a-zA-Z]+$/.test(typeValue?.spec?.resources?.requests?.storage)) {
-        const message = getters['i18n/t']('harvester.validation.generic.maximumSize', { max: '999999999 GiB' });
+        const message = getters['i18n/t']('harvester.validation.generic.maximumSize', { max: '999999999 Gi' });
 
         errors.push(getters['i18n/t']('harvester.validation.generic.tabError', { prefix, message }));
       }

--- a/pkg/harvester/validators/vm.js
+++ b/pkg/harvester/validators/vm.js
@@ -2,6 +2,7 @@ import { PVC } from '@shell/config/types';
 import { isValidMac, isValidDNSLabelName } from '@pkg/utils/regular';
 import { SOURCE_TYPE } from '@pkg/config/harvester-map';
 import { parseVolumeClaimTemplates } from '@pkg/utils/vm';
+import { GIBIBYTE } from '../utils/unit';
 
 const maxNameLength = 63;
 
@@ -88,7 +89,7 @@ export function vmDisks(spec, getters, errors, validatorArgs, displayKey, value)
       }
 
       if (typeValue?.spec?.resources?.requests?.storage && !/^([0-9][0-9]{0,8})[a-zA-Z]+$/.test(typeValue?.spec?.resources?.requests?.storage)) {
-        const message = getters['i18n/t']('harvester.validation.generic.maximumSize', { max: '999999999 Gi' });
+        const message = getters['i18n/t']('harvester.validation.generic.maximumSize', { max: `999999999 ${ GIBIBYTE }` });
 
         errors.push(getters['i18n/t']('harvester.validation.generic.tabError', { prefix, message }));
       }

--- a/pkg/harvester/validators/volume.js
+++ b/pkg/harvester/validators/volume.js
@@ -1,3 +1,5 @@
+import { GIBIBYTE } from '../utils/unit';
+
 export function volumeSize(size, getters, errors, validatorArgs, displayKey, value) {
   if (!size) {
     const key = getters['i18n/t']('harvester.volume.size');
@@ -6,7 +8,7 @@ export function volumeSize(size, getters, errors, validatorArgs, displayKey, val
   }
 
   if (size && !/^([0-9][0-9]{0,8})[a-zA-Z]+$/.test(size)) {
-    const message = getters['i18n/t']('harvester.validation.generic.maximumSize', { max: '999999999 Gi' });
+    const message = getters['i18n/t']('harvester.validation.generic.maximumSize', { max: `999999999 ${ GIBIBYTE }` });
 
     errors.push(message);
   }

--- a/pkg/harvester/validators/volume.js
+++ b/pkg/harvester/validators/volume.js
@@ -6,7 +6,7 @@ export function volumeSize(size, getters, errors, validatorArgs, displayKey, val
   }
 
   if (size && !/^([0-9][0-9]{0,8})[a-zA-Z]+$/.test(size)) {
-    const message = getters['i18n/t']('harvester.validation.generic.maximumSize', { max: '999999999 GiB' });
+    const message = getters['i18n/t']('harvester.validation.generic.maximumSize', { max: '999999999 Gi' });
 
     errors.push(message);
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
I notices there are different Gi / GB / GiB formats on harvester UI. 
-  GiB  = 1000 MB
-  GB = 1024 MiB
-  Gi = short for GiB (k8s yaml, harvester API, longhorn UI are using this format)

We should align all the memory / disk / quota to Gi format at this moment.

https://massive.io/file-transfer/gb-vs-gib-whats-the-difference/


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7572

### Test screenshot/video

<img width="1496" alt="Screenshot 2025-03-03 at 12 12 45 PM" src="https://github.com/user-attachments/assets/ad5c73ac-8252-4004-942d-b1c93e30ffb5" />

<img width="1299" alt="image" src="https://github.com/user-attachments/assets/8bb8551b-56f7-4703-b5ee-192c4afdffff" />

<img width="1482" alt="image" src="https://github.com/user-attachments/assets/bb347f6a-e4b3-4179-a638-4872a15a426f" />


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


