### PR TITLE
Fix missing remove button in Infobox

### DIFF
--- a/pkg/harvester/components/settings/csi-driver-config.vue
+++ b/pkg/harvester/components/settings/csi-driver-config.vue
@@ -196,6 +196,7 @@ export default {
     <InfoBox
       v-for="(driver, idx) in configArr"
       :key="idx"
+      class="box"
     >
       <button
         :disabled="disableEdit(driver.key)"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fix missing remove button.


<img width="1491" alt="Screenshot 2025-03-07 at 2 49 14 PM" src="https://github.com/user-attachments/assets/c343a7a0-b4aa-44bd-b83e-bf35cbcfa086" />

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7737


### Test screenshot/video

<img width="1492" alt="Screenshot 2025-03-07 at 2 51 39 PM" src="https://github.com/user-attachments/assets/0df43242-e51a-4472-afd9-e39272d9a976" />



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


