### PR TITLE
Fix undefined error in VM edit as yaml page

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
@@ -97,11 +97,13 @@ export default {
       });
 
       const devices = [
-        ...this.otherDevices(this.value.domain.devices.hostDevices || []),
+        ...this.otherDevices(this.value?.domain?.devices?.hostDevices || []),
         ...formatted,
       ];
 
-      set(this.value.domain.devices, 'hostDevices', devices);
+      if (devices.length > 0) {
+        set(this.value.domain.devices, 'hostDevices', devices);
+      }
     }
   },
 
@@ -121,7 +123,9 @@ export default {
           return inUse;
         }
 
-        vm.hostDevices.forEach((device) => {
+        const hostDevices = vm?.hostDevices || [];
+
+        hostDevices.forEach((device) => {
           inUse[device.name] = { usedBy: [vm.metadata.name] };
         });
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineUSBDevices/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineUSBDevices/index.vue
@@ -80,11 +80,13 @@ export default {
       });
 
       const devices = [
-        ...this.otherDevices(this.value.domain.devices.hostDevices || []),
+        ...this.otherDevices(this.value?.domain?.devices?.hostDevices || []),
         ...formatted,
       ];
 
-      set(this.value.domain.devices, 'hostDevices', devices);
+      if (devices.length > 0) {
+        set(this.value.domain.devices, 'hostDevices', devices);
+      }
     }
   },
 
@@ -121,7 +123,9 @@ export default {
           return inUse;
         }
 
-        vm.hostDevices.forEach((device) => {
+        const hostDevices = vm?.hostDevices || [];
+
+        hostDevices.forEach((device) => {
           inUse[device.name] = { usedBy: [vm.metadata.name] };
         });
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -2,6 +2,7 @@
 import { isEqual } from 'lodash';
 import { mapGetters } from 'vuex';
 import Tabbed from '@shell/components/Tabbed';
+import { clone } from '@shell/utils/object';
 import Tab from '@shell/components/Tabbed/Tab';
 import { Checkbox } from '@components/Form/Checkbox';
 import CruResource from '@shell/components/CruResource';
@@ -17,7 +18,6 @@ import UsbDevices from './VirtualMachineUSBDevices/index';
 import KeyValue from '@shell/components/form/KeyValue';
 
 import { clear } from '@shell/utils/array';
-import { clone } from '@shell/utils/object';
 import { saferDump } from '@shell/utils/create-yaml';
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
@@ -410,26 +410,29 @@ export default {
       const cloneDeepNewVM = clone(this.value);
 
       delete cloneDeepNewVM?.metadata;
+      delete cloneDeepNewVM?.__clone;
+
       delete this.cloneVM?.metadata;
       delete this.cloneVM?.__clone;
 
       const oldVM = JSON.parse(JSON.stringify(this.cloneVM));
       const newVM = JSON.parse(JSON.stringify(cloneDeepNewVM));
 
+      // we won't show restart dialog in yaml page as we don't have a way to detect change in yaml editor.
+      // only check VM is changed in form page.
       if (isEqual(oldVM, newVM)) {
         return;
       }
 
       return new Promise((resolve) => {
-        // Resolve immediately if there's no restart dialog in edit as yaml
-        if (!this?.$refs?.restartDialog) {
-          this.value.doActionGrowl('restart', {});
-
-          return resolve();
-        }
         this.isOpen = true;
+
         this.$nextTick(() => {
-          this.$refs.restartDialog.resolve = resolve;
+          if (this?.$refs?.restartDialog) {
+            this.$refs.restartDialog.resolve = resolve;
+          } else {
+            return resolve();
+          }
         });
       });
     },

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -421,8 +421,13 @@ export default {
       }
 
       return new Promise((resolve) => {
-        this.isOpen = true;
+        // Resolve immediately if there's no restart dialog in edit as yaml
+        if (!this?.$refs?.restartDialog) {
+          this.value.doActionGrowl('restart', {});
 
+          return resolve();
+        }
+        this.isOpen = true;
         this.$nextTick(() => {
           this.$refs.restartDialog.resolve = resolve;
         });

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -871,7 +871,7 @@ export default {
         }
       }
 
-      if (out.length === 0 && !!this.spec.template.spec.accessCredentials) {
+      if (out.length === 0 && !!this.spec.template.spec.accessCredentials === false) {
         delete this.spec.template.spec.accessCredentials;
       } else {
         this.spec.template.spec.accessCredentials = out;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This PR fixes two existing bugs
- resolve undefined error when clicking save button in VM edit as yaml page.
- `isEqual` logic when comparing VM spec in edit VM page.

<img width="1494" alt="Screenshot 2025-04-07 at 1 00 00 PM" src="https://github.com/user-attachments/assets/3e2608a3-593e-4061-b64e-40f0ca956a3b" />



### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7408

### Test screenshot/video
**Edit VM in form page and Edit VM in yaml page (won't restart VM)**


https://github.com/user-attachments/assets/a91cdfd2-6ce8-4f64-9b27-d14c85e3dfdd

**Edit VM with PCI device change**

https://github.com/user-attachments/assets/ebf6aa49-b28d-4dee-87de-eb77ec1f1518

### Extra technical notes summary

Even no change from UI, there still some diff in VM spec. Fixed in 2e4a7ac.

<img width="1005" alt="Screenshot 2025-04-07 at 11 38 44 AM" src="https://github.com/user-attachments/assets/c9262e48-22eb-4480-9b9a-b37759d193b5" />

