### PR TITLE
fix: cpu/ memory columns in host detail VM tab

### DIFF
--- a/pkg/harvester/detail/harvesterhci.io.host/VirtualMachineInstance.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/VirtualMachineInstance.vue
@@ -47,20 +47,26 @@ export default {
         STATE,
         NAME,
         {
-          name:     'vmCPU',
-          labelKey: 'tableHeaders.cpu',
-          search:   false,
-          sort:     ['spec.template.spec.domain.cpu.cores'],
-          value:    'spec.template.spec.domain.cpu.cores',
-          width:    120
+          name:        'CPU',
+          label:       'CPU',
+          sort:        ['displayCPU'],
+          value:       'displayCPU',
+          align:       'center',
+          dashIfEmpty: true,
         },
         {
-          name:     'vmRAM',
-          labelKey: 'glance.memory',
-          search:   false,
-          sort:     ['memorySort'],
-          value:    'spec.template.spec.domain.resources.limits.memory',
-          width:    120
+          name:          'Memory',
+          value:         'displayMemory',
+          sort:          ['memorySort'],
+          align:         'center',
+          labelKey:      'tableHeaders.memory',
+          formatter:     'Si',
+          formatterOpts: {
+            opts: {
+              increment: 1024, addSuffix: true, maxExponent: 3, minExponent: 3, suffix: 'i',
+            },
+            needParseSi: true
+          },
         },
         {
           name:      'ip',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Forget to update the CPU / Memory columns in host detail VM tab page.


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/8416

### Test screenshot or video
Before 
<img width="1470" height="795" alt="Screenshot 2025-07-29 at 3 47 55 PM" src="https://github.com/user-attachments/assets/f15c2b62-de8c-4aeb-8b60-428bc8db5490" />

After 


<img width="1470" height="733" alt="Screenshot 2025-07-29 at 3 52 13 PM" src="https://github.com/user-attachments/assets/7bcc73c9-412f-4055-aca6-60a9818cb0e9" />
