### PR TITLE
fix: disable harvesterhci.io/imageDisplayName label in edit VM lmage page

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -67,5 +67,6 @@ export const HCI = {
   VM_DEVICE_ALLOCATION_DETAILS:     'harvesterhci.io/deviceAllocationDetails',
   SVM_BACKUP_ID:                    'harvesterhci.io/svmbackupId',
   DISABLE_LONGHORN_V2_ENGINE:       'node.longhorn.io/disable-v2-data-engine',
-  K8S_ARCH:                         'kubernetes.io/arch'
+  K8S_ARCH:                         'kubernetes.io/arch',
+  IMAGE_DISPLAY_NAME:               'harvesterhci.io/imageDisplayName'
 };

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
@@ -110,6 +110,7 @@ export default {
       headers:        {},
       fileUrl:        '',
       file:           '',
+      HCI_ANNOTATIONS,
     };
   },
 
@@ -595,6 +596,8 @@ export default {
           :pad-left="false"
           :read-allowed="false"
           :value-can-be-empty="true"
+          :toggle-filter="true"
+          :protected-keys="[HCI_ANNOTATIONS.IMAGE_DISPLAY_NAME]"
           @focusKey="focusKey"
           @update:value="value.setLabels($event)"
         >
@@ -611,7 +614,7 @@ export default {
             <input
               v-else
               v-model="row[valueName]"
-              :disabled="isView"
+              :disabled="isView || row[keyName] === HCI_ANNOTATIONS.IMAGE_DISPLAY_NAME"
               :type="'text'"
               :placeholder="t('keyValue.valuePlaceholder')"
               autocorrect="off"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Disable the row if the key is `harvesterhci.io/imageDisplayName`

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] Disable harvesterhci.io/imageDisplayName label in edit VM lmage page #6031](https://github.com/harvester/harvester/issues/6031)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Navigate to Images -> Edit Config -> Labels tab
- Locate the row with key `harvesterhci.io/imageDisplayName` and verify both inputs are disabled

![issue-6031](https://github.com/user-attachments/assets/a9d4f10e-ae22-4f65-b56e-60313c970478)

### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

