### PR TITLE
feat: display N/A in vlanID for overlay network

### DIFF
--- a/pkg/harvester/models/k8s.cni.cncf.io.networkattachmentdefinition.js
+++ b/pkg/harvester/models/k8s.cni.cncf.io.networkattachmentdefinition.js
@@ -2,7 +2,7 @@ import SteveModel from '@shell/plugins/steve/steve-class';
 import { HCI } from '@shell/config/labels-annotations';
 import { NETWORK_TYPE } from '../config/types';
 
-const { UNTAGGED } = NETWORK_TYPE;
+const { UNTAGGED, OVERLAY } = NETWORK_TYPE;
 
 export default class NetworkAttachmentDef extends SteveModel {
   applyDefaults() {
@@ -45,7 +45,7 @@ export default class NetworkAttachmentDef extends SteveModel {
   }
 
   get vlanId() {
-    return this.vlanType === UNTAGGED ? 'N/A' : this.parseConfig.vlan;
+    return this.vlanType === UNTAGGED || this.vlanType === OVERLAY ? 'N/A' : this.parseConfig.vlan;
   }
 
   get customValidationRules() {
@@ -68,7 +68,7 @@ export default class NetworkAttachmentDef extends SteveModel {
     const route = annotations[HCI.NETWORK_ROUTE];
     let config = {};
 
-    if (this.vlanType === UNTAGGED) {
+    if (this.vlanType === UNTAGGED || this.vlanType === OVERLAY) {
       return 'N/A';
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
feat: display N/A in vlanID and route connectivity for created overlay network.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/8724

### Test screenshot or video
Before
<img width="1496" height="808" alt="Screenshot 2025-09-05 at 10 51 47 AM" src="https://github.com/user-attachments/assets/c36ba7ca-7660-4b23-ae2f-a295b4ab2110" />

After


<img width="1491" height="801" alt="Screenshot 2025-09-05 at 10 51 51 AM" src="https://github.com/user-attachments/assets/9d6bde0c-e81f-44e5-851a-4bcb7fc7f5a5" />
