### PR TITLE
feat: support manually configuring VM IP

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -68,5 +68,6 @@ export const HCI = {
   SVM_BACKUP_ID:                    'harvesterhci.io/svmbackupId',
   DISABLE_LONGHORN_V2_ENGINE:       'node.longhorn.io/disable-v2-data-engine',
   K8S_ARCH:                         'kubernetes.io/arch',
-  IMAGE_DISPLAY_NAME:               'harvesterhci.io/imageDisplayName'
+  IMAGE_DISPLAY_NAME:               'harvesterhci.io/imageDisplayName',
+  CUSTOM_IP:                        'harvesterhci.io/custom-ip'
 };

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -189,9 +189,15 @@ export default {
         }
 
         this.value.spec['templateId'] = `${ namespace }/${ name }`;
+
+        // inherit labels and annotations so the VM gets them when created from the template
         this.value.spec.vm.metadata.labels = {
           ...this.value.spec.vm.metadata.labels,
           ...this.value.metadata.labels
+        };
+        this.value.spec.vm.metadata.annotations = {
+          ...this.value.spec.vm.metadata.annotations,
+          ...this.value.metadata.annotations
         };
         const res = await this.value.save();
 
@@ -361,6 +367,26 @@ export default {
           :read-allowed="false"
           :value-can-be-empty="true"
           @update:value="value.setInstanceLabels($event)"
+        />
+      </Tab>
+      <Tab
+        name="annotations"
+        :label="t('harvester.tab.annotations')"
+        :weight="-11"
+      >
+        <Banner color="info">
+          <t k="harvester.virtualMachine.annotations.banner" />
+        </Banner>
+        <KeyValue
+          key="annotations"
+          :value="value.annotations"
+          :protected-keys="value.systemAnnotations || []"
+          :toggle-filter="true"
+          :add-label="t('labels.addAnnotation')"
+          :mode="mode"
+          :read-allowed="false"
+          :value-can-be-empty="true"
+          @update:value="value.setAnnotations($event)"
         />
       </Tab>
       <Tab

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -255,9 +255,10 @@ export default {
 
         cloneVersionVM.metadata.annotations[HCI_ANNOTATIONS.VOLUME_CLAIM_TEMPLATE] = JSON.stringify(deleteDataSource);
 
-        // Update labels and instance labels value
+        // Update labels, instance labels and annotations
         this.value.metadata.labels = cloneVersionVM.metadata.labels;
         this.value.spec.template.metadata.labels = cloneVersionVM.spec.template.metadata.labels;
+        this.value.metadata.annotations = cloneVersionVM.metadata.annotations;
 
         this.getInitConfig({
           value: cloneVersionVM, existUserData: true, fromTemplate: true

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -765,9 +765,30 @@ export default {
       </Tab>
 
       <Tab
+        name="annotations"
+        :label="t('harvester.tab.annotations')"
+        :weight="-11"
+      >
+        <Banner color="info">
+          <t k="harvester.virtualMachine.annotations.banner" />
+        </Banner>
+        <KeyValue
+          key="annotations"
+          :value="value.annotations"
+          :protected-keys="value.systemAnnotations || []"
+          :toggle-filter="toggler"
+          :add-label="t('labels.addAnnotation')"
+          :mode="mode"
+          :read-allowed="false"
+          :value-can-be-empty="true"
+          @update:value="value.setAnnotations($event)"
+        />
+      </Tab>
+
+      <Tab
         name="advanced"
         :label="t('harvester.tab.advanced')"
-        :weight="-11"
+        :weight="-12"
       >
         <div class="row mb-20">
           <div class="col span-6">

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -229,6 +229,8 @@ harvester:
           {count, plural,
           =1 {core}
           other {cores}}
+    harvesterIpAddress:
+      customIpTooltip: "Custom IP (set via annotation)"
   tableHeaders:
     imageEncryption: Encryption
     size: Size

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -276,6 +276,7 @@ harvester:
     quotas: Quotas
     snapshots: Snapshots
     instanceLabel: Instance Labels
+    annotations: Annotations
   fields:
     version: Version
     name: Name
@@ -792,6 +793,8 @@ harvester:
       banner: These labels are automatically synchronized to the virtual machine instance.
     labels:
       banner: These key values are added as labels to the virtual machine.
+    annotations:
+      banner: These key values are added as annotations to the virtual machine.
 
   volume:
     label: Volumes

--- a/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
@@ -284,4 +284,10 @@ export default class HciVmTemplateVersion extends HarvesterResource {
   get efiPersistentStateFeatureEnabled() {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('efiPersistentState');
   }
+
+  get systemAnnotations() {
+    const annotations = this.annotations || {};
+
+    return Object.keys(annotations).filter((key) => key.includes(HCI_ANNOTATIONS.TEMPLATE_VERSION_CUSTOM_NAME));
+  }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Added `Annotations` tab in the VM config
- Display custom IP in the `IP Address` column

### PR Checklists
- Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?
    - [ ] Yes, the relevant PR is at:
- Are backend engineers aware of UI changes?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[FEATURE] Support manually configuring VM IP #7299](https://github.com/harvester/harvester/issues/7299)

### Test screenshot/video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**Case 1: create VM**
- Create a VM without any networks
- Add the annotation `harvesterhci.io/custom-ip: 192.168.1.1`
- In the `IP Address` column, `192.168.1.1` should be displayed as plain text color.
- Hover over the IP address, it shows tooltip with the content `Custom IP (set via annotation)`

https://github.com/user-attachments/assets/29a8bed9-e266-42f4-9b08-ad2367b6a524

**Case 2: create VM from template**
- Create a VM template without any networks and annotation `harvesterhci.io/custom-ip: 192.168.1.1`
- Create a VM with that template
- The custom should be displayed in the `IP Address` column

https://github.com/user-attachments/assets/bd043892-bf42-4848-b4c6-4dae2faa6993


### Extra technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


