### PR TITLE
feat: add confirmation modal for vm soft reboot and restart

### DIFF
--- a/pkg/harvester/dialog/ConfirmExecutionDialog.vue
+++ b/pkg/harvester/dialog/ConfirmExecutionDialog.vue
@@ -130,7 +130,7 @@ export default {
     <template #body>
       <div class="pl-10 pr-10">
         <span
-          v-clean-html="t(warningMessageKey, { type, names: resourceNames }, true)"
+          v-clean-html="t(warningMessageKey, { action: modalData.action, type, names: resourceNames }, true)"
         ></span>
         <div class="text-info mt-20">
           {{ protip }}

--- a/pkg/harvester/dialog/ConfirmExecutionDialog.vue
+++ b/pkg/harvester/dialog/ConfirmExecutionDialog.vue
@@ -130,7 +130,7 @@ export default {
     <template #body>
       <div class="pl-10 pr-10">
         <span
-          v-clean-html="t(warningMessageKey, { action: modalData.action, type, names: resourceNames }, true)"
+          v-clean-html="t(warningMessageKey, { type, names: resourceNames }, true)"
         ></span>
         <div class="text-info mt-20">
           {{ protip }}

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -48,10 +48,7 @@ dialog:
       other { and <b>{count} other </b>}
       }
     protip: "Tip: Hold the {alternateLabel} key while clicking action to bypass this confirmation"
-    stop:
-      message: "Are you sure you want to continue stop the {type} {names}?"
-    pause:
-      message: "Are you sure you want to continue pause the {type} {names}?"
+    warningMessage: "Are you sure you want to continue {action} the {type} {names}?"
   promptRemove:
     title: "Delete {type}"
     warningMessage: "Deleting the selected {type} permanently removes all resources on {thisOrThese} {type}. This action is irreversible. Do you want to continue?"
@@ -66,7 +63,6 @@ harvester:
       tip: 'Upload an icon to replace the Harvester favicon in the browser tab. Max file size is 20KB'
   productLabel: 'Harvester'
   modal:
-    
     backup:
       success: 'Backup { backUpName } has been initiated.'
       addBackup: Add Backup
@@ -897,7 +893,7 @@ harvester:
     releaseTip: Please read the upgrade documentation carefully. You can view details on the <a href="{url}" target="_blank">Harvester Release Notes</a>.
     checkReady: I have read and understood the upgrade instructions related to this Harvester version.
     pending: Pending
-    upload: 
+    upload:
       duplicatedFile: The file you are trying to upload already exists.
     repoInfo:
       upgradeStatus: Upgrade Status

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -48,7 +48,14 @@ dialog:
       other { and <b>{count} other </b>}
       }
     protip: "Tip: Hold the {alternateLabel} key while clicking action to bypass this confirmation"
-    warningMessage: "Are you sure you want to continue {action} the {type} {names}?"
+    stop:
+      message: "Are you sure you want to stop the {type} {names}?"
+    pause:
+      message: "Are you sure you want to pause the {type} {names}?"
+    restart:
+      message: "Are you sure you want to restart the {type} {names}?"
+    softreboot:
+      message: "Are you sure you want to soft reboot the {type} {names}?"
   promptRemove:
     title: "Delete {type}"
     warningMessage: "Deleting the selected {type} permanently removes all resources on {thisOrThese} {type}. This action is irreversible. Do you want to continue?"

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -312,12 +312,22 @@ export default class VirtVm extends HarvesterResource {
     this.metadata.annotations[HCI_ANNOTATIONS.VOLUME_CLAIM_TEMPLATE] = JSON.stringify(deleteDataSource);
   }
 
-  restartVM() {
-    this.doActionGrowl('restart', {});
+  restartVM(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      action:            'restart',
+      warningMessageKey: 'dialog.confirmExecution.warningMessage',
+      component:         'ConfirmExecutionDialog'
+    });
   }
 
-  softrebootVM() {
-    this.doActionGrowl('softreboot', {});
+  softrebootVM(resources = this) {
+    this.$dispatch('promptModal', {
+      resources,
+      action:            'softreboot',
+      warningMessageKey: 'dialog.confirmExecution.warningMessage',
+      component:         'ConfirmExecutionDialog'
+    });
   }
 
   openLogs() {
@@ -410,7 +420,7 @@ export default class VirtVm extends HarvesterResource {
     this.$dispatch('promptModal', {
       resources,
       action:            'pause',
-      warningMessageKey: 'dialog.confirmExecution.pause.message',
+      warningMessageKey: 'dialog.confirmExecution.warningMessage',
       component:         'ConfirmExecutionDialog'
     });
   }
@@ -434,7 +444,7 @@ export default class VirtVm extends HarvesterResource {
     this.$dispatch('promptModal', {
       resources,
       action:            'stop',
-      warningMessageKey: 'dialog.confirmExecution.stop.message',
+      warningMessageKey: 'dialog.confirmExecution.warningMessage',
       component:         'ConfirmExecutionDialog'
     });
   }

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -131,11 +131,12 @@ export default class VirtVm extends HarvesterResource {
         label:   this.t('harvester.action.unpause')
       },
       {
-        action:   'restartVM',
-        enabled:  !!this.actions?.restart,
-        icon:     'icon icon-refresh',
-        label:    this.t('harvester.action.restart'),
-        bulkable: true
+        action:     'restartVM',
+        enabled:    !!this.actions?.restart,
+        icon:       'icon icon-refresh',
+        label:      this.t('harvester.action.restart'),
+        bulkable:   true,
+        bulkAction: 'restartVM'
       },
       {
         action:  'softrebootVM',

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -316,7 +316,7 @@ export default class VirtVm extends HarvesterResource {
     this.$dispatch('promptModal', {
       resources,
       action:            'restart',
-      warningMessageKey: 'dialog.confirmExecution.warningMessage',
+      warningMessageKey: 'dialog.confirmExecution.restart.message',
       component:         'ConfirmExecutionDialog'
     });
   }
@@ -325,7 +325,7 @@ export default class VirtVm extends HarvesterResource {
     this.$dispatch('promptModal', {
       resources,
       action:            'softreboot',
-      warningMessageKey: 'dialog.confirmExecution.warningMessage',
+      warningMessageKey: 'dialog.confirmExecution.softreboot.message',
       component:         'ConfirmExecutionDialog'
     });
   }
@@ -420,7 +420,7 @@ export default class VirtVm extends HarvesterResource {
     this.$dispatch('promptModal', {
       resources,
       action:            'pause',
-      warningMessageKey: 'dialog.confirmExecution.warningMessage',
+      warningMessageKey: 'dialog.confirmExecution.pause.message',
       component:         'ConfirmExecutionDialog'
     });
   }
@@ -444,7 +444,7 @@ export default class VirtVm extends HarvesterResource {
     this.$dispatch('promptModal', {
       resources,
       action:            'stop',
-      warningMessageKey: 'dialog.confirmExecution.warningMessage',
+      warningMessageKey: 'dialog.confirmExecution.stop.message',
       component:         'ConfirmExecutionDialog'
     });
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- add confirmation for vm `softreboot` and `restart`

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[ENHANCEMENT][UI] Add confirmation pop-up for VM disruptive actions #8420](https://github.com/harvester/harvester/issues/8420)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Navigate to the Virtual Machines list page
- Perform `Restart` and `Soft Reboot` action on a VM
- A confirmation modal should appear before the action is executed

https://github.com/user-attachments/assets/114e5312-8198-436d-98fb-c35d95475456


