### PR TITLE
feat: add Insecure Skip TLS Verify checkbox in cluster-registration-url setting

### DIFF
--- a/pkg/harvester/components/settings/cluster-registration-url.vue
+++ b/pkg/harvester/components/settings/cluster-registration-url.vue
@@ -1,0 +1,111 @@
+<script>
+import Tip from '@shell/components/Tip';
+import MessageLink from '@shell/components/MessageLink';
+import CreateEditView from '@shell/mixins/create-edit-view';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import { HCI_SETTING } from '../../config/settings';
+import { Checkbox } from '@components/Form/Checkbox';
+
+export default {
+  name: 'HarvesterEditClusterRegistrationURL',
+
+  components: {
+    LabeledInput, Tip, MessageLink, Checkbox
+  },
+
+  mixins: [CreateEditView],
+
+  data() {
+    let parseDefaultValue = {};
+
+    try {
+      parseDefaultValue = JSON.parse(this.value.value);
+    } catch (error) {
+      parseDefaultValue = { url: '', insecureSkipTLSVerify: true };
+    }
+
+    return {
+      parseDefaultValue,
+      errors: []
+    };
+  },
+
+  created() {
+    this.update();
+  },
+  computed: {
+    toCA() {
+      return `${ HCI_SETTING.ADDITIONAL_CA }?mode=edit`;
+    }
+  },
+
+  watch: {
+    value: {
+      handler(neu) {
+        let parseDefaultValue;
+
+        try {
+          parseDefaultValue = JSON.parse(neu.value);
+        } catch (err) {
+          parseDefaultValue = { url: '', insecureSkipTLSVerify: true };
+        }
+        this.parseDefaultValue = parseDefaultValue;
+        this.update();
+      },
+      deep: true
+    }
+  },
+
+  methods: {
+    update() {
+      this.value['value'] = JSON.stringify(this.parseDefaultValue);
+    },
+
+    useDefault() {
+      this.parseDefaultValue = { url: '', insecureSkipTLSVerify: true };
+    }
+  }
+};
+</script>
+
+<template>
+  <div
+    class="row"
+    @input="update"
+  >
+    <div class="col span-12">
+      <LabeledInput
+        v-model:value="parseDefaultValue.url"
+        class="mb-20"
+        :mode="mode"
+        :label="t('harvester.setting.clusterRegistrationUrl.url')"
+      />
+      <Checkbox
+        v-model:value="parseDefaultValue.insecureSkipTLSVerify"
+        class="check mb-5"
+        type="checkbox"
+        :label="t('harvester.setting.clusterRegistrationUrl.insecureSkipTLSVerify')"
+      />
+      <Tip
+        class="mb-20"
+        icon="icon icon-info"
+      >
+        <MessageLink
+          :to="toCA"
+          target="_blank"
+          prefix-label="harvester.setting.clusterRegistrationUrl.tip.prefix"
+          middle-label="harvester.setting.clusterRegistrationUrl.tip.middle"
+          suffix-label="harvester.setting.clusterRegistrationUrl.tip.suffix"
+        />
+      </Tip>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+// p {
+//   display: flex;
+//   align-items: center;
+// }
+
+</style>

--- a/pkg/harvester/components/settings/cluster-registration-url.vue
+++ b/pkg/harvester/components/settings/cluster-registration-url.vue
@@ -21,7 +21,7 @@ export default {
     try {
       parseDefaultValue = JSON.parse(this.value.value);
     } catch (error) {
-      parseDefaultValue = { url: '', insecureSkipTLSVerify: true };
+      parseDefaultValue = { url: '', insecureSkipTLSVerify: false };
     }
 
     return {
@@ -47,7 +47,7 @@ export default {
         try {
           parseDefaultValue = JSON.parse(neu.value);
         } catch (err) {
-          parseDefaultValue = { url: '', insecureSkipTLSVerify: true };
+          parseDefaultValue = { url: '', insecureSkipTLSVerify: false };
         }
         this.parseDefaultValue = parseDefaultValue;
         this.update();
@@ -62,8 +62,15 @@ export default {
     },
 
     useDefault() {
-      this.parseDefaultValue = { url: '', insecureSkipTLSVerify: true };
-    }
+      this.parseDefaultValue = { url: '', insecureSkipTLSVerify: false };
+    },
+
+    updateInsecureSkipTLSVerify(newValue) {
+      const { url = '' } = this.parseDefaultValue;
+
+      this.parseDefaultValue = { url, insecureSkipTLSVerify: newValue };
+      this.update();
+    },
   }
 };
 </script>
@@ -85,6 +92,7 @@ export default {
         class="check mb-5"
         type="checkbox"
         :label="t('harvester.setting.clusterRegistrationUrl.insecureSkipTLSVerify')"
+        @update:value="updateInsecureSkipTLSVerify"
       />
       <Tip
         class="mb-20"
@@ -101,11 +109,3 @@ export default {
     </div>
   </div>
 </template>
-
-<style lang="scss" scoped>
-// p {
-//   display: flex;
-//   align-items: center;
-// }
-
-</style>

--- a/pkg/harvester/components/settings/cluster-registration-url.vue
+++ b/pkg/harvester/components/settings/cluster-registration-url.vue
@@ -19,7 +19,9 @@ export default {
     let parseDefaultValue = {};
 
     try {
-      parseDefaultValue = this.value.value.includes('insecureSkipTLSVerify') ? JSON.parse(this.value.value) : this.value.value;
+      const tlsVerifyEnabled = this.$store.getters['harvester-common/getFeatureEnabled']('clusterRegistrationTLSVerify');
+
+      parseDefaultValue = tlsVerifyEnabled ? JSON.parse(this.value.value) : this.value.value;
     } catch (error) {
       parseDefaultValue = this.getDefaultValue();
     }

--- a/pkg/harvester/components/settings/cluster-registration-url.vue
+++ b/pkg/harvester/components/settings/cluster-registration-url.vue
@@ -19,9 +19,9 @@ export default {
     let parseDefaultValue = {};
 
     try {
-      parseDefaultValue = JSON.parse(this.value.value);
+      parseDefaultValue = this.value.value.includes('insecureSkipTLSVerify') ? JSON.parse(this.value.value) : this.value.value;
     } catch (error) {
-      parseDefaultValue = { url: '', insecureSkipTLSVerify: false };
+      parseDefaultValue = this.getDefaultValue();
     }
 
     return {
@@ -30,39 +30,51 @@ export default {
     };
   },
 
-  created() {
-    this.update();
-  },
   computed: {
     toCA() {
       return `${ HCI_SETTING.ADDITIONAL_CA }?mode=edit`;
-    }
-  },
-
-  watch: {
-    value: {
-      handler(neu) {
-        let parseDefaultValue;
-
-        try {
-          parseDefaultValue = JSON.parse(neu.value);
-        } catch (err) {
-          parseDefaultValue = { url: '', insecureSkipTLSVerify: false };
-        }
-        this.parseDefaultValue = parseDefaultValue;
-        this.update();
+    },
+    clusterRegistrationTLSVerifyEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('clusterRegistrationTLSVerify');
+    },
+    registrationURL: {
+      get() {
+        return this.clusterRegistrationTLSVerifyEnabled ? this.parseDefaultValue.url : this.parseDefaultValue;
       },
-      deep: true
+
+      set(value) {
+        if (this.clusterRegistrationTLSVerifyEnabled) {
+          this.parseDefaultValue.url = value;
+        } else {
+          this.parseDefaultValue = value;
+        }
+      }
     }
   },
 
   methods: {
+    getDefaultValue() {
+      if (this.clusterRegistrationTLSVerifyEnabled) {
+        return { url: '', insecureSkipTLSVerify: false };
+      } else {
+        return '';
+      }
+    },
+
+    updateUrl() {
+      this.update();
+    },
+
     update() {
-      this.value['value'] = JSON.stringify(this.parseDefaultValue);
+      if (this.clusterRegistrationTLSVerifyEnabled) {
+        this.value['value'] = JSON.stringify(this.parseDefaultValue);
+      } else {
+        this.value['value'] = this.parseDefaultValue;
+      }
     },
 
     useDefault() {
-      this.parseDefaultValue = { url: '', insecureSkipTLSVerify: false };
+      this.parseDefaultValue = this.getDefaultValue();
     },
 
     updateInsecureSkipTLSVerify(newValue) {
@@ -78,34 +90,36 @@ export default {
 <template>
   <div
     class="row"
-    @input="update"
   >
     <div class="col span-12">
       <LabeledInput
-        v-model:value="parseDefaultValue.url"
+        v-model:value="registrationURL"
         class="mb-20"
         :mode="mode"
         :label="t('harvester.setting.clusterRegistrationUrl.url')"
+        @update:value="updateUrl"
       />
-      <Checkbox
-        v-model:value="parseDefaultValue.insecureSkipTLSVerify"
-        class="check mb-5"
-        type="checkbox"
-        :label="t('harvester.setting.clusterRegistrationUrl.insecureSkipTLSVerify')"
-        @update:value="updateInsecureSkipTLSVerify"
-      />
-      <Tip
-        class="mb-20"
-        icon="icon icon-info"
-      >
-        <MessageLink
-          :to="toCA"
-          target="_blank"
-          prefix-label="harvester.setting.clusterRegistrationUrl.tip.prefix"
-          middle-label="harvester.setting.clusterRegistrationUrl.tip.middle"
-          suffix-label="harvester.setting.clusterRegistrationUrl.tip.suffix"
+      <div v-if="clusterRegistrationTLSVerifyEnabled">
+        <Checkbox
+          v-model:value="parseDefaultValue.insecureSkipTLSVerify"
+          class="check mb-5"
+          type="checkbox"
+          :label="t('harvester.setting.clusterRegistrationUrl.insecureSkipTLSVerify')"
+          @update:value="updateInsecureSkipTLSVerify"
         />
-      </Tip>
+        <Tip
+          class="mb-20"
+          icon="icon icon-info"
+        >
+          <MessageLink
+            :to="toCA"
+            target="_blank"
+            prefix-label="harvester.setting.clusterRegistrationUrl.tip.prefix"
+            middle-label="harvester.setting.clusterRegistrationUrl.tip.middle"
+            suffix-label="harvester.setting.clusterRegistrationUrl.tip.suffix"
+          />
+        </Tip>
+      </div>
     </div>
   </div>
 </template>

--- a/pkg/harvester/components/settings/cluster-registration-url.vue
+++ b/pkg/harvester/components/settings/cluster-registration-url.vue
@@ -19,11 +19,10 @@ export default {
     let parseDefaultValue = {};
 
     try {
-      const tlsVerifyEnabled = this.$store.getters['harvester-common/getFeatureEnabled']('clusterRegistrationTLSVerify');
-
-      parseDefaultValue = tlsVerifyEnabled ? JSON.parse(this.value.value) : this.value.value;
+      parseDefaultValue = JSON.parse(this.value.value);
     } catch (error) {
-      parseDefaultValue = this.getDefaultValue();
+      parseDefaultValue.url = this.value.value;
+      parseDefaultValue.insecureSkipTLSVerify = true;
     }
 
     return {

--- a/pkg/harvester/components/settings/cluster-registration-url.vue
+++ b/pkg/harvester/components/settings/cluster-registration-url.vue
@@ -1,16 +1,16 @@
 <script>
-import Tip from '@shell/components/Tip';
 import MessageLink from '@shell/components/MessageLink';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { HCI_SETTING } from '../../config/settings';
 import { Checkbox } from '@components/Form/Checkbox';
+import { Banner } from '@components/Banner';
 
 export default {
   name: 'HarvesterEditClusterRegistrationURL',
 
   components: {
-    LabeledInput, Tip, MessageLink, Checkbox
+    LabeledInput, MessageLink, Checkbox, Banner
   },
 
   mixins: [CreateEditView],
@@ -93,6 +93,15 @@ export default {
     class="row"
   >
     <div class="col span-12">
+      <Banner color="info">
+        <MessageLink
+          :to="toCA"
+          target="_blank"
+          prefix-label="harvester.setting.clusterRegistrationUrl.tip.prefix"
+          middle-label="harvester.setting.clusterRegistrationUrl.tip.middle"
+          suffix-label="harvester.setting.clusterRegistrationUrl.tip.suffix"
+        />
+      </Banner>
       <LabeledInput
         v-model:value="registrationURL"
         class="mb-20"
@@ -108,18 +117,6 @@ export default {
           :label="t('harvester.setting.clusterRegistrationUrl.insecureSkipTLSVerify')"
           @update:value="updateInsecureSkipTLSVerify"
         />
-        <Tip
-          class="mb-20"
-          icon="icon icon-info"
-        >
-          <MessageLink
-            :to="toCA"
-            target="_blank"
-            prefix-label="harvester.setting.clusterRegistrationUrl.tip.prefix"
-            middle-label="harvester.setting.clusterRegistrationUrl.tip.middle"
-            suffix-label="harvester.setting.clusterRegistrationUrl.tip.suffix"
-          />
-        </Tip>
       </div>
     </div>
   </div>

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -61,6 +61,7 @@ const FEATURE_FLAGS = {
   'v1.8.0': [
     'hotplugCdRom',
     'supportBundleFileNameSetting',
+    'clusterRegistrationTLSVerify'
   ],
 };
 

--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -40,7 +40,6 @@ export const HCI_SETTING = {
   RANCHER_CLUSTER:                        'rancher-cluster',
   MAX_HOTPLUG_RATIO:                      'max-hotplug-ratio',
   KUBEVIRT_MIGRATION:                     'kubevirt-migration'
-
 };
 
 export const HCI_ALLOWED_SETTINGS = {
@@ -131,7 +130,6 @@ export const HCI_SINGLE_CLUSTER_ALLOWED_SETTING = {
     kind:     'custom',
     from:     'import',
     canReset: true,
-    // featureFlag: 'clusterRegistrationTLSVerify'
   },
   [HCI_SETTING.UI_PL]: {
     kind: 'custom', from: 'import', alias: 'branding'

--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -40,6 +40,7 @@ export const HCI_SETTING = {
   RANCHER_CLUSTER:                        'rancher-cluster',
   MAX_HOTPLUG_RATIO:                      'max-hotplug-ratio',
   KUBEVIRT_MIGRATION:                     'kubevirt-migration'
+
 };
 
 export const HCI_ALLOWED_SETTINGS = {
@@ -127,9 +128,10 @@ export const HCI_ALLOWED_SETTINGS = {
 
 export const HCI_SINGLE_CLUSTER_ALLOWED_SETTING = {
   [HCI_SETTING.CLUSTER_REGISTRATION_URL]: {
-    kind:     'json',
+    kind:     'custom',
     from:     'import',
     canReset: true,
+    // featureFlag: 'clusterRegistrationTLSVerify'
   },
   [HCI_SETTING.UI_PL]: {
     kind: 'custom', from: 'import', alias: 'branding'

--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -127,7 +127,8 @@ export const HCI_ALLOWED_SETTINGS = {
 
 export const HCI_SINGLE_CLUSTER_ALLOWED_SETTING = {
   [HCI_SETTING.CLUSTER_REGISTRATION_URL]: {
-    kind:     'url',
+    kind:     'json',
+    from:     'import',
     canReset: true,
   },
   [HCI_SETTING.UI_PL]: {

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1354,7 +1354,7 @@ harvester:
       url: URL
       insecureSkipTLSVerify: Insecure Skip TLS Verify
       tip: 
-        prefix: Harvester secures cluster registration via TLS by default. If opt out this option, you must provide custom CA certificates using the
+        prefix: Harvester secures cluster registration via TLS by default. If opt out "Insecure SKip TLS Verify", you must provide custom CA certificates using the
         middle: 'additional-ca'
         suffix: setting.
       message: To completely unset the imported Harvester cluster, please also remove it on the Rancher Dashboard UI via the <code> Virtualization Management </code> page.

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1351,6 +1351,12 @@ harvester:
         retention: How long to retain metrics
         retentionSize: Maximum size of metrics
     clusterRegistrationUrl:
+      url: URL
+      insecureSkipTLSVerify: Insecure Skip TLS Verify
+      tip: 
+        prefix: Harvester secures cluster registration via TLS by default. If opt out this option, you must provide custom CA certificates using the
+        middle: 'additional-ca'
+        suffix: setting.
       message: To completely unset the imported Harvester cluster, please also remove it on the Rancher Dashboard UI via the <code> Virtualization Management </code> page.
     ntpServers:
       isNotIPV4: The address you entered is not IPv4 or host. Please enter a valid IPv4 address or a host address.

--- a/pkg/harvester/models/harvesterhci.io.setting.js
+++ b/pkg/harvester/models/harvesterhci.io.setting.js
@@ -52,10 +52,18 @@ export default class HciSetting extends HarvesterResource {
     });
   }
 
+  get clusterRegistrationTLSVerifyFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('clusterRegistrationTLSVerify');
+  }
+
   get customValue() {
     if (this.metadata.name === HCI_SETTING.STORAGE_NETWORK) {
       try {
         return JSON.stringify(JSON.parse(this.value), null, 2);
+      } catch (e) {}
+    } else if (this.metadata.name === HCI_SETTING.CLUSTER_REGISTRATION_URL) {
+      try {
+        return this.clusterRegistrationTLSVerifyFeatureEnabled ? JSON.stringify(JSON.parse(this.value), null, 2) : this.value;
       } catch (e) {}
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
From v1.8.0, we default enable the TLS for rancher registration connection. 

The payload changed to a json object (in string type)
```
{
  "url": "https://10.115.4.204/v3/import/55zm68mf68xrnt2xjgwk2rnslfkpx8jmlszxccjlmn7cvkbx54z5jv_c-7dwsd.yaml",
  "insecureSkipTLSVerify": true
}
```


For v1.7.1 or earlier verion, keep original payload as string
```
https://10.115.4.204/v3/import/55zm68mf68xrnt2xjgwk2rnslfkpx8jmlszxccjlmn7cvkbx54z5jv_c-7dwsd.yaml
```


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @ihcsim 

### Related Issue #
https://github.com/harvester/suse-virtualization-mgmt/issues/5

### Test screenshot or video
v1.8.0
**With additional-ca setting**

https://github.com/user-attachments/assets/5b7554ef-6717-4dad-8c73-f071e80c1e55


**Without addition-ca**

https://github.com/user-attachments/assets/1836eb0a-e723-479d-9b3f-64297c70ed2b




v1.7.1 or below
https://github.com/user-attachments/assets/d2717d10-6534-4183-b8ad-c8bd63443256



