### PR TITLE
feat: drop machine type dropdown from VM advanced options

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -39,7 +39,6 @@ const FEATURE_FLAGS = {
   ],
   'v1.5.1': [],
   'v1.6.0': [
-    'vmMachineTypes',
     'customSupportBundle',
     'csiOnlineExpandValidation',
     'vmNetworkMigration',
@@ -50,7 +49,9 @@ const FEATURE_FLAGS = {
     'vmCloneRunStrategy',
   ],
   'v1.6.1': [],
-  'v1.7.0': []
+  'v1.7.0': [
+    'vmMachineTypeAuto'
+  ]
 };
 
 const generateFeatureFlags = () => {

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -873,7 +873,10 @@ export default {
               />
             </div>
 
-            <div class="col span-6">
+            <div
+              v-if="!value.vmMachineTypeAutoFeatureEnabled"
+              class="col span-6"
+            >
               <LabeledSelect
                 v-model:value="machineType"
                 label-key="harvester.virtualMachine.input.MachineType"

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -299,9 +299,11 @@ export default {
   async created() {
     await this.$store.dispatch(`${ this.inStore }/findAll`, { type: SECRET });
 
-    if (this.value.vmMachineTypesFeatureEnabled) {
+    if (!this.value.vmMachineTypeAutoFeatureEnabled) {
       try {
-        const url = this.$store.getters['harvester-common/getHarvesterClusterUrl']('v1/harvester/clusters/local?link=machineTypes');
+        const url = this.$store.getters['harvester-common/getHarvesterClusterUrl'](
+          'v1/harvester/clusters/local?link=machineTypes'
+        );
         const machineTypes = await this.$store.dispatch('harvester/request', { url });
 
         this.machineTypes = machineTypes;

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -1236,8 +1236,8 @@ export default class VirtVm extends HarvesterResource {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('thirdPartyStorage');
   }
 
-  get vmMachineTypesFeatureEnabled() {
-    return this.$rootGetters['harvester-common/getFeatureEnabled']('vmMachineTypes');
+  get vmMachineTypeAutoFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('vmMachineTypeAuto');
   }
 
   get isBackupTargetUnavailable() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Removed the `Machine Type` dropdown from the VM advanced options

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is: 

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[ENHANCEMENT] drop machine type dropdown from VM advanced options #8631](https://github.com/harvester/harvester/issues/8631)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**v1.7.0**
<img width="1920" height="1016" alt="1 7 0" src="https://github.com/user-attachments/assets/a6677b56-306c-4bc3-9112-1b02b9e15cab" />

**v1.6.0**
<img width="1920" height="1019" alt="1 6 0" src="https://github.com/user-attachments/assets/e06bec6f-0ab2-4941-a9e4-baf11a3b5406" />
