### PR TITLE
fix: support-bundle-expiration can be invalid value 000003333

### DIFF
--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -62,7 +62,7 @@ export const HCI_ALLOWED_SETTINGS = {
   },
   [HCI_SETTING.OVERCOMMIT_CONFIG]:                      { kind: 'json', from: 'import' },
   [HCI_SETTING.SUPPORT_BUNDLE_TIMEOUT]:                 {},
-  [HCI_SETTING.SUPPORT_BUNDLE_EXPIRATION]:              {},
+  [HCI_SETTING.SUPPORT_BUNDLE_EXPIRATION]:              { kind: 'number' },
   [HCI_SETTING.SUPPORT_BUNDLE_NODE_COLLECTION_TIMEOUT]: { featureFlag: 'supportBundleNodeCollectionTimeoutSetting' },
   [HCI_SETTING.SUPPORT_BUNDLE_IMAGE]:                   { kind: 'json', from: 'import' },
   [HCI_SETTING.STORAGE_NETWORK]:                        {

--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -61,9 +61,9 @@ export const HCI_ALLOWED_SETTINGS = {
     kind: 'multiline', canReset: true, from: 'import'
   },
   [HCI_SETTING.OVERCOMMIT_CONFIG]:                      { kind: 'json', from: 'import' },
-  [HCI_SETTING.SUPPORT_BUNDLE_TIMEOUT]:                 {},
+  [HCI_SETTING.SUPPORT_BUNDLE_TIMEOUT]:                 { kind: 'number' },
   [HCI_SETTING.SUPPORT_BUNDLE_EXPIRATION]:              { kind: 'number' },
-  [HCI_SETTING.SUPPORT_BUNDLE_NODE_COLLECTION_TIMEOUT]: { featureFlag: 'supportBundleNodeCollectionTimeoutSetting' },
+  [HCI_SETTING.SUPPORT_BUNDLE_NODE_COLLECTION_TIMEOUT]: { kind: 'number', featureFlag: 'supportBundleNodeCollectionTimeoutSetting' },
   [HCI_SETTING.SUPPORT_BUNDLE_IMAGE]:                   { kind: 'json', from: 'import' },
   [HCI_SETTING.STORAGE_NETWORK]:                        {
     kind: 'custom', from: 'import', canReset: true
@@ -89,7 +89,7 @@ export const HCI_ALLOWED_SETTINGS = {
   [HCI_SETTING.NTP_SERVERS]:           {
     kind: 'json', from: 'import', canReset: true
   },
-  [HCI_SETTING.KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES]:   { featureFlag: 'kubeconfigDefaultTokenTTLMinutesSetting' },
+  [HCI_SETTING.KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES]:   { kind: 'number', featureFlag: 'kubeconfigDefaultTokenTTLMinutesSetting' },
   [HCI_SETTING.LONGHORN_V2_DATA_ENGINE_ENABLED]:        {
     kind:         'boolean',
     experimental: true,

--- a/pkg/harvester/edit/harvesterhci.io.setting.vue
+++ b/pkg/harvester/edit/harvesterhci.io.setting.vue
@@ -4,7 +4,7 @@ import { RadioGroup } from '@components/Form/Radio';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { TextAreaAutoGrow } from '@components/Form/TextArea';
-
+import UnitInput from '@shell/components/form/UnitInput';
 import CreateEditView from '@shell/mixins/create-edit-view';
 
 import { HCI_ALLOWED_SETTINGS, HCI_SINGLE_CLUSTER_ALLOWED_SETTING, HCI_SETTING } from '../config/settings';
@@ -15,7 +15,8 @@ export default {
     LabeledInput,
     LabeledSelect,
     RadioGroup,
-    TextAreaAutoGrow
+    TextAreaAutoGrow,
+    UnitInput
   },
 
   mixins: [CreateEditView],
@@ -128,6 +129,13 @@ export default {
         await this.clusterRegistrationUrlTip();
       }
 
+      // remove any leading zeros (e.g. '0123' becomes 123)
+      if (this.setting.kind === 'number' && this.value.value) {
+        const num = Number(this.value.value);
+
+        this.value.value = isNaN(num) ? 0 : `${ num }`;
+      }
+
       this.save(done);
     },
 
@@ -236,6 +244,13 @@ export default {
         <TextAreaAutoGrow
           v-model:value="value.value"
           :min-height="254"
+        />
+      </div>
+      <div v-else-if="setting.kind === 'number'">
+        <LabeledInput
+          v-model:value="value.value"
+          :label="t('advancedSettings.edit.value')"
+          type="number"
         />
       </div>
       <div v-else>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Ensure that any numeric input in the settings is normalized by removing leading zeros, e.g., `000003333` to `3333`.
This applies to the following field inputs:
- support-bundle-timeout
- support-bundle-expiration
- support-bundle-node-collection-timeout
- kubeconfig-default-token-ttl-minutes

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] support-bundle-expiration can be invalid value 000003333  #5074](https://github.com/harvester/harvester/issues/5074#issuecomment-2803355943)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Navigate to the settings page and edit the `support-bundle-expiration` field
- Enter `000003333` and click `Save`, it should automatically convert to `3333`

https://github.com/user-attachments/assets/1ce4cf8e-a2c6-4d8e-9caa-d83c8fdcab9f

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A
