### PR TITLE
Fix secretRef is different when edit as yaml

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -669,7 +669,7 @@ export default {
         }
       });
 
-      if (!this.secretName || this.needNewSecret) {
+      if (!this.secretName) {
         this.secretName = this.generateSecretName(this.secretNamePrefix);
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The root cause is [parseDiskRows()](https://github.com/harvester/harvester-ui-extension/blob/9256391627c82cd3ae599c68b91fbadf3aa924d4/pkg/harvester/mixins/harvester-vm/index.js#L640-L675) calls twice even single click `edit as yaml` .


<img width="1474" alt="Screenshot 2025-04-02 at 5 39 17 PM" src="https://github.com/user-attachments/assets/06ff5b6a-1654-4cce-8e3f-d5e6720e2ed4" />

It's caused by [CruResource component change](https://github.com/rancher/dashboard/blob/bef1ffc2954aa78d304e174fb972ef20e13c048e/shell/components/CruResource.vue#L434-L440) in shell.  (commit: https://github.com/rancher/dashboard/commit/b464d15ee0a0d50c78c316b08fba80257f792e2c)


The workaround is if `this.secretName` has value, no need to generate another `this.secretName`
### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Yu-Jack 

### Related Issue #
https://github.com/harvester/harvester/issues/7408

### Test screenshot/video


https://github.com/user-attachments/assets/e4501b39-81a0-45a9-8ca1-8afd3047a65a




### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


