### PR TITLE
fix: dynamic get VM's machine type API endpoint

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -296,9 +296,20 @@ export default {
 
   async created() {
     await this.$store.dispatch(`${ this.inStore }/findAll`, { type: SECRET });
-    const machineTypes = this.value.vmMachineTypesFeatureEnabled ? await this.$store.dispatch('harvester/request', { url: '/v1/harvester/clusters/local?link=machineTypes' }) : [''];
 
-    this.machineTypes = machineTypes;
+    if (this.value.vmMachineTypesFeatureEnabled) {
+      try {
+        const url = this.$store.getters['harvester-common/getHarvesterClusterUrl']('/v1/harvester/clusters/local?link=machineTypes');
+        const machineTypes = await this.$store.dispatch('harvester/request', { url });
+
+        this.machineTypes = machineTypes;
+      } catch (err) {
+        this.machineTypes = [''];
+      }
+    } else {
+      this.machineTypes = [''];
+    }
+
     this.getInitConfig({ value: this.value, init: this.isCreate });
   },
 

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -299,7 +299,7 @@ export default {
 
     if (this.value.vmMachineTypesFeatureEnabled) {
       try {
-        const url = this.$store.getters['harvester-common/getHarvesterClusterUrl']('/v1/harvester/clusters/local?link=machineTypes');
+        const url = this.$store.getters['harvester-common/getHarvesterClusterUrl']('v1/harvester/clusters/local?link=machineTypes');
         const machineTypes = await this.$store.dispatch('harvester/request', { url });
 
         this.machineTypes = machineTypes;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Dynamic get API endpoint based on the env

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[GUI] [BUG] VM's machine type options is not support #7357](https://github.com/harvester/harvester/issues/7357)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**Integration mode**
![issue-7357-integrate](https://github.com/user-attachments/assets/d3cba02d-2cd3-424a-99e5-d54f405edbd8)

**Standalone mode**
![issue-7357-standalone](https://github.com/user-attachments/assets/b2e46a92-24a4-4173-9388-680a41c9d1a9)


