### PR TITLE
chore: bump version to v1.6.0-rc4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harvester-ui-extension",
-  "version": "1.6.0-rc3",
+  "version": "1.6.0-rc4",
   "private": false,
   "engines": {
     "node": ">=20.0.0"

--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -113,7 +113,10 @@ export const HCI_ALLOWED_SETTINGS = {
   [HCI_SETTING.RANCHER_CLUSTER]:                        {
     kind: 'custom', from: 'import', canReset: true, featureFlag: 'rancherClusterSetting'
   },
-  [HCI_SETTING.MAX_HOTPLUG_RATIO]: { kind: 'number', featureFlag: 'cpuMemoryHotplug' },
+  [HCI_SETTING.MAX_HOTPLUG_RATIO]:    { kind: 'number', featureFlag: 'cpuMemoryHotplug' },
+  [HCI_SETTING.VM_MIGRATION_NETWORK]:  {
+    kind: 'json', from: 'import', canReset: true, featureFlag: 'vmNetworkMigration',
+  },
 };
 
 export const HCI_SINGLE_CLUSTER_ALLOWED_SETTING = {

--- a/pkg/harvester/package.json
+++ b/pkg/harvester/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvester",
   "description": "Rancher UI Extension for Harvester",
-  "version": "1.6.0-rc3",
+  "version": "1.6.0-rc4",
   "private": false,
   "rancher": {
     "annotations": {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- chore: bump version to v1.6.0-rc4
- fix: missing vm migration network setting (mis-remove by PR commit https://github.com/harvester/harvester-ui-extension/pull/391/commits/3ee8e851ccbb0d05c3989c235dab4dc0241e3d8a#diff-3ae8225bde0a37f75e179477d54d243c5d603b1ff44ef993aa2a43b727f29264)

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video
<img width="1462" height="803" alt="Screenshot 2025-07-30 at 12 09 22 PM" src="https://github.com/user-attachments/assets/996c15b0-587b-4fa5-a5d2-a33d11e44402" />
<img width="1469" height="801" alt="Screenshot 2025-07-30 at 12 09 31 PM" src="https://github.com/user-attachments/assets/6dde8a70-1402-4063-93db-d1d5a3157616" />



