### PR TITLE
Change isKVMDisable condition 

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -66,4 +66,5 @@ export const HCI = {
   VM_DEVICE_ALLOCATION_DETAILS:     'harvesterhci.io/deviceAllocationDetails',
   SVM_BACKUP_ID:                    'harvesterhci.io/svmbackupId',
   DISABLE_LONGHORN_V2_ENGINE:       'node.longhorn.io/disable-v2-data-engine',
+  K8s_ARCH:                         'kubernetes.io/arch'
 };

--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -66,5 +66,5 @@ export const HCI = {
   VM_DEVICE_ALLOCATION_DETAILS:     'harvesterhci.io/deviceAllocationDetails',
   SVM_BACKUP_ID:                    'harvesterhci.io/svmbackupId',
   DISABLE_LONGHORN_V2_ENGINE:       'node.longhorn.io/disable-v2-data-engine',
-  K8s_ARCH:                         'kubernetes.io/arch'
+  K8S_ARCH:                         'kubernetes.io/arch'
 };

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -185,9 +185,14 @@ export default class HciNode extends HarvesterResource {
   }
 
   get isKVMDisable() {
-    const allNotExist = !this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_AMD_CPU] && !this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_INTEL_CPU];
+    // Arm based
+    const isARMMachine = this.metadata.label?.[HCI_ANNOTATIONS.K8s_ARCH]?.includes('arm');
 
-    return this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_AMD_CPU] === 'false' || this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_INTEL_CPU] === 'false' || allNotExist;
+    if (isARMMachine) {
+      return !!this.status.capacity['devices.kubevirt.io/kvm'];
+    }
+
+    return this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_AMD_CPU] === 'false' || this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_INTEL_CPU] === 'false';
   }
 
   get stateDisplay() {

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -186,10 +186,10 @@ export default class HciNode extends HarvesterResource {
 
   get isKVMDisable() {
     // Arm based
-    const isARMMachine = this.metadata.label?.[HCI_ANNOTATIONS.K8s_ARCH]?.includes('arm');
+    const isARMMachine = this.metadata.labels?.[HCI_ANNOTATIONS.K8S_ARCH]?.includes('arm');
 
     if (isARMMachine) {
-      return !!this.status.capacity['devices.kubevirt.io/kvm'];
+      return this.status.capacity['devices.kubevirt.io/kvm'] && this.status.capacity['devices.kubevirt.io/kvm'] === '0';
     }
 
     return this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_AMD_CPU] === 'false' || this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_INTEL_CPU] === 'false';

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -192,7 +192,9 @@ export default class HciNode extends HarvesterResource {
       return this.status.capacity['devices.kubevirt.io/kvm'] && this.status.capacity['devices.kubevirt.io/kvm'] === '0';
     }
 
-    return this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_AMD_CPU] === 'false' || this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_INTEL_CPU] === 'false';
+    const allNotExist = !this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_AMD_CPU] && !this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_INTEL_CPU];
+
+    return allNotExist || this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_AMD_CPU] === 'false' || this.metadata?.labels?.[HCI_ANNOTATIONS.KVM_INTEL_CPU] === 'false';
   }
 
   get stateDisplay() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Change to check `kubernetes.io/arch: arm64` and presence of `devices.kubevirt.io/kvm` in node.status.capacity for ARM based machine.


### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/5366

### Test screenshot/video
Before change

<img width="1488" alt="Screenshot 2025-05-14 at 2 17 57 PM" src="https://github.com/user-attachments/assets/01f2edb5-a483-4ed9-b55f-287659d84dfb" />

After change

<img width="1495" alt="Screenshot 2025-05-14 at 2 17 52 PM" src="https://github.com/user-attachments/assets/8ff66d02-a709-4a1e-b00c-b2c22fa141a5" />


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


