### PR TITLE
feat: enable snapshot and clone for LHv2

### DIFF
--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -35,15 +35,10 @@ export default class HciPv extends HarvesterResource {
   get availableActions() {
     let out = super._availableActions;
 
-    // Longhorn V2 provisioner do not support volume clone feature yet
-    if (this.isLonghornV2) {
-      out = out.filter((action) => action.action !== 'goToClone');
-    } else {
-      const clone = out.find((action) => action.action === 'goToClone');
+    const clone = out.find((action) => action.action === 'goToClone');
 
-      if (clone) {
-        clone.action = 'goToCloneVolume';
-      }
+    if (clone) {
+      clone.action = 'goToCloneVolume';
     }
 
     const exportImageAction = {
@@ -65,10 +60,6 @@ export default class HciPv extends HarvesterResource {
         takeSnapshotAction,
         ...out
       ];
-      // TODO: remove this block if Longhorn V2 engine supports restore volume snapshot
-      if (this.isLonghornV2) {
-        out = out.filter((action) => action.action !== takeSnapshotAction.action);
-      }
     } else { // v1.4 / v1.3
       if (!this.isLonghorn || !this.isLonghornV2) {
         out = [

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -87,17 +87,11 @@ const IgnoreMessages = ['pod has unbound immediate PersistentVolumeClaims'];
 
 export default class VirtVm extends HarvesterResource {
   get availableActions() {
-    let out = super._availableActions;
+    const out = super._availableActions;
+    const clone = out.find((action) => action.action === 'goToClone');
 
-    // VM attached with Longhorn V2 volume doesn't support clone feature
-    if (this.longhornV2Volumes.length > 0) {
-      out = out.filter((action) => action.action !== 'goToClone');
-    } else {
-      const clone = out.find((action) => action.action === 'goToClone');
-
-      if (clone) {
-        clone.action = 'goToCloneVM';
-      }
+    if (clone) {
+      clone.action = 'goToCloneVM';
     }
 
     return [
@@ -159,7 +153,7 @@ export default class VirtVm extends HarvesterResource {
       },
       {
         action:  'takeVMSnapshot',
-        enabled: (!!this.actions?.snapshot || !!this.action?.backup) && !this.longhornV2Volumes.length,
+        enabled: (!!this.actions?.snapshot || !!this.action?.backup),
         icon:    'icon icon-snapshot',
         label:   this.t('harvester.action.vmSnapshot')
       },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Now that Longhorn supports volume clone with the V2 data engine, we can enable volume snapshot and clone.

Note: this requires https://github.com/harvester/harvester/pull/9415

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/6710

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


