### PR TITLE
ci: remove the single quota for use commit hash

### DIFF
--- a/.github/workflows/build-and-publish-standalone.yaml
+++ b/.github/workflows/build-and-publish-standalone.yaml
@@ -52,12 +52,13 @@ jobs:
 
       - name: Apply gcs auth
         # https://github.com/google-github-actions/auth
-        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2'
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        
         with:
           credentials_json: "${{ env.GOOGLE_AUTH }}"
 
       - name: Upload build
-        uses: 'google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2'
+        uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2
         # https://github.com/google-github-actions/upload-cloud-storage
         with:
           path: ${{steps.build-hosted.outputs.BUILD_HOSTED_DIR}}
@@ -96,12 +97,12 @@ jobs:
 
       - name: Apply gcs auth
         # https://github.com/google-github-actions/auth
-        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2'
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: "${{ env.GOOGLE_AUTH }}"
 
       - name: Upload tar
-        uses: 'google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2'
+        uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2
         with:
           path: ${{steps.build-embedded.outputs.BUILD_EMBEDED_TGZ}}
           destination: releases.rancher.com/harvester-ui/dashboard
@@ -140,12 +141,12 @@ jobs:
 
       - name: Apply gcs auth
         # https://github.com/google-github-actions/auth
-        uses: 'google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2'
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: "${{ env.GOOGLE_AUTH }}"
 
       - name: Upload plugin tar
-        uses: 'google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2'
+        uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2
         with:
           path: dist-pkg/${{steps.ci-build-pkg.outputs.PKG_TARBALL}}
           destination: releases.rancher.com/harvester-ui/plugin
@@ -155,7 +156,7 @@ jobs:
           process_gcloudignore: false
 
       - name: Upload plugin directory
-        uses: 'google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2'
+        uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2
         with:
           path: dist-pkg/${{steps.ci-build-pkg.outputs.PKG_NAME}}
           destination: releases.rancher.com/harvester-ui/plugin/${{steps.ci-build-pkg.outputs.PKG_NAME}}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixed failed workflow https://github.com/harvester/harvester-ui-extension/actions/runs/23521604317/job/68466022479 by removing single quota.

<img width="1461" height="603" alt="Screenshot 2026-03-25 at 12 51 15 PM" src="https://github.com/user-attachments/assets/7823c3be-7572-4c5c-9f16-7d63262ec82d" />

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video


Result is good : https://github.com/harvester/harvester-ui-extension/actions/runs/23525809221/job/68479021981


