### PR TITLE
fix: Harvester upgrade ISO related internal image can be selected to create VM when an upgrade is ongoing

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -35,6 +35,7 @@ export const HCI = {
   NODE_SCHEDULABLE:                 'kubevirt.io/schedulable',
   NETWORK_ROUTE:                    'network.harvesterhci.io/route',
   MATCHED_NODES:                    'network.harvesterhci.io/matched-nodes',
+  UPGRADE:                          'harvesterhci.io/upgrade',
   OS_UPGRADE_IMAGE:                 'harvesterhci.io/os-upgrade-image',
   LATEST_UPGRADE:                   'harvesterhci.io/latestUpgrade',
   UPGRADE_STATE:                    'harvesterhci.io/upgradeState',

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -8,6 +8,7 @@ import { Banner } from '@components/Banner';
 import { PVC } from '@shell/config/types';
 import { formatSi, parseSi } from '@shell/utils/units';
 import { HCI } from '../../../../types';
+import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import { VOLUME_TYPE, InterfaceOption } from '../../../../config/harvester-map';
 import { _VIEW } from '@shell/config/query-params';
 import LabelValue from '@shell/components/LabelValue';
@@ -70,6 +71,7 @@ export default {
     return {
       GIBIBYTE,
       VOLUME_TYPE,
+      HCI_ANNOTATIONS,
       InterfaceOption,
       loading: false,
       images:  [],
@@ -97,7 +99,7 @@ export default {
           // exclude internal images created during upgrade
           const isInternalCreatedImage =
             image.namespace === 'harvester-system' &&
-            image.labels?.['harvesterhci.io/upgrade'];
+            image.labels?.[HCI_ANNOTATIONS.UPGRADE];
 
           return !isInternalCreatedImage;
         })

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -90,12 +90,22 @@ export default {
     },
 
     imagesOption() {
-      return this.images.filter((c) => c.isReady).sort((a, b) => a.creationTimestamp > b.creationTimestamp ? -1 : 1).map( (I) => {
-        return {
-          label: this.imageOptionLabel(I),
-          value: I.id
-        };
-      });
+      return this.images
+        .filter((image) => {
+          if (!image.isReady) return false;
+
+          // exclude internal images created during upgrade
+          const isInternalCreatedImage =
+            image.namespace === 'harvester-system' &&
+            image.labels?.['harvesterhci.io/upgrade'];
+
+          return !isInternalCreatedImage;
+        })
+        .sort((a, b) => (a.creationTimestamp > b.creationTimestamp ? -1 : 1))
+        .map((image) => ({
+          label: this.imageOptionLabel(image),
+          value: image.id,
+        }));
     },
 
     imageName() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Filter out internal created image when upgrading

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] Harvester upgrade ISO related internal image can be selected to create VM when an upgrade is ongoing #8277
](https://github.com/harvester/harvester/issues/8277)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Trigger an upgrade and wait for the image to finish downloading
- Create a VM, the upgrade image should not appear in the image dropdown
- Same behavior should apply to the vm `Templates` page

https://github.com/user-attachments/assets/8eafb47f-4874-4b04-91f3-325464b8ed86



### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


