### PR TITLE
refactor: remove unneeded translation keys for rancher cluster setting

### DIFF
--- a/pkg/harvester/components/settings/rancher-cluster.vue
+++ b/pkg/harvester/components/settings/rancher-cluster.vue
@@ -208,7 +208,15 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-:deep(textarea) {
-  overflow-y: auto !important;
+$yaml-height: 540px;
+
+:deep() .yaml-editor{
+  flex: 1;
+  min-height: $yaml-height;
+  & .code-mirror .CodeMirror {
+    position: initial;
+    height: auto;
+    min-height: $yaml-height;
+  }
 }
 </style>

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1127,19 +1127,8 @@ harvester:
       privateKey: Private Key
       ca: CA
     rancherCluster:
-      description: Configure Rancher cluster integration for guest cluster management. This setting allows you to specify a Rancher KubeConfig and configure automatic cleanup behavior.
       kubeConfig: Rancher KubeConfig
-      kubeConfigPlaceholder: Paste your Rancher KubeConfig content here...
       removeUpstreamClusterWhenNamespaceIsDeleted: Remove Upstream Cluster When Namespace Is Deleted
-      createSecret: Create Rancher KubeConfig Secret
-      updateSecret: Update Rancher KubeConfig Secret
-      creatingSecret: Creating Secret...
-      updatingSecret: Updating Secret...
-      secretExists: A Rancher KubeConfig secret already exists and will be updated
-      secretCreated: Rancher KubeConfig secret created successfully
-      secretUpdated: Rancher KubeConfig secret updated successfully
-      secretCreationFailed: Failed to create Rancher KubeConfig secret
-      invalidKubeConfig: Invalid KubeConfig format. Please ensure it's a valid JSON kubeConfig file with apiVersion and kind fields.
     storageNetwork:
       range:
         placeholder: e.g. 172.16.0.0/24


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- remove unneeded translation keys for rancher cluster setting
- add yaml min height

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/7356

### Test screenshot or video
<img width="1496" height="816" alt="Screenshot 2025-07-21 at 5 32 05 PM" src="https://github.com/user-attachments/assets/03d2e942-0c32-45ad-98b4-5b98258af80e" />

