### PR TITLE
fix: preserve YAML device parameters on config editing

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -767,6 +767,9 @@ export default {
         }
       }
 
+      const specDisks = this.spec?.template?.spec?.domain?.devices?.disks;
+      const mergedDisks = this.mergeDeviceList(specDisks, disks);
+
       let spec = {
         ...this.spec,
         runStrategy: this.runStrategy,
@@ -789,7 +792,7 @@ export default {
               ...this.spec.template?.spec?.domain,
               devices: {
                 ...this.spec.template?.spec?.domain?.devices,
-                disks,
+                disks: mergedDisks,
               },
             },
             volumes,
@@ -888,13 +891,16 @@ export default {
         interfaces.push(_interface);
       });
 
+      const specInterfaces = this.spec?.template?.spec?.domain?.devices?.interfaces;
+      const mergedInterfaces = this.mergeDeviceList(specInterfaces, interfaces);
+
       const spec = {
         ...this.spec.template.spec,
         domain: {
           ...this.spec.template.spec.domain,
           devices: {
             ...this.spec.template.spec.domain.devices,
-            interfaces,
+            interfaces: mergedInterfaces,
           },
         },
         networks
@@ -1541,6 +1547,23 @@ export default {
       }
 
       this.refreshYamlEditor();
+    },
+
+    mergeDeviceList(specDeviceList, deviceList) {
+      if (!specDeviceList || specDeviceList.length === 0) {
+        return deviceList;
+      }
+      const specDeviceMap = new Map(specDeviceList.map((device) => [device.name, device]));
+
+      return deviceList.map((device) => {
+        const specDevice = specDeviceMap.get(device.name);
+
+        if (specDevice) {
+          return { ...specDevice, ...device };
+        }
+
+        return device;
+      });
     },
 
     refreshYamlEditor() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This fixes the bug described on https://github.com/harvester/harvester/issues/8946
VM device configurations were being incorrectly overwritten when generating their YAML specifications.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
https://github.com/harvester/harvester/issues/8946

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


