### PR TITLE
Fix uploading image stuck at edit page

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachineimage.vue
@@ -291,7 +291,7 @@ export default {
 
           const res = await this.value.save();
 
-          await res.uploadImage(file);
+          res.uploadImage(file);
 
           buttonCb(true);
           this.done();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

After clicking create button, the uploading image stuck at edit page.
 
<img width="1493" alt="Screenshot 2025-06-11 at 2 49 31 PM" src="https://github.com/user-attachments/assets/9a60e7cf-4908-4ec9-90c1-563343a990ab" />

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7690

### Test screenshot or video

https://github.com/user-attachments/assets/c5c4e1b6-1c0e-4159-8b42-e26eb87f22af



