### PR TITLE
fix: unable to create VM when choose l2vlan network

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -891,16 +891,13 @@ export default {
         interfaces.push(_interface);
       });
 
-      const specInterfaces = this.spec?.template?.spec?.domain?.devices?.interfaces;
-      const mergedInterfaces = this.mergeDeviceList(specInterfaces, interfaces);
-
       const spec = {
         ...this.spec.template.spec,
         domain: {
           ...this.spec.template.spec.domain,
           devices: {
             ...this.spec.template.spec.domain.devices,
-            interfaces: mergedInterfaces,
+            interfaces,
           },
         },
         networks
@@ -1098,6 +1095,10 @@ export default {
 
       if (R.macAddress) {
         _interface.macAddress = R.macAddress;
+      }
+
+      if (R.tag) {
+        _interface.tag = R.tag;
       }
 
       _interface.model = R.model;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fix: unable to create VM when choose l2vlan network

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/9165

### Test screenshot or video

https://github.com/user-attachments/assets/5dd8b94d-c993-448d-a651-747240bf027c




