### PR TITLE
feat: volume online resizing is blocked when configured from the VM page

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/index.vue
@@ -17,6 +17,7 @@ import { SOURCE_TYPE } from '../../../config/harvester-map';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../../config/harvester';
 import { HCI } from '../../../types';
 import { VOLUME_MODE } from '@pkg/harvester/config/types';
+import { OFF } from '../../../models/kubevirt.io.virtualmachine';
 
 export default {
   emits: ['update:value'],
@@ -266,7 +267,17 @@ export default {
 
     isLonghornV2(volume) {
       return volume?.pvc?.isLonghornV2 || volume?.pvc?.storageClass?.isLonghornV2;
-    }
+    },
+
+    isResizeDisabled(volume) {
+      if (this.isCreate) return false;
+      if (volume.newCreateId) return false;
+
+      const isStopped = this.vm.stateDisplay === OFF;
+      const isLonghornV2 = this.isLonghornV2(volume);
+
+      return !isStopped || isLonghornV2;
+    },
   },
 };
 </script>
@@ -347,6 +358,7 @@ export default {
               :is-edit="isEdit"
               :is-view="isView"
               :is-virtual-type="isVirtualType"
+              :is-resize-disabled="isResizeDisabled(rows[i])"
               :mode="mode"
               :idx="i"
               :validate-required="validateRequired"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -64,7 +64,12 @@ export default {
     isVirtualType: {
       type:    Boolean,
       default: true
-    }
+    },
+
+    isResizeDisabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   data() {
@@ -133,10 +138,6 @@ export default {
 
     thirdPartyStorageEnabled() {
       return this.$store.getters['harvester-common/getFeatureEnabled']('thirdPartyStorage');
-    },
-
-    isLonghornV2() {
-      return this.value.pvc?.isLonghornV2 || this.value.pvc?.storageClass?.isLonghornV2;
     },
 
     selectedImage() {
@@ -350,7 +351,7 @@ export default {
             :label="t('harvester.fields.size')"
             :mode="mode"
             :required="validateRequired"
-            :disable="isLonghornV2"
+            :disabled="isResizeDisabled"
             :suffix="GIBIBYTE"
             @update:value="update"
           />

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
@@ -56,7 +56,12 @@ export default {
     isVirtualType: {
       type:    Boolean,
       default: true
-    }
+    },
+
+    isResizeDisabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   data() {
@@ -133,10 +138,6 @@ export default {
           disabled
         };
       }) || [];
-    },
-
-    isLonghornV2() {
-      return this.value.pvc?.isLonghornV2 || this.value.pvc?.storageClass?.isLonghornV2;
     },
 
     isLonghornStorageClass() {
@@ -310,7 +311,7 @@ export default {
             :mode="mode"
             :required="validateRequired"
             :label="t('harvester.fields.size')"
-            :disabled="isLonghornV2"
+            :disabled="isResizeDisabled"
             :suffix="GIBIBYTE"
             @update:value="update"
           />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Disable the `Size` field when editing a VM volume

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @WebberHuang1118 

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[GUI] [BUG] Volume online resizing is blocked when configured from the VM page #8674](https://github.com/harvester/harvester/issues/8674)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**Editable:**
- Creating a new VM
- Adding a new volume or image volume
- Editing a stopped VM

**Not Editable:**
- Editing a running or paused VM
- Using Longhorn V2 volume 
- Adding an existing volume (original behavior)

https://github.com/user-attachments/assets/62087197-9340-4ecd-98cb-d41266c523fc
