### PR TITLE
fix: failed to clone an image file created by file upload

### DIFF
--- a/pkg/harvester/detail/harvesterhci.io.virtualmachineimage/index.vue
+++ b/pkg/harvester/detail/harvesterhci.io.virtualmachineimage/index.vue
@@ -118,6 +118,10 @@ export default {
     imageName() {
       return this.value?.metadata?.annotations?.[HCI_ANNOTATIONS.IMAGE_NAME] || '-';
     },
+
+    sourceType() {
+      return this.value?.spec?.sourceType;
+    },
   }
 };
 </script>
@@ -249,6 +253,16 @@ export default {
           >
             &mdash;
           </span>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col span-12">
+          <LabelValue
+            :name="t('harvester.image.source')"
+            :value="sourceType"
+            class="mb-20"
+          />
         </div>
       </div>
 

--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -43,8 +43,8 @@ export default class HciVmImage extends HarvesterResource {
 
     out = out.filter( (A) => !toFilter.includes(A.action));
 
-    // filter out clone action if not encrypted or decrypted
-    if (!this.isEncrypted && !this.isDecrypted) {
+    // show `Clone` only when imageSource is `download`
+    if (this.imageSource !== 'download') {
       out = out.filter(({ action }) => action !== 'goToClone');
     }
 
@@ -207,13 +207,6 @@ export default class HciVmImage extends HarvesterResource {
   get isEncrypted() {
     return this.spec.sourceType === 'clone' &&
     this.spec.securityParameters?.cryptoOperation === 'encrypt' &&
-    !!this.spec.securityParameters?.sourceImageName &&
-    !!this.spec.securityParameters?.sourceImageNamespace;
-  }
-
-  get isDecrypted() {
-    return this.spec.sourceType === 'clone' &&
-    this.spec.securityParameters?.cryptoOperation === 'decrypt' &&
     !!this.spec.securityParameters?.sourceImageName &&
     !!this.spec.securityParameters?.sourceImageNamespace;
   }

--- a/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
+++ b/pkg/harvester/models/harvesterhci.io.virtualmachineimage.js
@@ -43,6 +43,11 @@ export default class HciVmImage extends HarvesterResource {
 
     out = out.filter( (A) => !toFilter.includes(A.action));
 
+    // filter out clone action if not encrypted or decrypted
+    if (!this.isEncrypted && !this.isDecrypted) {
+      out = out.filter(({ action }) => action !== 'goToClone');
+    }
+
     const schema = this.$getters['schemaFor'](HCI.VM);
     let canCreateVM = true;
 
@@ -202,6 +207,13 @@ export default class HciVmImage extends HarvesterResource {
   get isEncrypted() {
     return this.spec.sourceType === 'clone' &&
     this.spec.securityParameters?.cryptoOperation === 'encrypt' &&
+    !!this.spec.securityParameters?.sourceImageName &&
+    !!this.spec.securityParameters?.sourceImageNamespace;
+  }
+
+  get isDecrypted() {
+    return this.spec.sourceType === 'clone' &&
+    this.spec.securityParameters?.cryptoOperation === 'decrypt' &&
     !!this.spec.securityParameters?.sourceImageName &&
     !!this.spec.securityParameters?.sourceImageNamespace;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Show `Clone` action only when the image resource type is `download`

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] Failed to clone an image file created by file upload, prompt 'File Name is required' error #7207](https://github.com/harvester/harvester/issues/7207)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Navigate to the Image list page
- Ensure the `Clone` action is visible for images with resource type `download`

https://github.com/user-attachments/assets/62977e02-f8c0-4bd6-9689-d45424cc2632
