### PR TITLE
fix: set maxSockets : 1 if not enabled cpuMemoryhotplug

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -687,14 +687,12 @@ export default {
         set(this.spec.template.spec, 'domain.memory.maxGuest', this.maxMemory);
         set(this.spec.template.spec, 'domain.resources.limits.memory', this.maxMemory);
       } else {
+        this.spec.template.spec.domain.cpu.maxSockets = 1;
         this.spec.template.spec.domain.cpu.sockets = 1;
         this.spec.template.spec.domain.cpu.cores = this.cpu;
         this.spec.template.spec.domain.resources.limits.cpu = this.cpu?.toString();
         this.spec.template.spec.domain.resources.limits.memory = this.memory;
         // clean below fields as we don't need them if not enable CPU and memory hotplug
-        if (this.spec?.template?.spec?.domain?.cpu?.maxSockets) {
-          delete this.spec.template.spec.domain.cpu.maxSockets;
-        }
         if (this.spec?.template?.spec?.domain?.memory?.maxGuest) {
           delete this.spec.template.spec.domain.memory.maxGuest;
         }

--- a/pkg/harvester/utils/cpuMemory.js
+++ b/pkg/harvester/utils/cpuMemory.js
@@ -10,10 +10,12 @@ export function getVmCPUMemoryValues(vm) {
   }
 
   const isHotplugEnabled = isCPUMemoryHotPlugEnabled(vm);
+  const { sockets = 1, threads = 1, cores = 1 } = vm.spec.template.spec.domain.cpu || {};
+  const cpu = sockets * threads * cores;
 
   if (isHotplugEnabled) {
     return {
-      cpu:       vm.spec.template.spec.domain.cpu.sockets,
+      cpu,
       memory:    vm.spec.template.spec.domain?.memory?.guest || null,
       maxCpu:    vm.spec.template.spec.domain.cpu?.maxSockets || 0,
       maxMemory: vm.spec.template.spec.domain?.memory?.maxGuest || null,
@@ -21,7 +23,7 @@ export function getVmCPUMemoryValues(vm) {
     };
   } else {
     return {
-      cpu:    vm.spec.template.spec.domain.cpu.cores,
+      cpu,
       memory: vm.spec.template.spec.domain.resources?.limits?.memory || null,
       isHotplugEnabled
     };
@@ -29,8 +31,5 @@ export function getVmCPUMemoryValues(vm) {
 }
 
 export function isCPUMemoryHotPlugEnabled(vm) {
-  return vm?.metadata?.annotations[HCI_ANNOTATIONS.VM_CPU_MEMORY_HOTPLUG] === 'true' ||
-    !!vm?.spec?.template?.spec?.domain.cpu?.maxSockets ||
-    !!vm?.spec?.template?.spec?.domain?.memory?.maxGuest ||
-    false;
+  return vm?.metadata?.annotations[HCI_ANNOTATIONS.VM_CPU_MEMORY_HOTPLUG] === 'true' || !!vm?.spec?.template?.spec?.domain?.memory?.maxGuest || false;
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Change 
- set maxSockets : 1 if not enabled cpuMemory hotplug
- show CPU count by `cores*sockets*threads` no matter enable cpuMemory hotplug or not
### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/9059

### Test screenshot or video

https://github.com/user-attachments/assets/0c6f6931-b604-45ed-8ea8-21af23ccd553



