### PR TITLE
Add logic to block import harvester version lower than 1.3.0

### DIFF
--- a/pkg/harvester/utils/feature-flags.js
+++ b/pkg/harvester/utils/feature-flags.js
@@ -41,7 +41,7 @@ export const featureEnabled = (featureKey, serverVersion) => {
 
   if (semver.lt(version.replace('v', ''), minSupportedVersion)) {
     // eslint-disable-next-line no-console
-    console.error('Harvester ui extension only supports Harvester cluster version greater or equal to 1.3.0. Current version: ', version);
+    console.error(`Harvester UI extension only supports Harvester cluster version >= ${ minSupportedVersion }. Current version: ${ version }`);
 
     return false;
   }

--- a/pkg/harvester/utils/feature-flags.js
+++ b/pkg/harvester/utils/feature-flags.js
@@ -35,7 +35,17 @@ function latestMinorVersion(v) {
 }
 
 export const featureEnabled = (featureKey, serverVersion) => {
+  const minSupportedVersion = '1.3.0';
+
   const version = getVersion(serverVersion);
+
+  if (semver.lt(version.replace('v', ''), minSupportedVersion)) {
+    // eslint-disable-next-line no-console
+    console.error('Harvester ui extension only supports Harvester cluster version greater or equal to 1.3.0. Current version: ', version);
+
+    return false;
+  }
+
   let releasedFeatures = RELEASE_FEATURES[version];
 
   if (!releasedFeatures) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Root cause is [releasedFeatures](https://github.com/harvester/harvester-ui-extension/blob/78234b9e1ea927639479696403f68597043ce691/pkg/harvester/utils/feature-flags.js#L39-L46) is undefined when importing harvester cluster v1.2.1


<img width="1492" alt="Screenshot 2025-04-10 at 2 20 36 PM" src="https://github.com/user-attachments/assets/c5264d40-60b9-4fba-b057-0f68360af470" />

We add version fallback logic in https://github.com/harvester/harvester-ui-extension/pull/60 previously.

This PR adds explicit logic to block import harvester version lower than 1.3.0

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/6971#issuecomment-2789567896

### Test screenshot/video
Import 1.2.1
<img width="1496" alt="Screenshot 2025-04-10 at 2 35 17 PM" src="https://github.com/user-attachments/assets/930c31e3-a76f-4c25-9430-4ce24338e43e" />

Import 1.5.0-rc3
<img width="1495" alt="Screenshot 2025-04-10 at 2 56 00 PM" src="https://github.com/user-attachments/assets/adc534f8-ce7f-4dda-a27d-617f6e6e9931" />


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


