### PR TITLE
fix: bold not rendered in confirmation of pause/stop

### DIFF
--- a/pkg/harvester/dialog/ConfirmExecutionDialog.vue
+++ b/pkg/harvester/dialog/ConfirmExecutionDialog.vue
@@ -67,7 +67,7 @@ export default {
     plusMore() {
       const remaining = this.resources.length - this.names.length;
 
-      return this.t('dialog.confirmExecution.andOthers', { count: remaining });
+      return this.t('dialog.confirmExecution.andOthers', { count: remaining }, true);
     },
 
     type() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Add an argument to disable HTML escaping.

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] bold not rendered in confirmation of pause/stop #7517](https://github.com/harvester/harvester/issues/7517)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2025-05-08 at 1 45 52 PM (2)](https://github.com/user-attachments/assets/2ab6fbfb-f660-4688-ba1e-986623e6e1e2)

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

