### PR TITLE
fix: miimon value not set to default(100ms) when user configures -1 from UI

### DIFF
--- a/pkg/harvester/models/network.harvesterhci.io.vlanconfig.js
+++ b/pkg/harvester/models/network.harvesterhci.io.vlanconfig.js
@@ -16,7 +16,10 @@ export default class HciVlanConfig extends HarvesterResource {
       uplink: {
         nics:           [],
         linkAttributes: {},
-        bondOptions:    { mode: 'active-backup' },
+        bondOptions:    {
+          mode:   'active-backup',
+          miimon: -1
+        },
       },
     };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Set `mode: active-backup` and `miimon: -1` by default

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
[[BUG] miimon value not set to default(100ms) when user configures -1 from UI #8015](https://github.com/harvester/harvester/issues/9274)

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
https://github.com/user-attachments/assets/11050339-146e-46a0-9a2b-6c120cb9a735


