### PR TITLE
Remove disabled for upgrade action

### DIFF
--- a/pkg/harvester/models/harvesterhci.io.setting.js
+++ b/pkg/harvester/models/harvesterhci.io.setting.js
@@ -32,14 +32,11 @@ export default class HciSetting extends HarvesterResource {
     const hasUpgradeAccess = !!schema?.collectionMethods.find((x) => ['post'].includes(x.toLowerCase()));
 
     if (this.id === HCI_SETTING.SERVER_VERSION && hasUpgradeAccess) {
-      const latestUpgrade = this.$getters['all'](HCI.UPGRADE).find((upgrade) => upgrade.isLatestUpgrade);
-
       out.unshift({
         action:   'goToAirgapUpgrade',
         enabled:  true,
         icon:     'icon icon-refresh',
         label:    this.t('harvester.upgradePage.upgrade'),
-        disabled: !!latestUpgrade && latestUpgrade?.isUpgradeSucceeded
       });
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
No mattter there is a cluster upgrade ongoing or not.  we allow user to enter the upgrade page.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @brandboat 

### Related Issue #
https://github.com/harvester/harvester/issues/8149#issuecomment-2970846032

### Test screenshot or video
<img width="1481" alt="image" src="https://github.com/user-attachments/assets/48b50774-01f9-44ea-803e-f6bd7f037128" />

