### PR TITLE
feat: UI change for vmimages created by vm-import-controller

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -69,5 +69,6 @@ export const HCI = {
   DISABLE_LONGHORN_V2_ENGINE:       'node.longhorn.io/disable-v2-data-engine',
   K8S_ARCH:                         'kubernetes.io/arch',
   IMAGE_DISPLAY_NAME:               'harvesterhci.io/imageDisplayName',
-  CUSTOM_IP:                        'harvesterhci.io/custom-ip'
+  CUSTOM_IP:                        'harvesterhci.io/custom-ip',
+  IMPORTED_IMAGE:                   'migration.harvesterhci.io/imported'
 };

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -105,8 +105,9 @@ export default {
         })
         .sort((a, b) => (a.creationTimestamp > b.creationTimestamp ? -1 : 1))
         .map((image) => ({
-          label: this.imageOptionLabel(image),
-          value: image.id,
+          label:    this.imageOptionLabel(image),
+          value:    image.id,
+          disabled: image.isImportedImage
         }));
     },
 

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -878,6 +878,8 @@ harvester:
         uploading: "{name} is uploading, please do not refresh or close the page."
     checksum: Checksum
     checksumTip: Validate the image using the SHA512 checksum, if specified.
+    tooltip:
+      imported: Created automatically by the vm-import-controller
 
   vmTemplate:
     label: Templates

--- a/pkg/harvester/list/harvesterhci.io.virtualmachineimage.vue
+++ b/pkg/harvester/list/harvesterhci.io.virtualmachineimage.vue
@@ -90,6 +90,11 @@ export default {
                 v-if="row.isEncrypted"
                 class="icon icon-lock"
               />
+              <i
+                v-if="row.isImportedImage"
+                v-clean-tooltip="t('harvester.image.tooltip.imported')"
+                class="icon icon-info"
+              />
             </router-link>
             <span v-else>
               {{ row.nameDisplay }}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Add tooltip for imported images
- Disable actions for imported images
- Prevent creating VMs from imported images

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @ibrokethecloud 

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[ENHANCEMENT] UI change to hide vmimages created by vm-import-controller #8504](https://github.com/harvester/harvester/issues/8504)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Create an image with the label `migration.harvesterhci.io/imported` to simulate an imported image
- On the Images page:
  - The image should show a tooltip with the text `Created automatically by the vm-import-controller`
![image-tooltip](https://github.com/user-attachments/assets/469a3dd9-7a40-41e9-a1f9-326771b850b7)
  - The image actions should be limited to `Download`, `Download YAML`, and `Delete`
![disable-actions](https://github.com/user-attachments/assets/f77e05aa-86f8-4c31-89ce-fa592ee67882)
- On create VM page, imported image should be grayed out (not selectable)
![disable-vm-image](https://github.com/user-attachments/assets/4d5a2d7e-f8db-4330-9704-6ed043b971f0)

