### PR TITLE
fix: IPPool Config should provide same content as YAML

### DIFF
--- a/pkg/harvester/edit/loadbalancer.harvesterhci.io.ippool/Range.vue
+++ b/pkg/harvester/edit/loadbalancer.harvesterhci.io.ippool/Range.vue
@@ -29,7 +29,7 @@ export default {
     const rows = (this.value || []).map((row) => {
       let type = 'cidr';
 
-      if (row.rangeStart && row.rangeEnd) {
+      if (row.rangeStart || row.rangeEnd) {
         type = 'range';
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Update the range condition from `AND` to `OR`

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] IPPool Config should provide same content as YAML #6046](https://github.com/harvester/harvester/issues/6046)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- The `Start IP` field should be displayed in the `range-subnet-start` config
![range-start](https://github.com/user-attachments/assets/5c0a97ee-9678-4c95-9a91-8ef6b05cf2e0)

- The `End IP` field should be displayed in the `range-subnet-end` config
![range-end](https://github.com/user-attachments/assets/075c425d-8026-4b4c-b70c-57c74cdb7016)

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


