### PR TITLE
fix: volume's name is not required

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.volume.vue
+++ b/pkg/harvester/edit/harvesterhci.io.volume.vue
@@ -378,6 +378,7 @@ export default {
     <NameNsDescription
       :value="value"
       :namespaced="true"
+      :name-required="false"
       :mode="mode"
       @update:value="$emit('update:value', $event)"
     />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Set the volume's name input as optional

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] Volume's name is not required #7030](https://github.com/harvester/harvester/issues/7030)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2025-05-08 at 2 47 06 PM (2)](https://github.com/user-attachments/assets/4d4dac50-f248-4289-9502-72fb5a8da1d4)

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


