### PR TITLE
fix: Labels and Instance Labels from VM template are not applied when creating VM

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -189,6 +189,10 @@ export default {
         }
 
         this.value.spec['templateId'] = `${ namespace }/${ name }`;
+        this.value.spec.vm.metadata.labels = {
+          ...this.value.spec.vm.metadata.labels,
+          ...this.value.metadata.labels
+        };
         const res = await this.value.save();
 
         await this.saveSecret(res);

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -255,6 +255,10 @@ export default {
 
         cloneVersionVM.metadata.annotations[HCI_ANNOTATIONS.VOLUME_CLAIM_TEMPLATE] = JSON.stringify(deleteDataSource);
 
+        // Update labels and instance labels value
+        this.value.metadata.labels = cloneVersionVM.metadata.labels;
+        this.value.spec.template.metadata.labels = cloneVersionVM.spec.template.metadata.labels;
+
         this.getInitConfig({
           value: cloneVersionVM, existUserData: true, fromTemplate: true
         });

--- a/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachinetemplateversion.js
@@ -60,11 +60,11 @@ export default class HciVmTemplateVersion extends HarvesterResource {
   applyDefaults() {
     const spec = {
       vm: {
-        metadata: { annotations: { [HCI_ANNOTATIONS.VOLUME_CLAIM_TEMPLATE]: '[]' } },
+        metadata: { annotations: { [HCI_ANNOTATIONS.VOLUME_CLAIM_TEMPLATE]: '[]' }, labels: {} },
         spec:     {
           runStrategy: 'RerunOnFailure',
           template:    {
-            metadata: { annotations: {} },
+            metadata: { annotations: {}, labels: {} },
             spec:     {
               domain: {
                 machine: { type: '' },

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -233,7 +233,7 @@ export default class VirtVm extends HarvesterResource {
     const spec = {
       runStrategy: 'RerunOnFailure',
       template:    {
-        metadata: { annotations: {} },
+        metadata: { annotations: {}, labels: {} },
         spec:     {
           domain: {
             machine: { type: '' },
@@ -283,6 +283,7 @@ export default class VirtVm extends HarvesterResource {
 
     if (realMode !== _CLONE) {
       this.metadata['annotations'] = { [HCI_ANNOTATIONS.VOLUME_CLAIM_TEMPLATE]: '[]' };
+      this.metadata['labels'] = {};
       this['spec'] = spec;
     }
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Inherit `Labels` and `Instance Labels` from VM template

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[BUG] Labels and Instance Labels from VM template are not applied when creating VM [#8394](https://github.com/harvester/harvester/issues/8394)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Go to `Advanced` -> `Templates`
- Create a template, and set values for `Labels` and `Instance Labels`
- Use this template to create a new VM
- Inspect the new VM's `Labels` and `Instance Labels`, it should inherit both from template

https://github.com/user-attachments/assets/eb2d5375-1d6c-48e5-934e-992628e87e6e


