### PR TITLE
fix: no namespaces information when trying to change the support-bundle-namespaces settings

### DIFF
--- a/pkg/harvester/components/settings/support-bundle-namespaces.vue
+++ b/pkg/harvester/components/settings/support-bundle-namespaces.vue
@@ -53,8 +53,6 @@ export default {
     },
 
     namespaceOptions() {
-      if (this.availableNamespaces.length === 0) return [];
-
       const allSelected =
         this.namespaces.length === this.filteredNamespaces.length &&
         this.filteredNamespaces.every((ns) => this.namespaces.includes(ns));


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- The dropdown is empty because there is JS exception error

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] No namespaces information when trying to change the support-bundle-namespaces settings #8739](https://github.com/harvester/harvester/issues/8739#event-18770745975)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
- Navigate to Advanced > Setting > support-bundle-namespaces
- Click the dropdown menu and verify it displays correct namespaces

https://github.com/user-attachments/assets/98d455c4-87ef-4c4b-b65f-be71d6032d3a
