### PR TITLE
fix: UI should handle exception when downloading an imported yet image

### DIFF
--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -50,35 +50,45 @@ export default class HciVmImage extends HarvesterResource {
       canCreateVM = false;
     }
 
-    return [
+    const customActions = this.isReady ? [
       {
         action:   'createFromImage',
         enabled:  canCreateVM,
         icon:     'icon icon-circle-plus',
         label:    this.t('harvester.action.createVM'),
-        disabled: !this.isReady,
       },
       {
         action:   'encryptImage',
         enabled:  this.volumeEncryptionFeatureEnabled && !this.isEncrypted,
         icon:     'icon icon-lock',
         label:    this.t('harvester.action.encryptImage'),
-        disabled: !this.isReady,
       },
       {
         action:   'decryptImage',
         enabled:  this.volumeEncryptionFeatureEnabled && this.isEncrypted,
         icon:     'icon icon-unlock',
         label:    this.t('harvester.action.decryptImage'),
-        disabled: !this.isReady,
       },
       {
-        action:  'imageDownload',
-        enabled: this.links?.download,
-        icon:    'icon icon-download',
-        label:   this.t('asyncButton.download.action'),
-      },
-      ...out
+        action:   'imageDownload',
+        enabled:  this.links?.download,
+        icon:     'icon icon-download',
+        label:    this.t('asyncButton.download.action'),
+      }
+    ] : [];
+
+    let filteredOut;
+
+    if (customActions.length > 0) {
+      filteredOut = out;
+    } else {
+      // if the first item is a divider, remove it from the array
+      filteredOut = out[0]?.divider ? out.slice(1) : out;
+    }
+
+    return [
+      ...customActions,
+      ...filteredOut
     ];
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Hide related buttons until the image is successfully uploaded

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[backport v1.5] [TASK] UI should handle exception when downloading an imported yet image #8155](https://github.com/harvester/harvester/issues/8155)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Upload a VM image
- While the image is still being uploaded, the action menu should **NOT** display `Create Virtual Machine`, `Encrypt Image`, `Decrypt Image`, or `Download`
- Once the image is successfully uploaded, these actions should become visible in the menu

https://github.com/user-attachments/assets/6f15c837-416b-4f26-998b-88810967eded


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

