### PR TITLE
Hide usb device tab for harvester v1.3.x

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -212,7 +212,10 @@ export default {
       }
 
       return false;
-    }
+    },
+    usbPassthroughEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('usbPassthrough');
+    },
   },
 
   watch: {
@@ -682,7 +685,7 @@ export default {
       </Tab>
 
       <Tab
-        v-if="enabledPCI"
+        v-if="enabledPCI && usbPassthroughEnabled"
         :label="t('harvester.tab.usbDevices')"
         name="usbDevices"
         :weight="-7"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
[USB passthrough](https://github.com/harvester/harvester-ui-extension/blob/238c6607965845852687c92ba0c4ae1cd4851629/pkg/harvester/config/feature-flags.js#L30) feature was introduced in v1.4.0. 

We should hide this USB device tab in create / edit VM page for v1.3.x.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot/video
<img width="1496" alt="Screenshot 2025-04-09 at 10 31 35 AM" src="https://github.com/user-attachments/assets/46851396-e94b-4881-bbd5-8ed879ece5b9" />


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


