### PR TITLE
ci: add mergify commands_restrictions

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,14 @@
 pull_request_rules:
-- name: Ask to resolve conflict
-  conditions:
-    - conflict
-  actions:
-    comment:
-      message: This pull request is now in conflict. Could you fix it @{{author}}? 🙏
+  - name: Ask to resolve conflict
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: This pull request is now in conflict. Could you fix it @{{author}}? 🙏
+
+commands_restrictions:
+  backport:
+    conditions:
+      - or:
+        - sender-permission>=write
+        - sender=github-actions[bot]


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- `github-actions[bot]` does not have sufficient permissions to use the mergify command
- Add `github-actions[bot]` to the sender whitelist

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


