### PR TITLE
Fix OS upgrade page

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -848,6 +848,8 @@ harvester:
         =1 {1 image is uploading, please do not refresh or close the page.}
         other {{count} images are uploading, please do not refresh or close the page.}
         }
+      osUpgrade:
+        uploading: "{name} is uploading, please do not refresh or close the page."
     checksum: Checksum
     checksumTip: Validate the image using the SHA512 checksum, if specified.
 
@@ -1086,7 +1088,7 @@ harvester:
         addConfig: Add Configuration
 
     upgrade:
-      selectExitImage: Please select the OS image to upgrade.
+      unknownImageName: Image name is not found.
       imageUrl: Please input a valid image URL.
       chooseFile: Please select to upload an image.
       checksum: Checksum

--- a/pkg/harvester/list/harvesterhci.io.setting.vue
+++ b/pkg/harvester/list/harvesterhci.io.setting.vue
@@ -2,7 +2,6 @@
 import { mapGetters } from 'vuex';
 import { Banner } from '@components/Banner';
 import Loading from '@shell/components/Loading';
-import { VIEW_IN_API, DEV } from '@shell/store/prefs';
 import { MANAGEMENT } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
 import Tabbed from '@shell/components/Tabbed/index.vue';

--- a/pkg/harvester/list/harvesterhci.io.setting.vue
+++ b/pkg/harvester/list/harvesterhci.io.setting.vue
@@ -21,14 +21,6 @@ export default {
   },
 
   async fetch() {
-    let isDev;
-
-    try {
-      isDev = this.$store.getters['prefs/get'](VIEW_IN_API);
-    } catch {
-      isDev = this.$store.getters['prefs/get'](DEV);
-    }
-
     const isSingleProduct = !!this.$store.getters['isSingleProduct'];
     const inStore = this.$store.getters['currentProduct'].inStore;
 
@@ -77,7 +69,7 @@ export default {
       };
 
       s.hide = s.canHide = (s.kind === 'json' || s.kind === 'multiline' || s.customFormatter === 'json' || s.data.customFormatter === 'json');
-      s.hasActions = !s.readOnly || isDev;
+      s.hasActions = true;
       initSettings.push(s);
     });
 

--- a/pkg/harvester/list/harvesterhci.io.setting.vue
+++ b/pkg/harvester/list/harvesterhci.io.setting.vue
@@ -7,7 +7,7 @@ import { allHash } from '@shell/utils/promise';
 import Tabbed from '@shell/components/Tabbed/index.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 import Settings from '@pkg/harvester/components/SettingList.vue';
-import { HCI_ALLOWED_SETTINGS, HCI_SINGLE_CLUSTER_ALLOWED_SETTING } from '../config/settings';
+import { HCI_ALLOWED_SETTINGS, HCI_SINGLE_CLUSTER_ALLOWED_SETTING, HCI_SETTING } from '../config/settings';
 import { HCI } from '../types';
 
 export default {
@@ -68,7 +68,7 @@ export default {
       };
 
       s.hide = s.canHide = (s.kind === 'json' || s.kind === 'multiline' || s.customFormatter === 'json' || s.data.customFormatter === 'json');
-      s.hasActions = true;
+      s.hasActions = s.id === HCI_SETTING.SERVER_VERSION ? true : !s.readOnly;
       initSettings.push(s);
     });
 

--- a/pkg/harvester/models/harvesterhci.io.setting.js
+++ b/pkg/harvester/models/harvesterhci.io.setting.js
@@ -28,7 +28,9 @@ export default class HciSetting extends HarvesterResource {
     }
 
     const schema = this.$getters['schemaFor'](HCI.UPGRADE);
+    console.log("🚀 ~ HciSetting ~ get_availableActions ~ schema:", schema?.collectionMethods)
     const hasUpgradeAccess = !!schema?.collectionMethods.find((x) => ['post'].includes(x.toLowerCase()));
+    console.log("🚀 ~ HciSetting ~ get_availableActions ~ hasUpgradeAccess:", hasUpgradeAccess)
 
     if (this.id === HCI_SETTING.SERVER_VERSION && hasUpgradeAccess) {
       const latestUpgrade = this.$getters['all'](HCI.UPGRADE).find((upgrade) => upgrade.isLatestUpgrade);
@@ -38,7 +40,7 @@ export default class HciSetting extends HarvesterResource {
         enabled:  true,
         icon:     'icon icon-refresh',
         label:    this.t('harvester.upgradePage.upgrade'),
-        disabled: !!latestUpgrade && !latestUpgrade?.isUpgradeSucceeded
+        disabled: !!latestUpgrade && latestUpgrade?.isUpgradeSucceeded
       });
     }
 

--- a/pkg/harvester/models/harvesterhci.io.setting.js
+++ b/pkg/harvester/models/harvesterhci.io.setting.js
@@ -28,9 +28,8 @@ export default class HciSetting extends HarvesterResource {
     }
 
     const schema = this.$getters['schemaFor'](HCI.UPGRADE);
-    console.log("🚀 ~ HciSetting ~ get_availableActions ~ schema:", schema?.collectionMethods)
+
     const hasUpgradeAccess = !!schema?.collectionMethods.find((x) => ['post'].includes(x.toLowerCase()));
-    console.log("🚀 ~ HciSetting ~ get_availableActions ~ hasUpgradeAccess:", hasUpgradeAccess)
 
     if (this.id === HCI_SETTING.SERVER_VERSION && hasUpgradeAccess) {
       const latestUpgrade = this.$getters['all'](HCI.UPGRADE).find((upgrade) => upgrade.isLatestUpgrade);

--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -305,7 +305,7 @@ export default class HciVmImage extends HarvesterResource {
   }
 
   get uploadImage() {
-    return async(file) => {
+    return async(file, opt) => {
       const formData = new FormData();
 
       formData.append('chunk', file);
@@ -319,6 +319,7 @@ export default class HciVmImage extends HarvesterResource {
             'File-Size':    file.size,
           },
           params: { size: file.size },
+          signal: opt.signal,
         });
       } catch (err) {
         this.$ctx.commit('harvester-common/uploadError', { name: this.name, message: err.message }, { root: true });

--- a/pkg/harvester/pages/c/_cluster/airgapupgrade/index.vue
+++ b/pkg/harvester/pages/c/_cluster/airgapupgrade/index.vue
@@ -7,7 +7,6 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import UpgradeInfo from '../../../../components/UpgradeInfo';
-
 import { HCI } from '../../../../types';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../../../config/harvester';
 
@@ -112,7 +111,7 @@ export default {
 
     async save(buttonCb) {
       let res = null;
-
+      console.log('imageValue=',this.imageValue)
       this.errors = [];
       if (!this.imageValue.spec.displayName && this.uploadImage) {
         this.errors.push(this.$store.getters['i18n/t']('validation.required', { key: this.t('generic.name') }));
@@ -196,7 +195,7 @@ export default {
         const splitName = suffixName?.split('.') || [];
         const fileSuffix = splitName?.pop()?.toLowerCase();
 
-        if (splitName.length > 1 && fileSuffix === 'iso' && !this.imageValue.spec.displayName) {
+        if (splitName.length > 1 && fileSuffix === 'iso' && suffixName !== this.imageValue.spec.displayName) {
           this.imageValue.spec.displayName = suffixName;
         }
       },
@@ -204,7 +203,8 @@ export default {
     },
 
     file(neu) {
-      if (!this.imageValue.spec.displayName && neu.name) {
+      // update name input if select new image
+      if (neu.name && neu.name !== this.imageValue.spec.displayName) {
         this.imageValue.spec.displayName = neu.name;
       }
     }
@@ -249,7 +249,7 @@ export default {
 
       <div v-if="uploadImage">
         <LabeledInput
-          v-model.trim="imageValue.spec.displayName"
+          v-model:value.trim="imageValue.spec.displayName"
           class="mb-20"
           label-key="harvester.fields.name"
           required
@@ -285,7 +285,7 @@ export default {
 
         <LabeledInput
           v-if="sourceType === 'download'"
-          v-model.trim="imageValue.spec.url"
+          v-model:value.trim="imageValue.spec.url"
           class="labeled-input--tooltip"
           required
           label-key="harvester.image.url"
@@ -334,6 +334,7 @@ export default {
 
 <style lang="scss" scoped>
 #air-gap {
+  padding: 20px;
   :deep() .image-group .radio-group {
     display: flex;
     .radio-container {

--- a/pkg/harvester/pages/c/_cluster/airgapupgrade/index.vue
+++ b/pkg/harvester/pages/c/_cluster/airgapupgrade/index.vue
@@ -52,9 +52,10 @@ export default {
         checksum:    ''
       },
     });
-
+   
     this.value = value;
     this.imageValue = imageValue;
+    console.log('imageValue=', this.imageValue)
   },
 
   data() {
@@ -111,7 +112,7 @@ export default {
 
     async save(buttonCb) {
       let res = null;
-      console.log('imageValue=',this.imageValue)
+      
       this.errors = [];
       if (!this.imageValue.spec.displayName && this.uploadImage) {
         this.errors.push(this.$store.getters['i18n/t']('validation.required', { key: this.t('generic.name') }));
@@ -125,23 +126,23 @@ export default {
           this.imageValue.metadata.annotations[HCI_ANNOTATIONS.OS_UPGRADE_IMAGE] = 'True';
 
           if (this.sourceType === UPLOAD) {
-            this.imageValue.spec.sourceType = UPLOAD;
-            const file = this.file;
+            // this.imageValue.spec.sourceType = UPLOAD;
+            // const file = this.file;
 
-            if (!file.name) {
-              this.errors.push(this.$store.getters['i18n/t']('harvester.setting.upgrade.selectExitImage'));
-              buttonCb(false);
+            // if (!file.name) {
+            //   this.errors.push(this.$store.getters['i18n/t']('harvester.setting.upgrade.selectExitImage'));
+            //   buttonCb(false);
 
-              return;
-            }
+            //   return;
+            // }
 
-            this.imageValue.spec.url = '';
+            // this.imageValue.spec.url = '';
 
-            this.imageValue.metadata.annotations[HCI_ANNOTATIONS.IMAGE_NAME] = file.name;
+            // this.imageValue.metadata.annotations[HCI_ANNOTATIONS.IMAGE_NAME] = file.name;
 
-            res = await this.imageValue.save();
+            // res = await this.imageValue.save();
 
-            res.uploadImage(file);
+            // res.uploadImage(file);
           } else if (this.sourceType === DOWNLOAD) {
             this.imageValue.spec.sourceType = DOWNLOAD;
             if (!this.imageValue.spec.url) {
@@ -178,8 +179,29 @@ export default {
       }
     },
 
-    handleFileUpload() {
+    async uploadFile(file){
+      this.imageValue.spec.sourceType = UPLOAD;
+      // const file = this.file;
+
+      if (!file.name) {
+        this.errors.push(this.$store.getters['i18n/t']('harvester.setting.upgrade.selectExitImage'));
+        // buttonCb(false);
+
+        return;
+      }
+
+      this.imageValue.spec.url = '';
+
+      this.imageValue.metadata.annotations[HCI_ANNOTATIONS.IMAGE_NAME] = file.name;
+
+      res = await this.imageValue.save();
+
+      res.uploadImage(file);
+    },
+
+    async handleFileUpload() {
       this.file = this.$refs.file.files[0];
+      await this.uploadFile(this.file)
     },
 
     selectFile() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Two changes : 
1. Make upgrade button visible even not enable "View in API".
2. When user chooses an OS image, upload it immediately with progress bar.
 
### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @brandboat 

### Related Issue #
- https://github.com/harvester/harvester/issues/7690
- https://github.com/harvester/harvester/issues/8079

### Test screenshot/video

https://github.com/user-attachments/assets/d0640e6b-18f5-44cd-916b-c066b2b860e0



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


