### PR TITLE
fix: use default when csi-driver-config is not configured

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/CDISettings.vue
@@ -44,6 +44,12 @@ export default {
     };
 
     await allHash(hash);
+
+    if (this.mode === _CREATE ) {
+      this.setDefaultVolumeSnapshotClass();
+    } else {
+      this.initCDISettingsFromAnnotations();
+    }
   },
 
   data() {
@@ -57,14 +63,6 @@ export default {
       defaultAddValue: { volumeMode: null, accessModes: [] },
       noneOption:      { label: 'None', value: '' },
     };
-  },
-
-  created() {
-    if (this.mode === _CREATE ) {
-      this.setDefaultVolumeSnapshotClass();
-    } else {
-      this.initCDISettingsFromAnnotations();
-    }
   },
 
   computed: {
@@ -148,7 +146,7 @@ export default {
     setDefaultVolumeSnapshotClass() {
       try {
         const setting = this.$store.getters[`${ this.inStore }/byId`](HCI.SETTING, HCI_SETTING.CSI_DRIVER_CONFIG);
-        const config = JSON.parse(setting?.value || '{}');
+        const config = JSON.parse(setting?.value || setting?.default || '{}');
         const defaultClass = config?.[this.provisioner]?.volumeSnapshotClassName || null;
 
         const allClasses = this.$store.getters[`${ this.inStore }/all`](VOLUME_SNAPSHOT_CLASS) || [];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- If user never config `csi-driver-config`, there is no `value` in the settings response

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[GUI] [FEATURE] Expose CDI settings in Harvester to allow fine tuning CDI settings for day 2 operations #8682](https://github.com/harvester/harvester/issues/8682)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/48ba19c3-e65a-4044-a1e0-6591dfd3279b


