### PR TITLE
fix unable to detach PCI & USB device in VM edit page

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
@@ -101,9 +101,7 @@ export default {
         ...formatted,
       ];
 
-      if (devices.length > 0) {
-        set(this.value.domain.devices, 'hostDevices', devices);
-      }
+      set(this.value.domain.devices, 'hostDevices', devices);
     }
   },
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineUSBDevices/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineUSBDevices/index.vue
@@ -84,9 +84,7 @@ export default {
         ...formatted,
       ];
 
-      if (devices.length > 0) {
-        set(this.value.domain.devices, 'hostDevices', devices);
-      }
+      set(this.value.domain.devices, 'hostDevices', devices);
     }
   },
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -420,8 +420,10 @@ export default {
       delete this.cloneVM?.__clone;
 
       // add empty hostDevices to old VM as CRD does not have it.
-      if (this.cloneVM?.spec?.template?.spec?.domain?.devices?.hostDevices === undefined) {
-        this.cloneVM.spec.template.spec.domain.devices.hostDevices = [];
+      const devicesObj = this.cloneVM?.spec?.template?.spec?.domain?.devices;
+
+      if (devicesObj && devicesObj.hostDevices === undefined) {
+        devicesObj.hostDevices = [];
       }
 
       const oldVM = JSON.parse(JSON.stringify(this.cloneVM));

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -16,7 +16,6 @@ import PodAffinity from '@shell/components/form/PodAffinity';
 import VGpuDevices from './VirtualMachineVGpuDevices/index';
 import UsbDevices from './VirtualMachineUSBDevices/index';
 import KeyValue from '@shell/components/form/KeyValue';
-
 import { clear } from '@shell/utils/array';
 import { saferDump } from '@shell/utils/create-yaml';
 import { exceptionToErrorsArray } from '@shell/utils/error';
@@ -412,11 +411,18 @@ export default {
       }
       const cloneDeepNewVM = clone(this.value);
 
+      // new VM
       delete cloneDeepNewVM?.metadata;
       delete cloneDeepNewVM?.__clone;
 
+      // old VM
       delete this.cloneVM?.metadata;
       delete this.cloneVM?.__clone;
+
+      // add empty hostDevices to old VM as CRD does not have it.
+      if (this.cloneVM?.spec?.template?.spec?.domain?.devices?.hostDevices === undefined) {
+        this.cloneVM.spec.template.spec.domain.devices.hostDevices = [];
+      }
 
       const oldVM = JSON.parse(JSON.stringify(this.cloneVM));
       const newVM = JSON.parse(JSON.stringify(cloneDeepNewVM));

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -2,7 +2,7 @@
 import { isEqual } from 'lodash';
 import { mapGetters } from 'vuex';
 import Tabbed from '@shell/components/Tabbed';
-import { clone } from '@shell/utils/object';
+import { clone, set } from '@shell/utils/object';
 import Tab from '@shell/components/Tabbed/Tab';
 import { Checkbox } from '@components/Form/Checkbox';
 import CruResource from '@shell/components/CruResource';
@@ -423,7 +423,7 @@ export default {
       const devicesObj = this.cloneVM?.spec?.template?.spec?.domain?.devices;
 
       if (devicesObj && devicesObj.hostDevices === undefined) {
-        devicesObj.hostDevices = [];
+        set(devicesObj, 'hostDevices', []);
       }
 
       const oldVM = JSON.parse(JSON.stringify(this.cloneVM));


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Previous PR https://github.com/harvester/harvester-ui-extension/pull/233 added if condition to prevent unneeded restart VM dialog popup but causes [issue8071](https://github.com/harvester/harvester/issues/8071) regression bug.

Revert it to resolve issue 8071.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @Yu-Jack 

### Related Issue #
https://github.com/harvester/harvester/issues/8071

### Test screenshot/video


Should successfully detach PCI device

https://github.com/user-attachments/assets/a3efa852-d6b2-4e83-91a2-3ff18777d03d







### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


