### PR TITLE
feat: expose CDI settings

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -43,7 +43,8 @@ const FEATURE_FLAGS = {
     'customSupportBundle',
     'csiOnlineExpandValidation',
     'vmNetworkMigration',
-    'kubeovnVpcSubnet'
+    'kubeovnVpcSubnet',
+    'cdiSettings'
   ]
 };
 

--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -70,5 +70,9 @@ export const HCI = {
   K8S_ARCH:                         'kubernetes.io/arch',
   IMAGE_DISPLAY_NAME:               'harvesterhci.io/imageDisplayName',
   CUSTOM_IP:                        'harvesterhci.io/custom-ip',
-  IMPORTED_IMAGE:                   'migration.harvesterhci.io/imported'
+  IMPORTED_IMAGE:                   'migration.harvesterhci.io/imported',
+  FILESYSTEM_OVERHEAD:              'cdi.harvesterhci.io/filesystemOverhead',
+  CLONE_STRATEGY:                   'cdi.harvesterhci.io/storageProfileCloneStrategy',
+  VOLUME_MODE_ACCESS_MODES:         'cdi.harvesterhci.io/storageProfileVolumeModeAccessModes',
+  VOLUME_SNAPSHOT_CLASS:            'cdi.harvesterhci.io/storageProfileVolumeSnapshotClass',
 };

--- a/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
@@ -55,7 +55,7 @@ export default {
         filesystemOverhead:    null,
       },
       defaultAddValue: { volumeMode: null, accessModes: [] },
-      noneOption:      { label: 'None', value: null },
+      noneOption:      { label: 'None', value: '' },
     };
   },
 
@@ -72,8 +72,22 @@ export default {
       return this.$store.getters['currentProduct'].inStore;
     },
 
+    allVolumeModeOptions() {
+      return Object.values(VOLUME_MODE).map((mode) => ({ label: mode, value: mode }));
+    },
+
+    selectedVolumeModes() {
+      return this.cdiSettings.volumeModeAccessModes
+        .map((item) => item.volumeMode)
+        .filter(Boolean);
+    },
+
     volumeModeOptions() {
-      return [this.noneOption, ...Object.values(VOLUME_MODE).map((mode) => ({ label: mode, value: mode }))];
+      return [this.noneOption, ...this.allVolumeModeOptions].filter( (option) => !this.selectedVolumeModes.includes(option.value) );
+    },
+
+    allVolumeModesSelected() {
+      return this.selectedVolumeModes.length === this.allVolumeModeOptions.length;
     },
 
     accessModeOptions() {
@@ -206,6 +220,7 @@ export default {
     :add-label="t('harvester.storage.cdiSettings.volumeModeAccessModes.add')"
     :default-add-value="defaultAddValue"
     :protip="t('harvester.storage.cdiSettings.volumeModeAccessModes.tooltip')"
+    :add-disabled="allVolumeModesSelected"
   >
     <template #column-headers>
       <div class="column-headers">

--- a/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
@@ -1,0 +1,305 @@
+<script>
+import { VOLUME_MODE } from '@pkg/harvester/config/types';
+import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
+import ArrayList from '@shell/components/form/ArrayList';
+import { Checkbox } from '@components/Form/Checkbox';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { VOLUME_SNAPSHOT_CLASS, HCI } from '../../types';
+import { HCI_SETTING } from '../../config/settings';
+import { allHash } from '@shell/utils/promise';
+
+export default {
+  name: 'CDISettings',
+
+  props: {
+    value:    {
+      type:     Object,
+      required: true
+    },
+    mode:        {
+      type:     String,
+      required: true
+    },
+    provisioner: {
+      type:     String,
+      required: true
+    },
+    isCreate:    {
+      type:    Boolean,
+      default: false
+    }
+  },
+
+  components: {
+    ArrayList,
+    Checkbox,
+    LabeledInput,
+    LabeledSelect,
+  },
+
+  emits: ['update:cdiSettings'],
+
+  async fetch() {
+    const hash = {
+      volumeSnapshotClasses:  this.$store.dispatch(`${ this.inStore }/findAll`, { type: VOLUME_SNAPSHOT_CLASS }),
+      csiDriverConfigSetting: this.$store.dispatch(`${ this.inStore }/find`, { type: HCI.SETTING, id: HCI_SETTING.CSI_DRIVER_CONFIG }),
+    };
+
+    await allHash(hash);
+  },
+
+  data() {
+    return {
+      cdiSettings: {
+        volumeModeAccessMode: [],
+        volumeSnapshotClass:  null,
+        cloneStrategy:        null,
+        filesystemOverhead:   null,
+      },
+      defaultAddValue: { volumeMode: null, accessModes: [] },
+      noneOption:      { label: 'None', value: null },
+    };
+  },
+
+  created() {
+    if (this.isCreate) {
+      this.setDefaultVolumeSnapshotClass();
+    } else {
+      this.initCDISettingsFromAnnotations();
+    }
+  },
+
+  computed: {
+    inStore() {
+      return this.$store.getters['currentProduct'].inStore;
+    },
+
+    volumeModeOptions() {
+      return [this.noneOption, ...Object.values(VOLUME_MODE).map((mode) => ({ label: mode, value: mode }))];
+    },
+
+    accessModeOptions() {
+      return [
+        { label: 'ReadWriteOnce', value: 'ReadWriteOnce' },
+        { label: 'ReadOnlyMany', value: 'ReadOnlyMany' },
+        { label: 'ReadWriteMany', value: 'ReadWriteMany' },
+        { label: 'ReadWriteOncePod', value: 'ReadWriteOncePod' },
+      ];
+    },
+
+    cloneStrategyOptions() {
+      return [
+        this.noneOption,
+        { label: this.t('harvester.storage.cdiSettings.cloneStrategy.copy'), value: 'copy' },
+        { label: this.t('harvester.storage.cdiSettings.cloneStrategy.snapshot'), value: 'snapshot' },
+        { label: this.t('harvester.storage.cdiSettings.cloneStrategy.csiClone'), value: 'csi-clone' },
+      ];
+    },
+
+    volumeSnapshotClassOptions() {
+      const allClasses = this.$store.getters[`${ this.inStore }/all`](VOLUME_SNAPSHOT_CLASS) || [];
+      const filtered = allClasses.filter((c) => c.driver === this.provisioner);
+
+      return [this.noneOption, ...filtered.map((c) => ({ label: c.name, value: c.name }))];
+    },
+
+    isFilesystemOverheadValid() {
+      const val = this.cdiSettings.filesystemOverhead;
+
+      if (val === null || val === '') return true;
+      const regex = /^(0(\.\d{1,3})?|1(\.0{1,3})?)$/;
+
+      return regex.test(val);
+    }
+  },
+
+  watch: {
+    provisioner() {
+      this.resetCdiSettings();
+      this.$nextTick(this.setDefaultVolumeSnapshotClass);
+    },
+
+    cdiSettings: {
+      handler(val) {
+        this.$emit('update:cdiSettings', val);
+      },
+      deep:      true,
+      immediate: true,
+    }
+  },
+
+  methods: {
+    setDefaultVolumeSnapshotClass() {
+      try {
+        const setting = this.$store.getters[`${ this.inStore }/byId`](HCI.SETTING, HCI_SETTING.CSI_DRIVER_CONFIG);
+        const config = JSON.parse(setting?.value || '{}');
+        const defaultClass = config?.[this.provisioner]?.volumeSnapshotClassName || null;
+
+        const allClasses = this.$store.getters[`${ this.inStore }/all`](VOLUME_SNAPSHOT_CLASS) || [];
+        const matched = allClasses.find((cls) => cls.name === defaultClass && cls.driver === this.provisioner);
+
+        this.cdiSettings.volumeSnapshotClass = matched?.name || null;
+      } catch (e) {
+        console.error('Failed to parse CSI config:', e); // eslint-disable-line no-console
+        this.cdiSettings.volumeSnapshotClass = null;
+      }
+    },
+
+    initCDISettingsFromAnnotations() {
+      const annotations = this.value?.metadata?.annotations || {};
+
+      let volumeModeAccessMode = [];
+      const rawVolumeMode = annotations[HCI_ANNOTATIONS.VOLUME_MODE_ACCESS_MODES];
+
+      if (rawVolumeMode) {
+        try {
+          const parsed = JSON.parse(rawVolumeMode);
+
+          volumeModeAccessMode = Object.entries(parsed).map(([volumeMode, accessModes]) => ({
+            volumeMode,
+            accessModes: Array.isArray(accessModes) ? accessModes : [],
+          }));
+        } catch (e) {
+          console.error('Failed to parse volume mode/access mode annotation:', e); // eslint-disable-line no-console
+        }
+      }
+
+      if (volumeModeAccessMode.length) {
+        this.cdiSettings.volumeModeAccessMode = volumeModeAccessMode;
+      }
+      if (annotations[HCI_ANNOTATIONS.VOLUME_SNAPSHOT_CLASS]) {
+        this.cdiSettings.volumeSnapshotClass = annotations[HCI_ANNOTATIONS.VOLUME_SNAPSHOT_CLASS];
+      }
+      if (annotations[HCI_ANNOTATIONS.CLONE_STRATEGY]) {
+        this.cdiSettings.cloneStrategy = annotations[HCI_ANNOTATIONS.CLONE_STRATEGY];
+      }
+      if (annotations[HCI_ANNOTATIONS.FILESYSTEM_OVERHEAD]) {
+        this.cdiSettings.filesystemOverhead = annotations[HCI_ANNOTATIONS.FILESYSTEM_OVERHEAD];
+      }
+    },
+
+    resetCdiSettings() {
+      this.cdiSettings.volumeModeAccessMode = [this.defaultAddValue];
+      this.cdiSettings.volumeSnapshotClass = null;
+      this.cdiSettings.cloneStrategy = null;
+      this.cdiSettings.filesystemOverhead = null;
+    },
+
+    validateFilesystemOverhead(e) {
+      const val = e.target.value;
+
+      this.cdiSettings.filesystemOverhead = val;
+    }
+  }
+};
+</script>
+
+<template>
+  <ArrayList
+    v-model:value="cdiSettings.volumeModeAccessMode"
+    :initial-empty-row="true"
+    :show-header="true"
+    :mode="mode"
+    :title="t('harvester.storage.cdiSettings.volumeModeAndAccessMode.label')"
+    :add-label="t('harvester.storage.cdiSettings.volumeModeAndAccessMode.add')"
+    :default-add-value="defaultAddValue"
+    :protip="t('harvester.storage.cdiSettings.volumeModeAndAccessMode.tooltip')"
+  >
+    <template #column-headers>
+      <div class="column-headers">
+        <div
+          class="row"
+          :class="{ create: isCreate }"
+        >
+          <label
+            class="col span-3 value text-label mb-10"
+            for="volumeMode"
+          >
+            {{ t('harvester.storage.cdiSettings.volumeModeAndAccessMode.volumeMode') }}
+          </label>
+          <label
+            class="col span-9 value text-label mb-10"
+            for="accessMode"
+          >
+            {{ t('harvester.storage.cdiSettings.volumeModeAndAccessMode.accessMode.label') }}
+          </label>
+        </div>
+      </div>
+    </template>
+
+    <template #columns="{ row }">
+      <div class="row">
+        <div class="col span-3">
+          <LabeledSelect
+            id="volumeMode"
+            v-model:value="row.value.volumeMode"
+            :mode="mode"
+            :options="volumeModeOptions"
+          />
+        </div>
+        <div
+          id="accessMode"
+          class="col span-9"
+        >
+          <Checkbox
+            v-for="opt in accessModeOptions"
+            :key="opt.value"
+            v-model:value="row.value.accessModes"
+            :value-when-true="opt.value"
+            :label="opt.label"
+            type="checkbox"
+            :mode="mode"
+          />
+        </div>
+      </div>
+    </template>
+  </ArrayList>
+
+  <LabeledSelect
+    v-model:value="cdiSettings.volumeSnapshotClass"
+    class="select mt-20 mb-20"
+    :label="t('harvester.storage.cdiSettings.volumeSnapshotClass.label')"
+    :tooltip="t('harvester.storage.cdiSettings.volumeSnapshotClass.tooltip')"
+    :mode="mode"
+    :options="volumeSnapshotClassOptions"
+  />
+
+  <LabeledSelect
+    v-model:value="cdiSettings.cloneStrategy"
+    class="select mb-20"
+    :label="t('harvester.storage.cdiSettings.cloneStrategy.label')"
+    :tooltip="t('harvester.storage.cdiSettings.cloneStrategy.tooltip')"
+    :mode="mode"
+    :options="cloneStrategyOptions"
+  />
+
+  <LabeledInput
+    v-model:value="cdiSettings.filesystemOverhead"
+    class="select mb-20"
+    :label="t('harvester.storage.cdiSettings.fileSystemOverhead.label')"
+    :tooltip="t('harvester.storage.cdiSettings.fileSystemOverhead.tooltip')"
+    :mode="mode"
+    type="number"
+    :min="0"
+    :max="1"
+    :step="0.001"
+    :placeholder="t('harvester.storage.cdiSettings.fileSystemOverhead.placeholder')"
+    :status="isFilesystemOverheadValid ? null : 'error'"
+    @input="validateFilesystemOverhead"
+  />
+</template>
+
+<style scoped lang="scss">
+  .column-headers .row.create {
+    max-width: calc(100% - 75px);
+  }
+
+  .row {
+    align-items: center;
+  }
+
+  .select {
+    max-width: 480px;
+  }
+</style>

--- a/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
@@ -8,6 +8,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { VOLUME_SNAPSHOT_CLASS, HCI } from '../../types';
 import { HCI_SETTING } from '../../config/settings';
 import { allHash } from '@shell/utils/promise';
+import { _EDIT, _CREATE } from '@shell/config/query-params';
 
 export default {
   name: 'CDISettings',
@@ -25,10 +26,6 @@ export default {
       type:     String,
       required: true
     },
-    isCreate:    {
-      type:    Boolean,
-      default: false
-    }
   },
 
   components: {
@@ -63,7 +60,7 @@ export default {
   },
 
   created() {
-    if (this.isCreate) {
+    if (this.mode === _CREATE ) {
       this.setDefaultVolumeSnapshotClass();
     } else {
       this.initCDISettingsFromAnnotations();
@@ -111,6 +108,10 @@ export default {
       const regex = /^(0(\.\d{1,3})?|1(\.0{1,3})?)$/;
 
       return regex.test(val);
+    },
+
+    isCustomClass() {
+      return this.mode === _CREATE || this.mode === _EDIT;
     }
   },
 
@@ -210,7 +211,7 @@ export default {
       <div class="column-headers">
         <div
           class="row"
-          :class="{ create: isCreate }"
+          :class="{ custom: isCustomClass }"
         >
           <label
             class="col span-3 value text-label mb-10"
@@ -291,7 +292,7 @@ export default {
 </template>
 
 <style scoped lang="scss">
-  .column-headers .row.create {
+  .column-headers .row.custom {
     max-width: calc(100% - 75px);
   }
 

--- a/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
@@ -52,10 +52,10 @@ export default {
   data() {
     return {
       cdiSettings: {
-        volumeModeAccessMode: [],
-        volumeSnapshotClass:  null,
-        cloneStrategy:        null,
-        filesystemOverhead:   null,
+        volumeModeAccessModes: [],
+        volumeSnapshotClass:   null,
+        cloneStrategy:         null,
+        filesystemOverhead:    null,
       },
       defaultAddValue: { volumeMode: null, accessModes: [] },
       noneOption:      { label: 'None', value: null },
@@ -149,24 +149,24 @@ export default {
     initCDISettingsFromAnnotations() {
       const annotations = this.value?.metadata?.annotations || {};
 
-      let volumeModeAccessMode = [];
+      let volumeModeAccessModes = [];
       const rawVolumeMode = annotations[HCI_ANNOTATIONS.VOLUME_MODE_ACCESS_MODES];
 
       if (rawVolumeMode) {
         try {
           const parsed = JSON.parse(rawVolumeMode);
 
-          volumeModeAccessMode = Object.entries(parsed).map(([volumeMode, accessModes]) => ({
+          volumeModeAccessModes = Object.entries(parsed).map(([volumeMode, accessModes]) => ({
             volumeMode,
             accessModes: Array.isArray(accessModes) ? accessModes : [],
           }));
         } catch (e) {
-          console.error('Failed to parse volume mode/access mode annotation:', e); // eslint-disable-line no-console
+          console.error('Failed to parse annotation:', e); // eslint-disable-line no-console
         }
       }
 
-      if (volumeModeAccessMode.length) {
-        this.cdiSettings.volumeModeAccessMode = volumeModeAccessMode;
+      if (volumeModeAccessModes.length) {
+        this.cdiSettings.volumeModeAccessModes = volumeModeAccessModes;
       }
       if (annotations[HCI_ANNOTATIONS.VOLUME_SNAPSHOT_CLASS]) {
         this.cdiSettings.volumeSnapshotClass = annotations[HCI_ANNOTATIONS.VOLUME_SNAPSHOT_CLASS];
@@ -180,7 +180,7 @@ export default {
     },
 
     resetCdiSettings() {
-      this.cdiSettings.volumeModeAccessMode = [this.defaultAddValue];
+      this.cdiSettings.volumeModeAccessModes = [this.defaultAddValue];
       this.cdiSettings.volumeSnapshotClass = null;
       this.cdiSettings.cloneStrategy = null;
       this.cdiSettings.filesystemOverhead = null;
@@ -197,14 +197,14 @@ export default {
 
 <template>
   <ArrayList
-    v-model:value="cdiSettings.volumeModeAccessMode"
+    v-model:value="cdiSettings.volumeModeAccessModes"
     :initial-empty-row="true"
     :show-header="true"
     :mode="mode"
-    :title="t('harvester.storage.cdiSettings.volumeModeAndAccessMode.label')"
-    :add-label="t('harvester.storage.cdiSettings.volumeModeAndAccessMode.add')"
+    :title="t('harvester.storage.cdiSettings.volumeModeAccessModes.label')"
+    :add-label="t('harvester.storage.cdiSettings.volumeModeAccessModes.add')"
     :default-add-value="defaultAddValue"
-    :protip="t('harvester.storage.cdiSettings.volumeModeAndAccessMode.tooltip')"
+    :protip="t('harvester.storage.cdiSettings.volumeModeAccessModes.tooltip')"
   >
     <template #column-headers>
       <div class="column-headers">
@@ -216,13 +216,13 @@ export default {
             class="col span-3 value text-label mb-10"
             for="volumeMode"
           >
-            {{ t('harvester.storage.cdiSettings.volumeModeAndAccessMode.volumeMode') }}
+            {{ t('harvester.storage.cdiSettings.volumeModeAccessModes.volumeMode') }}
           </label>
           <label
             class="col span-9 value text-label mb-10"
-            for="accessMode"
+            for="accessModes"
           >
-            {{ t('harvester.storage.cdiSettings.volumeModeAndAccessMode.accessMode.label') }}
+            {{ t('harvester.storage.cdiSettings.volumeModeAccessModes.accessModes.label') }}
           </label>
         </div>
       </div>
@@ -239,7 +239,7 @@ export default {
           />
         </div>
         <div
-          id="accessMode"
+          id="accessModes"
           class="col span-9"
         >
           <Checkbox

--- a/pkg/harvester/edit/harvesterhci.io.storage/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/index.vue
@@ -457,7 +457,6 @@ export default {
           :value="value"
           :mode="mode"
           :provisioner="value.provisioner"
-          :is-create="isCreate"
         />
       </Tab>
     </Tabbed>

--- a/pkg/harvester/edit/harvesterhci.io.storage/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/index.vue
@@ -1,4 +1,5 @@
 <script>
+import { VOLUME_MODE } from '@pkg/harvester/config/types';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import CruResource from '@shell/components/CruResource';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
@@ -6,11 +7,10 @@ import ArrayList from '@shell/components/form/ArrayList';
 import Tab from '@shell/components/Tabbed/Tab';
 import Tabbed from '@shell/components/Tabbed';
 import { RadioGroup } from '@components/Form/Radio';
-
+import { Checkbox } from '@components/Form/Checkbox';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import Loading from '@shell/components/Loading';
-
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 import { mapFeature, UNSUPPORTED_STORAGE_DRIVERS } from '@shell/store/features';
 import {
@@ -45,6 +45,7 @@ export default {
     Tabbed,
     Loading,
     Tags,
+    Checkbox,
   },
 
   mixins: [CreateEditView],
@@ -117,6 +118,7 @@ export default {
         key:    '',
         values: [],
       },
+      cdiSettings: {},
     };
   },
 
@@ -204,7 +206,11 @@ export default {
 
     shouldShowCDISettingsTab() {
       return this.isCDISettingsFeatureEnabled && this.longhornSystemVersion === DATA_ENGINE_V2;
-    }
+    },
+
+    volumeModeOptions() {
+      return Object.values(VOLUME_MODE);
+    },
   },
 
   watch: {
@@ -418,14 +424,114 @@ export default {
         :label="t('harvester.storage.cdiSettings.label')"
         :weight="-2"
       >
-        CDI Settings
+        <ArrayList
+          v-model:value="cdiSettings"
+          :initial-empty-row="true"
+          :show-header="true"
+          :mode="modeOverride"
+          :title="t('harvester.storage.cdiSettings.volumeModeAndAccessMode.label')"
+          :add-label="t('harvester.storage.cdiSettings.volumeModeAndAccessMode.add')"
+          :protip="t('harvester.storage.cdiSettings.volumeModeAndAccessMode.tooltip')"
+        >
+          <template #column-headers>
+            <div class="column-headers">
+              <div
+                class="row"
+                :class="{ 'create': isCreate }"
+              >
+                <label
+                  class="col span-3 value text-label mb-10"
+                  for="volumeMode"
+                >
+                  {{ t('harvester.storage.cdiSettings.volumeModeAndAccessMode.volumeMode') }}
+                </label>
+                <label
+                  class="col span-9 value text-label mb-10"
+                  for="accessMode"
+                >
+                  {{ t('harvester.storage.cdiSettings.volumeModeAndAccessMode.accessMode') }}
+                </label>
+              </div>
+            </div>
+          </template>
+          <template #columns="scope">
+            <div class="row">
+              <div class="col span-3">
+                <LabeledSelect
+                  id="volumeMode"
+                  :mode="modeOverride"
+                  :options="volumeModeOptions"
+                />
+              </div>
+              <div
+                id="accessMode"
+                class="col span-9"
+              >
+                <Checkbox
+                  v-model:value="scope.row.value.values"
+                  class="check"
+                  type="checkbox"
+                  :label="'ReadWriteOnce'"
+                  :mode="modeOverride"
+                />
+                <Checkbox
+                  v-model:value="scope.row.value.values"
+                  class="check"
+                  type="checkbox"
+                  :label="'ReadOnlyMany'"
+                  :mode="modeOverride"
+                />
+                <Checkbox
+                  v-model:value="scope.row.value.values"
+                  class="check"
+                  type="checkbox"
+                  :label="'ReadWriteMany'"
+                  :mode="modeOverride"
+                />
+                <Checkbox
+                  v-model:value="scope.row.value.values"
+                  class="check"
+                  type="checkbox"
+                  :label="'ReadWriteOncePod'"
+                  :mode="modeOverride"
+                />
+              </div>
+            </div>
+          </template>
+        </ArrayList>
+        <LabeledSelect
+          class="select mt-20 mb-20"
+          :label="t('harvester.storage.cdiSettings.volumeSnapshotClass.label')"
+          :tooltip="t('harvester.storage.cdiSettings.volumeSnapshotClass.tooltip')"
+          :mode="modeOverride"
+        />
+        <LabeledSelect
+          class="select mb-20"
+          :label="t('harvester.storage.cdiSettings.cloneStrategy.label')"
+          :tooltip="t('harvester.storage.cdiSettings.cloneStrategy.tooltip')"
+          :mode="modeOverride"
+        />
+        <LabeledInput
+          class="select mb-20"
+          :label="t('harvester.storage.cdiSettings.fileSystemOverhead.label')"
+          :tooltip="t('harvester.storage.cdiSettings.fileSystemOverhead.tooltip')"
+          :mode="modeOverride"
+        />
       </Tab>
     </Tabbed>
   </CruResource>
 </template>
 
 <style lang="scss" scoped>
-  .custom-headers {
+  .column-headers .row.create {
+    max-width: calc(100% - 75px);
+  }
+
+  .row {
     align-items: center;
+  }
+
+  .select {
+    max-width: 480px;
   }
 </style>

--- a/pkg/harvester/edit/harvesterhci.io.storage/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/index.vue
@@ -197,6 +197,14 @@ export default {
 
       return v2DataEngine.value === 'true' ? DATA_ENGINE_V2 : DATA_ENGINE_V1;
     },
+
+    isCDISettingsFeatureEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('cdiSettings');
+    },
+
+    shouldShowCDISettingsTab() {
+      return this.isCDISettingsFeatureEnabled && this.longhornSystemVersion === DATA_ENGINE_V2;
+    }
   },
 
   watch: {
@@ -403,6 +411,14 @@ export default {
             </div>
           </template>
         </ArrayList>
+      </Tab>
+      <Tab
+        v-if="shouldShowCDISettingsTab"
+        name="cdiSettings"
+        :label="t('harvester.storage.cdiSettings.label')"
+        :weight="-2"
+      >
+        CDI Settings
       </Tab>
     </Tabbed>
   </CruResource>

--- a/pkg/harvester/edit/harvesterhci.io.storage/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/index.vue
@@ -455,7 +455,7 @@ export default {
         <CDISettings
           v-model:cdi-settings="cdiSettings"
           :value="value"
-          :mode="modeOverride"
+          :mode="mode"
           :provisioner="value.provisioner"
           :is-create="isCreate"
         />

--- a/pkg/harvester/edit/harvesterhci.io.storage/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/index.vue
@@ -287,16 +287,16 @@ export default {
     },
     formatCDISettings() {
       const annotations = this.value.metadata.annotations || {};
-      const volumeModeAccessMode = {};
+      const volumeModeAccessModes = {};
 
-      this.cdiSettings.volumeModeAccessMode.forEach((setting) => {
+      this.cdiSettings.volumeModeAccessModes.forEach((setting) => {
         if (setting.volumeMode && Array.isArray(setting.accessModes) && setting.accessModes.length > 0) {
-          volumeModeAccessMode[setting.volumeMode] = setting.accessModes;
+          volumeModeAccessModes[setting.volumeMode] = setting.accessModes;
         }
       });
 
-      if (Object.keys(volumeModeAccessMode).length > 0) {
-        annotations[HCI_ANNOTATIONS.VOLUME_MODE_ACCESS_MODES] = JSON.stringify(volumeModeAccessMode);
+      if (Object.keys(volumeModeAccessModes).length > 0) {
+        annotations[HCI_ANNOTATIONS.VOLUME_MODE_ACCESS_MODES] = JSON.stringify(volumeModeAccessModes);
       }
 
       if (this.cdiSettings.volumeSnapshotClass) {

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1373,6 +1373,21 @@ harvester:
       cannotDeleteOrDefaultTooltip: Internal storage classes cannot be deleted or set as default
     cdiSettings:
       label: CDI Settings
+      volumeModeAndAccessMode:
+        label: Volume Mode / Access Mode
+        tooltip: Specifies the default volume mode and access modes.
+        add: Add
+        volumeMode: Volume Mode
+        accessMode: Access Mode
+      volumeSnapshotClass:
+        label: Volume Snapshot Class
+        tooltip: Sets the Volume Snapshot Class name to be used when taking snapshots of PVCs under this StorageClass.
+      cloneStrategy:
+        label: Clone Strategy
+        tooltip: Defines the clone strategy to use for volumes created with this StorageClass.
+      fileSystemOverhead:
+        label: File System Overhead
+        tooltip: Specifies the percentage of filesystem overhead to consider when calculating PVC size.
 
   vlanConfig:
     title: Network Configuration

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1017,7 +1017,7 @@ harvester:
         progress: Restore in progress
         complete: Restore completed
 
-  subnet: 
+  subnet:
     cidrBlock:
       tooltip: The subnet range in CIDR notation. Note that the CIDR blocks of different Subnets' within the same VPC cannot overlap.
       label: CIDR Block
@@ -1068,8 +1068,6 @@ harvester:
         placeholder: e.g. 169.254.0.1/16
       remoteVpc:
         label: Remote VPC
-    
-   
   network:
     label: Virtual Machine Networks
     tabs:
@@ -1373,6 +1371,8 @@ harvester:
       label: Internal Storage Class
       cannotDeleteTooltip: Internal storage class volumes cannot be deleted
       cannotDeleteOrDefaultTooltip: Internal storage classes cannot be deleted or set as default
+    cdiSettings:
+      label: CDI Settings
 
   vlanConfig:
     title: Network Configuration

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1373,13 +1373,13 @@ harvester:
       cannotDeleteOrDefaultTooltip: Internal storage classes cannot be deleted or set as default
     cdiSettings:
       label: CDI Settings
-      volumeModeAndAccessMode:
-        label: Volume Mode / Access Mode
+      volumeModeAccessModes:
+        label: Volume Mode / Access Modes
         tooltip: Specifies the default volume mode and access modes.
         add: Add
         volumeMode: Volume Mode
-        accessMode:
-          label: Access Mode
+        accessModes:
+          label: Access Modes
       volumeSnapshotClass:
         label: Volume Snapshot Class
         tooltip: Sets the Volume Snapshot Class name to be used when taking snapshots of PVCs under this StorageClass.

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1378,16 +1378,21 @@ harvester:
         tooltip: Specifies the default volume mode and access modes.
         add: Add
         volumeMode: Volume Mode
-        accessMode: Access Mode
+        accessMode:
+          label: Access Mode
       volumeSnapshotClass:
         label: Volume Snapshot Class
         tooltip: Sets the Volume Snapshot Class name to be used when taking snapshots of PVCs under this StorageClass.
       cloneStrategy:
         label: Clone Strategy
         tooltip: Defines the clone strategy to use for volumes created with this StorageClass.
+        copy: Copy
+        snapshot: Snapshot
+        csiClone: CSI Clone
       fileSystemOverhead:
         label: File System Overhead
         tooltip: Specifies the percentage of filesystem overhead to consider when calculating PVC size.
+        placeholder: e.g. 0.05 (up to 3 decimal places, between 0 and 1)
 
   vlanConfig:
     title: Network Configuration


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Add `CDI Settings` tab in storage class page
- `CDI Settings` tab is not available for `longhorn-v1` StorageClass

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @brandboat 

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[GUI] [FEATURE] Expose CDI settings in Harvester to allow fine tuning CDI settings for day 2 operations #8682](https://github.com/harvester/harvester/issues/8682)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Create a SC with provisioner `Longhorn V1 (CSI)`, CDI Settings tab should be hidden
- Create a SC with provisioner `Longhorn V2 (CSI)` or `LVM`, CDI Settings tab should be visible
- Hover over and verify the tooltip content:
  - **Filesystem Overhead**: Specifies the percentage of filesystem overhead to consider when calculating PVC size.
  - **Clone Strategy**: Defines the clone strategy to use for volumes created with this StorageClass.
  - **Volume Snapshot Class**: Sets the Volume Snapshot Class name to be used when taking snapshots of PVCs under this StorageClass.
  - **Volume Mode Access Modes**: Specifies the default volume mode and access modes.
- Add combinations for `Volume Mode / Access Modes`:
  - Volume mode must be either `FileSystem` or `Block`
  - Access modes can include multiple from `ReadWriteOnce`, `ReadOnlyMany`, `ReadWriteMany`, `ReadWriteOncePod`
- `Volume Snapshot Class` should inherit value from `csi-driver-config` if not set manually
- Select `Clone Strategy` from `Copy`, `Snapshot`, `CSI Clone`
- Input `Filesystem Overhead` as a float between `0` and `1` (e.g., `0.123`)
- Input `Filesystem Overhead` should show **error state** if input is invalid
- Click `Save` and confirm the following annotations are added to the SC:
  - `cdi.harvesterhci.io/filesystemOverhead`
  - `cdi.harvesterhci.io/storageProfileCloneStrategy`
  - `cdi.harvesterhci.io/storageProfileVolumeSnapshotClass`
  - `cdi.harvesterhci.io/storageProfileVolumeModeAccessModes`
- Go to the SC details page, confirm values are displayed correctly

https://github.com/user-attachments/assets/a6df6d08-57a3-4dc8-8caf-00852a40f2a4
