### PR TITLE
chore: upgrade rancher/shell to 3.0.5-rc6

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-class-static-block": "7.26.0",
-    "@rancher/shell": "3.0.5-rc.3",
+    "@rancher/shell": "3.0.5-rc.6",
     "cache-loader": "^4.1.0",
     "color": "4.2.3",
     "ip": "2.0.1",

--- a/pkg/harvester/package.json
+++ b/pkg/harvester/package.json
@@ -7,7 +7,7 @@
     "annotations": {
       "catalog.cattle.io/display-name": "Harvester",
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.11.0-0",
+      "catalog.cattle.io/rancher-version": ">= 2.12.0-0",
       "catalog.cattle.io/ui-extensions-version": ">= 3.0.0 < 4.0.0"
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2986,6 +2986,11 @@
   resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.4.tgz#cb2fc423220fa71c609323b9ba7f7d344a755fcc"
   integrity sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
@@ -3133,10 +3138,10 @@
   resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.29.tgz#6546d69768c706bebd66bfa73b36aef3d105987a"
   integrity sha512-qBBqfazS9y5VjV7fJDPNXmxd9AP/2uiE05mKFWP41kpbO+tEb62RnUBXCm14XLeScDZQcOuiAKVHMmvCFzF0BA==
 
-"@rancher/shell@3.0.5-rc.3":
-  version "3.0.5-rc.3"
-  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-3.0.5-rc.3.tgz#8dae16e7a9f1ec7c952449d194023ad7eeefdb2f"
-  integrity sha512-2EkcS2WECWJz/wEnd2NZFHPomST8wWrJqml1z7rTRkF9vTJMltTOpshZGyAhIBmeNLRYOJKh/VU5l7YInALlcQ==
+"@rancher/shell@3.0.5-rc.6":
+  version "3.0.5-rc.6"
+  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-3.0.5-rc.6.tgz#8d842cf1b0f7e3e52af53538953cf9dc5bfd0639"
+  integrity sha512-B9+2WE1a06wRvCN7xvxp/HBdjrib04szIbc1pNBeMdDNCqQmZMvt2dftjYb44Tvg+4Ji8G+tcK8Q3Rry6NDJsw==
   dependencies:
     "@aws-sdk/client-ec2" "3.658.1"
     "@aws-sdk/client-eks" "3.1.0"
@@ -3167,6 +3172,7 @@
     babel-plugin-module-resolver "4.0.0"
     babel-preset-vue "2.0.2"
     cache-loader "4.1.0"
+    chart.js "4.4.8"
     clipboard-polyfill "4.0.1"
     codemirror ">=5.64.0 <6"
     codemirror-editor-vue3 "2.8.0"
@@ -5760,6 +5766,13 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+chart.js@4.4.8:
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.4.8.tgz#54645b638e9d585099bc16b892947b5e6cd2a552"
+  integrity sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 check-more-types@2.24.0, check-more-types@^2.24.0:
   version "2.24.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Upgrade rancher/shell from `3.0.5-rc3` to `3.0.5-rc6`
- Update `catalog.cattle.io/rancher-version` annotation to `>= 2.12.0-0`

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- ✅ Create page
<img width="1920" height="968" alt="Screenshot 2025-07-11 at 2 11 11 PM (2)" src="https://github.com/user-attachments/assets/2546b1f7-72be-417b-bdf6-e0c157cdb7c1" />

- ✅ Detail page
<img width="1920" height="969" alt="Screenshot 2025-07-11 at 2 11 18 PM (2)" src="https://github.com/user-attachments/assets/5a0be394-18f6-40ab-a01c-e6b69767fdfd" />

---

Followings need to wait for the fix from `@rancher/shell-rc.7`.
- ❌ VM networks page: exception error
<img width="1920" height="1080" alt="vm-network-error" src="https://github.com/user-attachments/assets/e7dd088e-289b-41b2-8151-504e623e2cb1" />

- ❌ VM Backups and snapshots page: It should show the edit component, but since there's no edit for backup, it shows the create component instead, which isn't expected.
<img width="1380" height="970" alt="backup-error" src="https://github.com/user-attachments/assets/66904b16-3096-4ecb-ac19-8b761902627e" />

