### PR TITLE
fix image.repo to image.repository for nvidia-driver-toolkit addon

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.addon/nvidia-driver-toolkit.vue
+++ b/pkg/harvester/edit/harvesterhci.io.addon/nvidia-driver-toolkit.vue
@@ -10,7 +10,7 @@ import { Banner } from '@components/Banner';
 
 import CreateEditView from '@shell/mixins/create-edit-view';
 
-const DEFAULT_VALUE = { image: { repo: 'rancher/harvester-nvidia-driver-toolkit' } };
+const DEFAULT_VALUE = { image: { repository: 'rancher/harvester-nvidia-driver-toolkit' } };
 
 export default {
   name:       'EditAddonNvidiaDriverToolkit',
@@ -122,7 +122,7 @@ export default {
           >
             <div class="col span-6">
               <LabeledInput
-                v-model:value="valuesContentJson.image.repo"
+                v-model:value="valuesContentJson.image.repository"
                 :mode="mode"
                 :required="true"
                 label-key="harvester.addons.nvidiaDriverToolkit.image.repository"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Change image.repo to image.repository.


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @ibrokethecloud 

### Related Issue #
https://github.com/harvester/harvester/issues/7896

### Test screenshot/video


https://github.com/user-attachments/assets/7285275f-7d11-456f-abe7-314630ae39c3



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


