### PR TITLE
Replace tag format in build-extension-on-release.yml

### DIFF
--- a/.github/workflows/build-extension-on-release.yml
+++ b/.github/workflows/build-extension-on-release.yml
@@ -11,6 +11,24 @@ defaults:
     working-directory: ./
 
 jobs:
+  setup-release-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.determine_tag.outputs.release_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine release tag
+        id: determine_tag
+        run: |
+          if [[ "${{ github.ref_name }}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            RELEASE_TAG="harvester-${BASH_REMATCH[1]}"
+            echo "${RELEASE_TAG}"
+            echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+          else
+            echo "Error: invalid tag format." && exit 1
+          fi
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -22,6 +40,7 @@ jobs:
         uses: ./.github/actions/lint
   build-extension-charts:
     needs:
+      - setup-release-tag
       - lint
     uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@master
     permissions:
@@ -31,4 +50,4 @@ jobs:
       pages: write
     with:
       target_branch: gh-pages
-      tagged_release: ${{ github.ref_name }}
+      tagged_release: '${{ needs.setup-release-tag.outputs.release_tag }}'


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
We want to have the same tag format `v1.5.0` for standalone and extension artifact build.

Replace tag v1.5.0 -> harvester-1.5.0 in .github/workflows/build-extension-on-release.yml.


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
See https://github.com/a110605/harvester-ui-extension/actions/runs/13713147398

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


