### PR TITLE
feat: add support for configuring transparent hugepages

### DIFF
--- a/pkg/harvester/config/doc-links.js
+++ b/pkg/harvester/config/doc-links.js
@@ -7,4 +7,5 @@ export const DOC = {
   UPGRADE_CONFIG_URL:        `/advanced/index#upgrade-config`,
   STORAGE_NETWORK_EXAMPLE:   `/advanced/storagenetwork#configuration-example`,
   SUPPORT_BUNDLE_NAMESPACES: `/advanced/index/#support-bundle-namespaces`,
+  TRANSPARENT_HUGEPAGES:     `https://docs.kernel.org/admin-guide/mm/transhuge.html`,
 };

--- a/pkg/harvester/detail/harvesterhci.io.host/HarvesterHugepages.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/HarvesterHugepages.vue
@@ -1,0 +1,119 @@
+<script>
+import LabelValue from '@shell/components/LabelValue';
+import { HCI } from '../../types';
+import { DOC } from '../../config/doc-links';
+
+export default {
+  name:       'HarvesterHugepages',
+  components: { LabelValue },
+
+  props: {
+    node: {
+      type:     Object,
+      required: true,
+    },
+  },
+
+  computed: {
+    docsTransparentHugepagesLink() {
+      return DOC.TRANSPARENT_HUGEPAGES;
+    },
+  },
+
+  async fetch() {
+    const inStore = this.$store.getters['currentProduct'].inStore;
+
+    const hash = await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.HUGEPAGES });
+
+    this.hugepages = hash.find((node) => {
+      return node.id === this.node.id;
+    });
+  },
+
+  data() {
+    return { hugepages: {} };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <template v-if="hugepages.status">
+      <h2>{{ t('harvester.host.hugepages.meminfo') }}</h2>
+
+      <div class="row mb-20">
+        <div class="col span-6">
+          <LabelValue
+            :name="t('harvester.host.hugepages.status.anon')"
+            :value="hugepages.status.meminfo.anonHugePages"
+          />
+        </div>
+        <div class="col span-6">
+          <LabelValue
+            :name="t('harvester.host.hugepages.status.size')"
+            :value="hugepages.status.meminfo.hugepageSize"
+          />
+        </div>
+      </div>
+
+      <div class="row mb-20">
+        <div class="col span-3">
+          <LabelValue
+            :name="t('harvester.host.hugepages.status.total')"
+            :value="hugepages.status.meminfo.hugePagesTotal"
+          />
+        </div>
+        <div class="col span-3">
+          <LabelValue
+            :name="t('harvester.host.hugepages.status.free')"
+            :value="hugepages.status.meminfo.hugePagesFree"
+          />
+        </div>
+        <div class="col span-3">
+          <LabelValue
+            :name="t('harvester.host.hugepages.status.rsvd')"
+            :value="hugepages.status.meminfo.hugePagesRsvd"
+          />
+        </div>
+        <div class="col span-3">
+          <LabelValue
+            :name="t('harvester.host.hugepages.status.surp')"
+            :value="hugepages.status.meminfo.hugePagesSurp"
+          />
+        </div>
+      </div>
+
+      <div>
+        <hr class="divider" />
+        <h3>
+          <t
+            k="harvester.host.hugepages.transparent.title"
+            :raw="true"
+            :url="docsTransparentHugepagesLink"
+          />
+        </h3>
+
+        <div class="row mb-20">
+          <div class="col span-4">
+            <LabelValue
+              :name="t('harvester.host.hugepages.transparent.enabled')"
+              :value="hugepages.spec.transparent.enabled"
+            />
+          </div>
+          <div class="col span-4">
+            <LabelValue
+              :name="t('harvester.host.hugepages.transparent.shmemEnabled')"
+              :value="hugepages.spec.transparent.shmemEnabled"
+            />
+          </div>
+          <div class="col span-4">
+            <LabelValue
+              :name="t('harvester.host.hugepages.transparent.defrag')"
+              :value="hugepages.spec.transparent.defrag"
+            />
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/pkg/harvester/detail/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/index.vue
@@ -27,6 +27,7 @@ import Instance from './VirtualMachineInstance';
 import Disk from './HarvesterHostDisk';
 import VlanStatus from './VlanStatus';
 import HarvesterKsmtuned from './HarvesterKsmtuned.vue';
+import HarvesterHugepages from './HarvesterHugepages.vue';
 import HarvesterSeeder from './HarvesterSeeder';
 
 const LONGHORN_SYSTEM = 'longhorn-system';
@@ -46,6 +47,7 @@ export default {
     VlanStatus,
     LabelValue,
     HarvesterKsmtuned,
+    HarvesterHugepages,
     Loading,
     SortableTable,
     HarvesterSeeder,
@@ -207,6 +209,12 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
 
       return !!this.$store.getters[`${ inStore }/schemaFor`](HCI.KSTUNED);
+    },
+
+    hasHugepagesSchema() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      return !!this.$store.getters[`${ inStore }/schemaFor`](HCI.HUGEPAGES);
     },
 
     hasBlockDevicesSchema() {
@@ -466,6 +474,16 @@ export default {
           :mode="mode"
           :node="value"
         />
+      </Tab>
+
+      <Tab
+        v-if="hasHugepagesSchema"
+        name="hugepages"
+        :weight="0"
+        :show-header="false"
+        :label="t('harvester.host.tabs.hugepages')"
+      >
+        <HarvesterHugepages :node="value" />
       </Tab>
 
       <Tab

--- a/pkg/harvester/edit/harvesterhci.io.host/HarvesterHugepages.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/HarvesterHugepages.vue
@@ -1,0 +1,157 @@
+<script>
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import { HCI } from '../../types';
+import { DOC } from '../../config/doc-links';
+
+export const hugepagesTHPEnabledMode = [{
+  label: 'Always',
+  value: 'always',
+}, {
+  label: 'Madvise',
+  value: 'madvise',
+}, {
+  label: 'Never',
+  value: 'never',
+}];
+
+export const hugepagesTHPShmemEnabledMode = [{
+  label: 'Always',
+  value: 'always',
+}, {
+  label: 'Within Size',
+  value: 'within_size',
+}, {
+  label: 'Advise',
+  value: 'advise',
+}, {
+  label: 'Never',
+  value: 'never',
+}, {
+  label: 'Deny',
+  value: 'deny',
+}, {
+  label: 'Force',
+  value: 'force',
+}];
+
+export const hugepagesTHPDefragMode = [{
+  label: 'Always',
+  value: 'always',
+}, {
+  label: 'Defer',
+  value: 'defer',
+}, {
+  label: 'Defer+Madvise',
+  value: 'defer+madvise',
+}, {
+  label: 'Madvise',
+  value: 'madvise',
+}, {
+  label: 'Never',
+  value: 'never'
+}];
+
+export default {
+  name:       'HarvesterHugepages',
+  components: { LabeledSelect },
+
+  props: {
+    node: {
+      type:     Object,
+      required: true,
+    },
+
+    registerBeforeHook: {
+      type:     Function,
+      required: true,
+    },
+  },
+
+  computed: {
+    docsTransparentHugepagesLink() {
+      return DOC.TRANSPARENT_HUGEPAGES;
+    },
+  },
+
+  methods: {
+    async saveHugepages() {
+      this.hugepages['spec'] = this.spec;
+
+      await this.hugepages.save().catch((reason) => {
+        if (reason?.type === 'error') {
+          this.$store.dispatch('growl/error', {
+            title:   this.t('harvester.notification.title.error'),
+            message: reason?.message,
+          }, { root: true });
+
+          return Promise.reject(new Error('saveHugepages error'));
+        }
+      });
+    },
+  },
+
+  async fetch() {
+    const inStore = this.$store.getters['currentProduct'].inStore;
+
+    const hash = await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.HUGEPAGES });
+
+    this.hugepages = hash.find((node) => {
+      return node.id === this.node.id;
+    });
+    this.spec = this.hugepages.spec;
+  },
+
+  data() {
+    return {
+      hugepages: {},
+      spec:      { transparent: {} },
+      hugepagesTHPEnabledMode,
+      hugepagesTHPShmemEnabledMode,
+      hugepagesTHPDefragMode,
+    };
+  },
+
+  created() {
+    this.registerBeforeHook(this.saveHugepages, 'saveHugepages');
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div>
+      <hr class="divider" />
+      <h3>
+        <t
+          k="harvester.host.hugepages.transparent.title"
+          :raw="true"
+          :url="docsTransparentHugepagesLink"
+        />
+      </h3>
+
+      <div class="row mb-20">
+        <div class="col span-4">
+          <LabeledSelect
+            v-model:value="spec.transparent.enabled"
+            :label="t('harvester.host.hugepages.transparent.enabled')"
+            :options="hugepagesTHPEnabledMode"
+          />
+        </div>
+        <div class="col span-4">
+          <LabeledSelect
+            v-model:value="spec.transparent.shmemEnabled"
+            :label="t('harvester.host.hugepages.transparent.shmemEnabled')"
+            :options="hugepagesTHPShmemEnabledMode"
+          />
+        </div>
+        <div class="col span-4">
+          <LabeledSelect
+            v-model:value="spec.transparent.defrag"
+            :label="t('harvester.host.hugepages.transparent.defrag')"
+            :options="hugepagesTHPDefragMode"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pkg/harvester/edit/harvesterhci.io.host/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/index.vue
@@ -28,6 +28,7 @@ import { HCI } from '../../types';
 import HarvesterDisk from './HarvesterDisk';
 import HarvesterSeeder from './HarvesterSeeder';
 import HarvesterKsmtuned from './HarvesterKsmtuned';
+import HarvesterHugepages from './HarvesterHugepages';
 import Tags from '../../components/DiskTags';
 import { LVM_DRIVER } from '../../models/harvester/storage.k8s.io.storageclass';
 import isEqual from 'lodash/isEqual';
@@ -50,6 +51,7 @@ export default {
     ArrayListGrouped,
     HarvesterDisk,
     HarvesterKsmtuned,
+    HarvesterHugepages,
     ButtonDropdown,
     KeyValue,
     Banner,
@@ -223,6 +225,12 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
 
       return !!this.$store.getters[`${ inStore }/schemaFor`](HCI.KSTUNED);
+    },
+
+    hasHugepagesSchema() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      return !!this.$store.getters[`${ inStore }/schemaFor`](HCI.HUGEPAGES);
     },
 
     hasBlockDevicesSchema() {
@@ -647,6 +655,17 @@ export default {
               <span v-else />
             </template>
           </ArrayListGrouped>
+        </Tab>
+        <Tab
+          v-if="hasHugepagesSchema"
+          name="Hugepages"
+          :weight="70"
+          :label="t('harvester.host.tabs.hugepages')"
+        >
+          <HarvesterHugepages
+            :node="value"
+            :register-before-hook="registerBeforeHook"
+          />
         </Tab>
         <Tab
           v-if="hasKsmtunedSchema"

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -435,6 +435,7 @@ harvester:
       storage: Storage
       labels: Labels
       ksmtuned: Ksmtuned
+      hugepages: Hugepages
       seeder: Out-of-band Access
     detail:
       kvm:
@@ -507,6 +508,20 @@ harvester:
         fullScans: Full Scans
         stableNodeChains: Stable Node Chains
         stableNodeDups: Stable Node Dups
+    hugepages:
+      meminfo: Meminfo
+      transparent:
+        title: Transparent Hugepages <a href="{url}" target="_blank"><i class="icon icon-info" /></a>
+        enabled: Enabled
+        shmemEnabled: Shared Memory Enabled
+        defrag: Defragmentation
+      status:
+        anon: Anonymous Hugepages (bytes)
+        size: Default Hugepage Size (bytes)
+        total: Total Hugepages
+        free: Free Hugepages
+        rsvd: Reserved Hugepages
+        surp: Surplus Hugepages
     disk:
       add: Add Disk
       path:

--- a/pkg/harvester/types.ts
+++ b/pkg/harvester/types.ts
@@ -37,6 +37,7 @@ export const HCI = {
   STORAGE:             'harvesterhci.io.storage',
   RESOURCE_QUOTA:      'harvesterhci.io.resourcequota',
   KSTUNED:             'node.harvesterhci.io.ksmtuned',
+  HUGEPAGES:           'node.harvesterhci.io.hugepage',
   PCI_DEVICE:          'devices.harvesterhci.io.pcidevice',
   PCI_CLAIM:           'devices.harvesterhci.io.pcideviceclaim',
   SR_IOV:              'devices.harvesterhci.io.sriovnetworkdevice',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds the ability to configure some transparent hugepage settings, and see some extra meminfo status for each node.

This is largely @m-ildefons' earlier work from https://github.com/m-ildefons/harvester-dashboard/tree/wip/hugepages, re-applied to harvester-ui-extension.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @tserong @m-ildefons 

### Related Issue #
https://github.com/harvester/harvester/issues/5006

### Test screenshot or video

Host Details:

<img width="1109" height="534" alt="image" src="https://github.com/user-attachments/assets/0a69319b-5708-48f3-a37b-d95d2a3d0d54" />

Host Configuration:

<img width="1103" height="473" alt="image" src="https://github.com/user-attachments/assets/03c89892-dac8-4156-aa0f-12c786b3e359" />

