### PR TITLE
fix: spec.domain.memory.guest is lost when restart VM

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -257,6 +257,7 @@ export default {
         :label="t('harvester.vmTemplate.tabs.basics')"
       >
         <CpuMemory
+          class="mb-20"
           :cpu="cpu"
           :memory="memory"
           :max-cpu="maxCpu"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineSSHKey.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineSSHKey.vue
@@ -240,7 +240,7 @@ export default {
 </script>
 
 <template>
-  <div class="mt-20">
+  <div>
     <LabeledSelect
       v-model:value="checkedSsh"
       :label="t('harvester.virtualMachine.input.sshKey')"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -605,6 +605,7 @@ export default {
         :label="t('harvester.virtualMachine.detail.tabs.basics')"
       >
         <CpuMemory
+          class="mb-20"
           :cpu="cpu"
           :max-cpu="maxCpu"
           :memory="memory"

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -691,10 +691,13 @@ export default {
         this.spec.template.spec.domain.cpu.cores = this.cpu;
         this.spec.template.spec.domain.resources.limits.cpu = this.cpu?.toString();
         this.spec.template.spec.domain.resources.limits.memory = this.memory;
-        // clean
-        delete this.spec.template.spec.resources;
-        delete this.spec.template.spec.domain.memory;
-        delete this.spec.template.spec.domain.cpu.maxSockets;
+        // clean below fields as we don't need them if not enable CPU and memory hotplug
+        if (this.spec?.template?.spec?.domain?.cpu?.maxSockets) {
+          delete this.spec.template.spec.domain.cpu.maxSockets;
+        }
+        if (this.spec?.template?.spec?.domain?.memory?.maxGuest) {
+          delete this.spec.template.spec.domain.memory.maxGuest;
+        }
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Checked with @FrankYang0529, remove below fields if uncheck CPU/memory hotplug feature 
- `spec.template.spec.domain.cpu.maxSockets`
- `spec.template.spec.domain.memory.maxGuest`

Fix the sshkey margin style

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @FrankYang0529 

### Related Issue #
https://github.com/harvester/harvester/issues/8907

### Test screenshot or video
After fix

https://github.com/user-attachments/assets/8dea8e2c-bc4d-49af-9b15-af208fc841d2




