### PR TITLE
refactor: filter anchor link in setting description when searching by keyword

### DIFF
--- a/pkg/harvester/components/SettingList.vue
+++ b/pkg/harvester/components/SettingList.vue
@@ -98,8 +98,12 @@ export default {
           return true;
         }
 
-        const description = this.t(setting.description, this.getDocLinkParams(setting) || {}, true)?.toLowerCase() || '';
+        let description = this.t(setting.description, this.getDocLinkParams(setting) || {}, true)?.toLowerCase() || '';
 
+        // remove <a> tags from description
+        if (description.includes('<a')) {
+          description = description.replace(/<a[^>]*>(.*?)<\/a>/g, '$1');
+        }
         // filter by description
         if (description.includes(searchQuery)) {
           return true;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
refactor: filter anchor link in setting description when searching

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/8477

### Test screenshot or video
Before
<img width="1920" height="1080" alt="des" src="https://github.com/user-attachments/assets/b8b268f6-42f6-46ba-a3d0-2d8bdf7bb3b1" />


After
<img width="1496" height="705" alt="Screenshot 2025-07-28 at 2 29 04 PM" src="https://github.com/user-attachments/assets/0ce50f00-fa6a-4b3f-88a8-0c9208627b92" />
<img width="1496" height="647" alt="image" src="https://github.com/user-attachments/assets/08b995fd-faaa-4c94-9320-34b98f2b1303" />
