### PR TITLE
Filter exported SC for non-longhorn V1 volume

### DIFF
--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -336,6 +336,10 @@ export default class HciPv extends HarvesterResource {
     return this.volumeProvider === LONGHORN_DRIVER;
   }
 
+  get isLonghornV1() {
+    return this.isLonghorn && !this.isLonghornV2;
+  }
+
   get isLonghornV2() {
     return this.dataEngine === DATA_ENGINE_V2;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

 Volume with non-longhorn v1 sc (LVM, lhv2) can't be exported to longhorn v1 sc image.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7572

### Test screenshot/video

https://github.com/user-attachments/assets/f292d869-6e56-4292-a696-286b341a4c9a



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


