### PR TITLE
fix: cluster member role user found 'backup target does not match the existing one' message on vm backup

### DIFF
--- a/pkg/harvester/models/harvesterhci.io.setting.js
+++ b/pkg/harvester/models/harvesterhci.io.setting.js
@@ -111,15 +111,18 @@ export default class HciSetting extends HarvesterResource {
   }
 
   get parseValue() {
-    let parseDefaultValue = {};
-
     try {
-      parseDefaultValue = JSON.parse(this.value);
+      if (this.value) {
+        return JSON.parse(this.value);
+      } else if (this.default) {
+        return JSON.parse(this.default);
+      }
     } catch (err) {
-      parseDefaultValue = JSON.parse(this.default);
+      // eslint-disable-next-line no-console
+      console.error('Failed to parse setting value or default:', err);
     }
 
-    return parseDefaultValue;
+    return {};
   }
 
   get isS3() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Hide the error message for `cluster-member` role

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] Cluster member role user found 'backup target does not match the existing one' message on vm backup  #7254
](https://github.com/harvester/harvester/issues/7254)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![issue-7254](https://github.com/user-attachments/assets/8e70dad3-9db8-49e3-aa35-5c1edfc9e04d)

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

