### PR TITLE
fix: find the correct vmim based on creationTimeStamp

### DIFF
--- a/pkg/harvester/detail/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/detail/kubevirt.io.virtualmachine/index.vue
@@ -139,10 +139,18 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const vmimList = this.$store.getters[`${ inStore }/all`](HCI.VMIM) || [];
 
-      const migrationUid = this.vmi?.status?.migrationState?.migrationUid;
-      const vmim = vmimList.find((VMIM) => VMIM?.metadata?.uid === migrationUid);
+      const vmiName = this.vmi?.name || '';
 
-      return vmim;
+      // filter the corresponding vmims by vmim.spec.vmiName and find the latest one by creationTimestamp
+      const vmim = vmimList.filter((VMIM) => VMIM?.spec?.vmiName === vmiName).sort((a, b) => {
+        if (a?.metadata?.creationTimestamp > b?.metadata?.creationTimestamp) {
+          return -1;
+        }
+
+        return 1;
+      });
+
+      return vmim.length > 0 && vmim[0] ? vmim[0] : null;
     },
 
     migrationEvents() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Update the logic to find correct vmim.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @brandboat 

### Related Issue #
https://github.com/harvester/harvester/issues/7339

### Test screenshot or video
<img width="1496" alt="Screenshot 2025-07-09 at 4 24 45 PM" src="https://github.com/user-attachments/assets/23444640-9922-48fd-9147-227e3f2ce496" />



