### PR TITLE
fix: VM's machine type options is not support

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -37,7 +37,9 @@ const FEATURE_FLAGS = {
     'liveMigrationProgress'
   ],
   'v1.5.1': [],
-  'v1.6.0': []
+  'v1.6.0': [
+    'vmMachineTypes'
+  ]
 };
 
 const generateFeatureFlags = () => {

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -114,13 +114,11 @@ export default {
     },
 
     machineTypeOptions() {
-      return this.value.vmMachineTypesFeatureEnabled ? this.machineTypes.map((type) => ({ label: type, value: type })) : [{
-        label: 'None',
-        value: ''
-      }, {
-        label: 'q35',
-        value: 'q35'
-      }];
+      return this.machineTypes.map((type) => {
+        if (!type) return { label: 'None', value: '' };
+
+        return { label: type, value: type };
+      });
     },
 
     templateOptions() {

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -114,13 +114,7 @@ export default {
     },
 
     machineTypeOptions() {
-      return [{
-        label: 'None',
-        value: ''
-      }, {
-        label: 'q35',
-        value: 'q35'
-      }];
+      return this.machineTypes.map((type) => ({ label: type, value: type }));
     },
 
     templateOptions() {

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -114,7 +114,13 @@ export default {
     },
 
     machineTypeOptions() {
-      return this.machineTypes.map((type) => ({ label: type, value: type }));
+      return this.value.vmMachineTypesFeatureEnabled ? this.machineTypes.map((type) => ({ label: type, value: type })) : [{
+        label: 'None',
+        value: ''
+      }, {
+        label: 'q35',
+        value: 'q35'
+      }];
     },
 
     templateOptions() {

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -72,6 +72,8 @@ export const OS = [{
 export const CD_ROM = 'cd-rom';
 export const HARD_DISK = 'disk';
 
+const MACHINE_TYPES = ['q35'];
+
 export default {
   mixins: [impl],
 
@@ -302,7 +304,7 @@ export default {
 
   async created() {
     await this.$store.dispatch(`${ this.inStore }/findAll`, { type: SECRET });
-    const machineTypes = await this.$store.dispatch('harvester/request', { url: '/v1/harvester/clusters/local?link=machineTypes' });
+    const machineTypes = this.value.vmMachineTypesFeatureEnabled ? await this.$store.dispatch('harvester/request', { url: '/v1/harvester/clusters/local?link=machineTypes' }) : MACHINE_TYPES;
 
     this.machineTypes = machineTypes;
     this.getInitConfig({ value: this.value, init: this.isCreate });

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -296,7 +296,7 @@ export default {
 
   async created() {
     await this.$store.dispatch(`${ this.inStore }/findAll`, { type: SECRET });
-    const machineTypes = this.value.vmMachineTypesFeatureEnabled ? await this.$store.dispatch('harvester/request', { url: '/v1/harvester/clusters/local?link=machineTypes' }) : [];
+    const machineTypes = this.value.vmMachineTypesFeatureEnabled ? await this.$store.dispatch('harvester/request', { url: '/v1/harvester/clusters/local?link=machineTypes' }) : [''];
 
     this.machineTypes = machineTypes;
     this.getInitConfig({ value: this.value, init: this.isCreate });

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -72,8 +72,6 @@ export const OS = [{
 export const CD_ROM = 'cd-rom';
 export const HARD_DISK = 'disk';
 
-const MACHINE_TYPES = ['q35'];
-
 export default {
   mixins: [impl],
 
@@ -282,12 +280,6 @@ export default {
       return Number(setting?.value || setting?.default);
     },
 
-    defaultMachineType() {
-      if (this.machineTypes.includes('q35')) return 'q35';
-
-      return this.machineTypes[0];
-    },
-
     affinityLabels() {
       return {
         namespaceInputLabel:      this.t('harvester.virtualMachine.affinity.namespaces.label'),
@@ -304,7 +296,7 @@ export default {
 
   async created() {
     await this.$store.dispatch(`${ this.inStore }/findAll`, { type: SECRET });
-    const machineTypes = this.value.vmMachineTypesFeatureEnabled ? await this.$store.dispatch('harvester/request', { url: '/v1/harvester/clusters/local?link=machineTypes' }) : MACHINE_TYPES;
+    const machineTypes = this.value.vmMachineTypesFeatureEnabled ? await this.$store.dispatch('harvester/request', { url: '/v1/harvester/clusters/local?link=machineTypes' }) : [];
 
     this.machineTypes = machineTypes;
     this.getInitConfig({ value: this.value, init: this.isCreate });
@@ -343,7 +335,7 @@ export default {
       const maintenanceStrategy = vm.metadata.labels?.[HCI_ANNOTATIONS.VM_MAINTENANCE_MODE_STRATEGY] || 'Migrate';
 
       const runStrategy = spec.runStrategy || 'RerunOnFailure';
-      const machineType = spec.template.spec.domain?.machine?.type || this.defaultMachineType;
+      const machineType = spec.template.spec.domain?.machine?.type || this.machineTypes[0];
 
       const cpu = spec.template.spec.domain?.cpu?.cores;
       const memory = spec.template.spec.domain.resources.limits.memory;

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -1205,6 +1205,10 @@ export default class VirtVm extends HarvesterResource {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('thirdPartyStorage');
   }
 
+  get vmMachineTypesFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('vmMachineTypes');
+  }
+
   setInstanceLabels(val) {
     if ( !this.spec?.template?.metadata?.labels ) {
       set(this, 'spec.template.metadata.labels', {});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Render machine type options based on the backend API response
- API endpoint: `${URL}/v1/harvester/cluster/local?link=machineType`

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [x] Yes, the backend owner is: @ibrokethecloud 

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[GUI] [BUG] VM's machine type options is not support #7357](https://github.com/harvester/harvester/issues/7357)

### Test screenshot/video
- Navigate to the VM page and create a VM
- Verify that the machine type options include `q35` and `pc-q35` for an AMD64 cluster.
- Verify that the machine type option includes `virt` for an ARM64 cluster.

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/9dab1568-9b62-4377-b7c4-7454121b517a



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


