### PR TITLE
ci: disable subject-max-length commitlint rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -27,7 +27,7 @@ module.exports = {
     'subject-case':           [0, 'never'],
     'subject-empty':          [2, 'never'],
     'subject-full-stop':      [2, 'never', '.'],
-    'subject-max-length':     [2, 'always', 72],
+    'subject-max-length':     [0, 'never'],
     'body-leading-blank':     [2, 'always'],
     'body-max-line-length':   [2, 'always', 100],
     'footer-leading-blank':   [2, 'always'],


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Some backport PR commits have commit subject too long.

Disable subject-max-length commitlint rule
<img width="1306" height="603" alt="image" src="https://github.com/user-attachments/assets/f15bf6d9-54e1-4e42-857c-13aed9368bd0" />

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


