### PR TITLE
ci: only run PR lint in PR stage

### DIFF
--- a/.github/workflows/run-lint.yaml
+++ b/.github/workflows/run-lint.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: ./.github/actions/lint
 
       - name: Validate PR title lint
+        if: github.event_name == 'pull_request'
         shell: bash
         run: echo "${{ github.event.pull_request.title }}" | npx commitlint
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
ci: only run PR lint in PR stage

https://github.com/harvester/harvester-ui-extension/actions/runs/17144532209/job/48638051804

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/8621

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


