### PR TITLE
fix the doneOverride path for harvesterhci.io.virtualmachinetemplate

### DIFF
--- a/pkg/harvester/models/harvesterhci.io.virtualmachinetemplate.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachinetemplate.js
@@ -2,6 +2,7 @@ import { MODE, _CREATE } from '@shell/config/query-params';
 import { HCI } from '../types';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
 import HarvesterResource from './harvester';
+import { clone } from '@shell/utils/object';
 
 export default class HciVmTemplate extends HarvesterResource {
   get availableActions() {
@@ -70,5 +71,13 @@ export default class HciVmTemplate extends HarvesterResource {
 
   get defaultVersion() {
     return this.status?.defaultVersion;
+  }
+
+  get doneOverride() {
+    const detailLocation = clone(this.listLocation);
+
+    detailLocation.params.resource = HCI.VM_VERSION;
+
+    return detailLocation;
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The page redirect to https://localhost:8005/harvester/c/local/harvesterhci.io.virtualmachinetemplate after deleting a VM template which got stange table layout.

It's should redirect to the same page https://localhost:8005/harvester/c/local/harvesterhci.io.virtualmachinetemplateversion.

https://github.com/user-attachments/assets/acdac14c-dd9c-46c4-8046-2e578ea5fb0b


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video

https://github.com/user-attachments/assets/4b352905-f5bf-40bd-9289-1f347c343895



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


