### PR TITLE
fix percent props typo

### DIFF
--- a/pkg/harvester/components/HarvesterUpgradeHeader.vue
+++ b/pkg/harvester/components/HarvesterUpgradeHeader.vue
@@ -301,14 +301,14 @@ export default {
 
           <ProgressBarList
             :title="t('harvester.upgradePage.upgradeNode')"
-            :precent="nodesPercent"
+            :percent="nodesPercent"
             :list="nodesStatus"
           />
           <p class="bordered-section"></p>
 
           <ProgressBarList
             :title="t('harvester.upgradePage.upgradeSysService')"
-            :precent="sysServiceTotal"
+            :percent="sysServiceTotal"
             :list="sysServiceUpgradeMessage"
           />
         </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Found the processlist always displayed 0% even successfully upgraded.

<img width="1496" alt="Screenshot 2025-03-11 at 2 44 00 PM" src="https://github.com/user-attachments/assets/460d851c-c02f-4075-b7da-e1650fa55825" />

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7578

### Test screenshot/video
<img width="1496" alt="Screenshot 2025-03-11 at 2 50 22 PM" src="https://github.com/user-attachments/assets/6454e589-246f-4f77-9835-fe9f517616dd" />

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


