### PR TITLE
Align settings page actionMenu style with other pages

### DIFF
--- a/pkg/harvester/components/SettingList.vue
+++ b/pkg/harvester/components/SettingList.vue
@@ -1,6 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
-import ActionMenu from '@shell/components/ActionMenuShell.vue';
+import ActionMenu from '@shell/components/ActionMenuShell';
 import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
 import { HCI_ALLOWED_SETTINGS, HCI_SETTING } from '../config/settings';
@@ -231,7 +231,7 @@ export default {
           :id="setting.id"
           class="action"
         >
-          <action-menu
+          <ActionMenu
             :resource="setting.data"
             :button-aria-label="t('advancedSettings.edit.label')"
             data-testid="action-button"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Align settings page actionMeun with other pages and Rancher settings.

https://github.com/rancher/dashboard/blob/6932a30d4e0dd9f21ec178412f42fb5b03fde3ec/shell/components/Setting.vue#L44-L49

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
[[UI][ENHANCEMENT] Align setting page popup menu style with other pages](https://github.com/harvester/harvester/issues/8496)

### Test screenshot or video
<img width="1478" alt="Screenshot 2025-06-17 at 2 39 21 PM" src="https://github.com/user-attachments/assets/3d899dd7-6ebb-4f13-a919-0fedc136dbed" />


