### PR TITLE
ci: replace tag with github.event.release.tag_name

### DIFF
--- a/.github/workflows/build-extension-on-release.yml
+++ b/.github/workflows/build-extension-on-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Determine release tag
         id: determine_tag
         run: |
-          if [[ "${{ github.ref_name }}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+          if [[ "${{ github.event.release.tag_name }}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             RELEASE_TAG="harvester-${BASH_REMATCH[1]}"
             echo "${RELEASE_TAG}"
             echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
`github.ref_name` sometimes got empty which blocks build `.github/workflows/build-extension-on-release.yml`


<img width="837" alt="image" src="https://github.com/user-attachments/assets/942a7f32-c4cf-45bc-90df-b34476813e39" />

Refer
- https://github.com/orgs/community/discussions/64528#discussioncomment-6784503
- https://stackoverflow.com/questions/76999207/release-tag-is-sometimes-absent-in-the-workflow

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video

<img width="934" alt="image" src="https://github.com/user-attachments/assets/06cf3b08-0e43-47a1-a7c8-5882724064ad" />


See https://github.com/a110605/harvester-ui-extension/actions/runs/15922860098/job/44913421691


