### PR TITLE
refactor: the promptRemove.confirmRelatedResource message needs to be refactored

### DIFF
--- a/pkg/harvester/dialog/ConfirmRelatedToRemoveDialog.vue
+++ b/pkg/harvester/dialog/ConfirmRelatedToRemoveDialog.vue
@@ -42,8 +42,25 @@ export default {
   computed: {
     ...mapState('action-menu', ['modalData']),
 
-    warningMessageKey() {
-      return this.modalData.warningMessageKey;
+    title() {
+      return this.modalData.title || 'dialog.promptRemove.title';
+    },
+
+    formattedType() {
+      return this.type.toLowerCase();
+    },
+
+    warningMessage() {
+      if (this.modalData.warningMessage) return this.t(this.modalData.warningMessage);
+
+      const isPlural = this.type.endsWith('s');
+      const thisOrThese = isPlural ? 'these' : 'this';
+      const defaultMessage = this.t('dialog.promptRemove.warningMessage', {
+        type: this.formattedType,
+        thisOrThese,
+      });
+
+      return defaultMessage;
     },
 
     names() {
@@ -101,7 +118,7 @@ export default {
     },
 
     protip() {
-      return this.t('promptRemove.protip', { alternateLabel });
+      return this.t('dialog.promptRemove.protip', { alternateLabel });
     },
   },
 
@@ -137,19 +154,22 @@ export default {
   >
     <template #title>
       <h4 class="text-default-text">
-        {{ t('promptRemove.title') }}
+        {{ t(title, { type }, true) }}
       </h4>
     </template>
 
     <template #body>
       <div class="pl-10 pr-10">
         <span
-          v-clean-html="t(warningMessageKey, { type, names: resourceNames }, true)"
+          v-clean-html="warningMessage"
         ></span>
 
         <div class="mt-10 mb-10">
           <span
-            v-clean-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
+            v-clean-html="t('dialog.promptRemove.confirmName', {
+              type: formattedType,
+              nameToMatch: escapeHtml(nameToMatch)
+            }, true)"
           ></span>
         </div>
         <div class="mb-10">

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -52,6 +52,11 @@ dialog:
       message: "Are you sure you want to continue stop the {type} {names}?"
     pause:
       message: "Are you sure you want to continue pause the {type} {names}?"
+  promptRemove:
+    title: "Delete {type}"
+    warningMessage: "Deleting the selected {type} permanently removes all resources on {thisOrThese} {type}. This action is irreversible. Do you want to continue?"
+    confirmName: "Type <b>{nameToMatch}</b> to delete the {type}:"
+    protip: "Tip: Hold the {alternateLabel} key while clicking Delete to bypass the confirmation step"
 
 harvester:
   branding:
@@ -782,7 +787,7 @@ harvester:
     instanceLabels:
       banner: These labels are automatically synchronized to the virtual machine instance.
     labels:
-      banner: These key values are added as labels to the virtual machine.  
+      banner: These key values are added as labels to the virtual machine.
 
   volume:
     label: Volumes

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -56,7 +56,7 @@ dialog:
     title: "Delete {type}"
     warningMessage: "Deleting the selected {type} permanently removes all resources on {thisOrThese} {type}. This action is irreversible. Do you want to continue?"
     confirmName: "Type <b>{nameToMatch}</b> to delete the {type}:"
-    protip: "Tip: Hold the {alternateLabel} key while clicking Delete to bypass the confirmation step"
+    protip: "Tip: Hold the {alternateLabel} key while clicking Delete to bypass the confirmation step."
 
 harvester:
   branding:

--- a/pkg/harvester/models/harvester/namespace.js
+++ b/pkg/harvester/models/harvester/namespace.js
@@ -67,8 +67,7 @@ export default class HciNamespace extends namespace {
   promptRemove(resources = this) {
     this.$dispatch('promptModal', {
       resources,
-      warningMessageKey: 'promptRemove.confirmRelatedResource',
-      component:         'ConfirmRelatedToRemoveDialog'
+      component: 'ConfirmRelatedToRemoveDialog'
     });
   }
 

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -115,8 +115,7 @@ export default class HciNode extends HarvesterResource {
   promptRemove(resources = this) {
     this.$dispatch('promptModal', {
       resources,
-      warningMessageKey: 'promptRemove.confirmRelatedResource',
-      component:         'ConfirmRelatedToRemoveDialog'
+      component: 'ConfirmRelatedToRemoveDialog'
     });
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Update confirm modal message
- Align the wording for both `Node` and `Namespace`

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] The promptRemove.confirmRelatedResource message needs to be refactored #5280](https://github.com/harvester/harvester/issues/5280#issuecomment-2875430803)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Modal with single node to delete
![host](https://github.com/user-attachments/assets/180740c3-3d8e-44ae-99a2-3b8793027699)

- Modal with multiple nodes to delete
![hosts](https://github.com/user-attachments/assets/ac712b06-78a5-4df6-872b-662c6f4d1a95)

- Modal with multi namespaces to delete
![Screenshot 2025-05-14 at 10 54 43 AM (2)](https://github.com/user-attachments/assets/45039ebc-768e-4533-b9cc-e41ee462fb67)


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


