### PR TITLE
Fix Rancher v2.10.5 w/ Harvester v1.4.3-rc1 Can Not Create New SSH Key From VM Creation Screen 

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineSSHKey.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineSSHKey.vue
@@ -1,13 +1,11 @@
 <script>
 import { mapGetters } from 'vuex';
 import { randomStr } from '@shell/utils/string';
-
+import { clone } from '@shell/utils/object';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import ModalWithCard from '@shell/components/ModalWithCard';
-
 import { _VIEW, _EDIT } from '@shell/config/query-params';
-
 import { NAMESPACE } from '@shell/config/types';
 import { HCI } from '../../types';
 
@@ -131,6 +129,7 @@ export default {
     checkedSsh(val) {
       // if click on Create a New...
       if (val.includes(_NEW)) {
+        this.checkedSsh = this.checkedSsh.filter((key) => key !== _NEW);
         this.show();
       }
     }
@@ -234,9 +233,7 @@ export default {
     },
 
     update() {
-      const sshKeys = this.checkedSsh.filter((key) => key !== _NEW);
-
-      this.$emit('update:sshKey', sshKeys);
+      this.$emit('update:sshKey', clone(this.checkedSsh));
     },
   }
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix create ssh key modal does not pop up in Rancher 2.10.5.

Previous PR change https://github.com/harvester/harvester-ui-extension/pull/146/files.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/8215

### Test screenshot/video

https://github.com/user-attachments/assets/81abc0d5-831a-4f4b-86f0-17949574fe76



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


