### PR TITLE
fix: allow set empty for backupVolumeSnapshotClassName in Setting csi-driver-config

### DIFF
--- a/pkg/harvester/components/settings/csi-driver-config.vue
+++ b/pkg/harvester/components/settings/csi-driver-config.vue
@@ -75,7 +75,11 @@ export default {
       const csiDrivers = this.$store.getters[`${ inStore }/all`](CSI_DRIVER) || [];
 
       return this.configArr.length >= csiDrivers.length;
-    }
+    },
+
+    allowEmptySnapshotClassNameFeatureEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('allowEmptySnapshotClassName');
+    },
   },
 
   methods: {
@@ -139,7 +143,7 @@ export default {
             errors.push(this.t('validation.required', { key: this.t('harvester.setting.csiDriverConfig.volumeSnapshotClassName') }, true));
           }
 
-          if (!config.value.backupVolumeSnapshotClassName) {
+          if (!this.allowEmptySnapshotClassNameFeatureEnabled && !config.value.backupVolumeSnapshotClassName) {
             errors.push(this.t('validation.required', { key: this.t('harvester.setting.csiDriverConfig.backupVolumeSnapshotClassName') }, true));
           }
         });
@@ -159,6 +163,12 @@ export default {
     },
 
     disableEdit(driver) {
+      return driver === LONGHORN_DRIVER;
+    },
+
+    isBackupVolumeSnapshotClassNameDisabled(driver) {
+      if (this.allowEmptySnapshotClassNameFeatureEnabled) return true;
+
       return driver === LONGHORN_DRIVER;
     },
 
@@ -227,7 +237,8 @@ export default {
             v-model:value="driver.value.backupVolumeSnapshotClassName"
             :mode="mode"
             required
-            :disabled="disableEdit(driver.key)"
+            :disabled="isBackupVolumeSnapshotClassNameDisabled(driver.key)"
+            :selectable="!allowEmptySnapshotClassNameFeatureEnabled"
             :options="getVolumeSnapshotOptions(driver.key)"
             :label="t('harvester.setting.csiDriverConfig.backupVolumeSnapshotClassName')"
             @keydown.native.enter.prevent="()=>{}"

--- a/pkg/harvester/components/settings/csi-driver-config.vue
+++ b/pkg/harvester/components/settings/csi-driver-config.vue
@@ -167,8 +167,10 @@ export default {
     },
 
     isBackupVolumeSnapshotClassNameDisabled(driver) {
-      if (this.allowEmptySnapshotClassNameFeatureEnabled) return true;
+      return driver === LONGHORN_DRIVER || this.allowEmptySnapshotClassNameFeatureEnabled;
+    },
 
+    isBackupVolumeSnapshotClassNameSelectable(driver) {
       return driver === LONGHORN_DRIVER;
     },
 
@@ -238,9 +240,9 @@ export default {
             :mode="mode"
             required
             :disabled="isBackupVolumeSnapshotClassNameDisabled(driver.key)"
-            :selectable="!allowEmptySnapshotClassNameFeatureEnabled"
             :options="getVolumeSnapshotOptions(driver.key)"
             :label="t('harvester.setting.csiDriverConfig.backupVolumeSnapshotClassName')"
+            @selectable="isBackupVolumeSnapshotClassNameSelectable(driver.key)"
             @keydown.native.enter.prevent="()=>{}"
             @update:value="update"
           />

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -43,7 +43,8 @@ const featuresV141 = [
 // TODO: add v1.4.2 official release note
 const featuresV142 = [
   ...featuresV141,
-  'refreshIntervalInSecond'
+  'refreshIntervalInSecond',
+  'allowEmptySnapshotClassName'
 ];
 
 // TODO: add v1.5.0 official release note


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The `backupVolumeSnapshotClassName` should be grayed out directly for third-party storage.

- v1.4.0 -> no gray out
- v1.4.1 -> no gray out
- v1.4.2 -> gray out
- v1.5.0 -> gray out

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @WebberHuang1118 

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG][GUI] Should Allow set empty for backupVolumeSnapshotClassName in Setting csi-driver-config #7737
](https://github.com/harvester/harvester/issues/7737#issuecomment-2700003551)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Navigate to Advanced ->Settings → edit `csi-driver-config`
- Click `Add`, and the `Backup Volume Snapshot Class Name field` should be disabled
- Select the appropriate option, save and ensure it saves correctly

![Screenshot 2025-03-06 at 2 49 45 PM (2)](https://github.com/user-attachments/assets/e3c25e0f-6fca-4432-9ef3-d1b8e1e4f1a3)
### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

