### PR TITLE
feat: add csi-online-expand-validation setting

### DIFF
--- a/pkg/harvester/components/settings/csi-online-expand-validation.vue
+++ b/pkg/harvester/components/settings/csi-online-expand-validation.vue
@@ -1,0 +1,221 @@
+<script>
+import { _EDIT } from '@shell/config/query-params';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import InfoBox from '@shell/components/InfoBox';
+import { allHash } from '@shell/utils/promise';
+import { CSI_DRIVER } from '../../types';
+import { LONGHORN_DRIVER } from '@shell/config/types';
+
+export default {
+  name: 'CSIOnlineExpandValidation',
+
+  components: {
+    InfoBox,
+    LabeledSelect,
+  },
+
+  props: {
+    mode: {
+      type:    String,
+      default: _EDIT,
+    },
+    value: {
+      type:    Object,
+      default: () => ({}),
+    },
+    registerBeforeHook: {
+      type:     Function,
+      required: true,
+    },
+  },
+
+  async fetch() {
+    const inStore = this.$store.getters['currentProduct'].inStore;
+
+    await allHash({ csiDrivers: this.$store.dispatch(`${ inStore }/findAll`, { type: CSI_DRIVER }) });
+  },
+
+  data() {
+    const initValue = this.value.value || this.value.default || '{}';
+
+    return { configArr: this.parseValue(initValue) };
+  },
+
+  created() {
+    this.registerBeforeHook?.(this.willSave, 'willSave');
+  },
+
+  computed: {
+    inStore() {
+      return this.$store.getters['currentProduct'].inStore;
+    },
+
+    csiDrivers() {
+      return this.$store.getters[`${ this.inStore }/all`](CSI_DRIVER) || [];
+    },
+
+    provisioners() {
+      const usedKeys = this.configArr.map(({ key }) => key);
+
+      return this.csiDrivers
+        .filter(({ name }) => !usedKeys.includes(name))
+        .map(({ name }) => name);
+    },
+
+    provisionerValue() {
+      return [
+        { label: 'True', value: true },
+        { label: 'False', value: false },
+      ];
+    },
+
+    disableAdd() {
+      return this.configArr.length >= this.csiDrivers.length;
+    },
+  },
+
+  methods: {
+    parseValue(raw) {
+      try {
+        const json = JSON.parse(raw);
+
+        return Object.entries(json).map(([key, value]) => ({
+          key,
+          value: value === 'true' ? true : value === 'false' ? false : value,
+        }));
+      } catch {
+        // eslint-disable-next-line no-console
+        console.warn('[CSIOnlineExpandValidation] Invalid JSON:', raw);
+
+        return [];
+      }
+    },
+
+    stringifyConfig() {
+      const obj = {};
+
+      this.configArr.forEach(({ key, value }) => {
+        obj[key] = value;
+      });
+
+      return this.configArr.length ? JSON.stringify(obj) : '';
+    },
+
+    update() {
+      this.value.value = this.stringifyConfig();
+    },
+
+    willSave() {
+      const errors = [];
+
+      this.configArr.forEach(({ key }) => {
+        if (!key) {
+          errors.push(
+            this.t('validation.required', { key: this.t('harvester.setting.csiOnlineExpandValidation.provisioner') }, true)
+          );
+        }
+      });
+
+      this.value.value = this.stringifyConfig();
+
+      return errors.length ? Promise.reject(errors) : Promise.resolve();
+    },
+
+    disableEdit(driverKey) {
+      return driverKey === LONGHORN_DRIVER;
+    },
+
+    add() {
+      this.configArr.push({ key: '', value: true });
+    },
+
+    remove(index) {
+      this.configArr.splice(index, 1);
+      this.update();
+    },
+
+    useDefault() {
+      this.configArr = this.parseValue(this.value.default || '{}');
+      this.update();
+    },
+
+    onValueChange(idx, newVal) {
+      const val = newVal === 'true' ? true : newVal === 'false' ? false : newVal;
+
+      this.configArr[idx].value = val;
+      this.update();
+    },
+  },
+};
+</script>
+
+<template>
+  <div>
+    <InfoBox
+      v-for="(driver, idx) in configArr"
+      :key="idx"
+      class="box"
+    >
+      <button
+        class="role-link btn btn-sm remove"
+        type="button"
+        :disabled="disableEdit(driver.key)"
+        @click="remove(idx)"
+      >
+        <i class="icon icon-x" />
+      </button>
+
+      <div class="row">
+        <div class="col span-4">
+          <LabeledSelect
+            v-model:value="driver.key"
+            label-key="harvester.setting.csiOnlineExpandValidation.provisioner"
+            required
+            searchable
+            :mode="mode"
+            :disabled="disableEdit(driver.key)"
+            :options="provisioners"
+            @update:value="update"
+            @keydown.native.enter.prevent
+          />
+        </div>
+
+        <div class="col span-4">
+          <LabeledSelect
+            v-model:value="driver.value"
+            :value="driver.value.toString()"
+            label-key="harvester.setting.csiOnlineExpandValidation.value"
+            required
+            searchable
+            :mode="mode"
+            :disabled="disableEdit(driver.key)"
+            :options="provisionerValue"
+            @update:value="val => onValueChange(idx, val)"
+            @keydown.native.enter.prevent
+          />
+        </div>
+      </div>
+    </InfoBox>
+
+    <button
+      class="btn btn-sm role-primary"
+      :disabled="disableAdd"
+      @click="add"
+    >
+      {{ t('generic.add') }}
+    </button>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.box {
+  position: relative;
+  padding-top: 40px;
+}
+.remove {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 0;
+}
+</style>

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -40,7 +40,8 @@ const FEATURE_FLAGS = {
   'v1.5.1': [],
   'v1.6.0': [
     'vmMachineTypes',
-    'customSupportBundle'
+    'customSupportBundle',
+    'csiOnlineExpandValidation'
   ]
 };
 

--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -28,6 +28,7 @@ export const HCI_SETTING = {
   RELEASE_DOWNLOAD_URL:                   'release-download-url',
   CCM_CSI_VERSION:                        'harvester-csi-ccm-versions',
   CSI_DRIVER_CONFIG:                      'csi-driver-config',
+  CSI_ONLINE_EXPAND_VALIDATION:           'csi-online-expand-validation',
   VM_TERMINATION_PERIOD:                  'default-vm-termination-grace-period-seconds',
   NTP_SERVERS:                            'ntp-servers',
   AUTO_ROTATE_RKE2_CERTS:                 'auto-rotate-rke2-certs',
@@ -53,12 +54,15 @@ export const HCI_ALLOWED_SETTINGS = {
     from:        'import',
     featureFlag: 'autoRotateRke2CertsSetting'
   },
-  [HCI_SETTING.CSI_DRIVER_CONFIG]:       { kind: 'json', from: 'import' },
-  [HCI_SETTING.SERVER_VERSION]:          { readOnly: true },
-  [HCI_SETTING.UPGRADE_CHECKER_ENABLED]: { kind: 'boolean' },
-  [HCI_SETTING.UPGRADE_CHECKER_URL]:     { kind: 'url' },
-  [HCI_SETTING.HTTP_PROXY]:              { kind: 'json', from: 'import' },
-  [HCI_SETTING.ADDITIONAL_CA]:           {
+  [HCI_SETTING.CSI_DRIVER_CONFIG]:            { kind: 'json', from: 'import' },
+  [HCI_SETTING.CSI_ONLINE_EXPAND_VALIDATION]: {
+    kind: 'json', from: 'import', featureFlag: 'csiOnlineExpandValidation'
+  },
+  [HCI_SETTING.SERVER_VERSION]:               { readOnly: true },
+  [HCI_SETTING.UPGRADE_CHECKER_ENABLED]:      { kind: 'boolean' },
+  [HCI_SETTING.UPGRADE_CHECKER_URL]:          { kind: 'url' },
+  [HCI_SETTING.HTTP_PROXY]:                   { kind: 'json', from: 'import' },
+  [HCI_SETTING.ADDITIONAL_CA]:                {
     kind: 'multiline', canReset: true, from: 'import'
   },
   [HCI_SETTING.OVERCOMMIT_CONFIG]:                      { kind: 'json', from: 'import' },

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1098,6 +1098,9 @@ harvester:
       provisioner: Provisioner
       volumeSnapshotClassName: Volume Snapshot Class Name
       backupVolumeSnapshotClassName: Backup Volume Snapshot Class Name
+    csiOnlineExpandValidation:
+      provisioner: Provisioner
+      value: Value
     containerdRegistry:
       mirrors:
         mirrors: Mirrors
@@ -1597,6 +1600,7 @@ advancedSettings:
     'harv-backup-target': Custom backup target to store virtual machine backups.
     'branding': Branding allows administrators to globally re-brand the UI by customizing the Harvester product name, logos, and color scheme.
     'harv-csi-driver-config': Configure additional information for CSI drivers.
+    'harv-csi-online-expand-validation': Allow online volume expansion for specific CSI drivers.
     'harv-containerd-registry': Containerd Registry Configuration to connect private registries.
     'harv-log-level': Configure Harvester server log level. Defaults to Info.
     'harv-server-version': Harvester server version.


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Add new setting `csi-online-expand-validation`

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @WebberHuang1118 

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[GUI] [FEATURE] Online resize of disks / volumes attached to virtual machines #8314](https://github.com/harvester/harvester/issues/8314)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Navigate to Settings and verify that the `csi-online-expand-validation` setting is displayed correctly, the default value should be:
```json
{
  "driver.longhorn.io": true
}
```
- Click `Edit Setting`, confirm that `driver.longhorn.io is` enabled by default and is read-only (immutable)
- Click `Add` to include another provisioner (e.g., `nfs.csi.k8s.io`) and set its value to `True`
- Verify that the `Add` button becomes disabled if there are no more provisioners available to select
- Click `Save`, verify that the saved configuration looks like the following:
```json
{
  "driver.longhorn.io": true,
  "nfs.csi.k8s.io": true
}
```
- Click `Use the default value` and verify that the configuration resets to the default

https://github.com/user-attachments/assets/bcc8c69e-a3f6-443c-bca5-7a997950bccb



