### PR TITLE
fix: change auth/V3user to auth/user

### DIFF
--- a/pkg/harvester/dialog/EnablePciPassthrough.vue
+++ b/pkg/harvester/dialog/EnablePciPassthrough.vue
@@ -4,6 +4,7 @@ import { Card } from '@components/Card';
 import AsyncButton from '@shell/components/AsyncButton';
 import { escapeHtml } from '@shell/utils/string';
 import { HCI } from '../types';
+import { getHarvesterUserName } from '../utils/auth';
 
 export default {
   name: 'HarvesterEnablePciPassthrough',
@@ -34,16 +35,7 @@ export default {
     },
 
     async save(buttonCb) {
-      // isSingleProduct == this is a standalone Harvester cluster
-      const isSingleProduct = this.$store.getters['isSingleProduct'];
-      let userName = 'admin';
-
-      // if this is imported Harvester, there may be users other than 'admin
-      if (!isSingleProduct) {
-        const user = this.$store.getters['auth/user'];
-
-        userName = user?.username || user?.id;
-      }
+      const userName = getHarvesterUserName(this.$store.getters);
 
       for (let i = 0; i < this.resources.length; i++) {
         const actionResource = this.resources[i];

--- a/pkg/harvester/dialog/EnablePciPassthrough.vue
+++ b/pkg/harvester/dialog/EnablePciPassthrough.vue
@@ -40,7 +40,7 @@ export default {
 
       // if this is imported Harvester, there may be users other than 'admin
       if (!isSingleProduct) {
-        const user = this.$store.getters['auth/v3User'];
+        const user = this.$store.getters['auth/user'];
 
         userName = user?.username || user?.id;
       }

--- a/pkg/harvester/dialog/EnableUSBPassthrough.vue
+++ b/pkg/harvester/dialog/EnableUSBPassthrough.vue
@@ -40,7 +40,7 @@ export default {
 
       // if this is imported Harvester, there may be users other than 'admin
       if (!isSingleProduct) {
-        const user = this.$store.getters['auth/v3User'];
+        const user = this.$store.getters['auth/user'];
 
         userName = user?.username || user?.id;
       }

--- a/pkg/harvester/dialog/EnableUSBPassthrough.vue
+++ b/pkg/harvester/dialog/EnableUSBPassthrough.vue
@@ -4,6 +4,7 @@ import { Card } from '@components/Card';
 import AsyncButton from '@shell/components/AsyncButton';
 import { escapeHtml } from '@shell/utils/string';
 import { HCI } from '../types';
+import { getHarvesterUserName } from '../utils/auth';
 
 export default {
   name: 'HarvesterEnableUSBPassthrough',
@@ -34,16 +35,7 @@ export default {
     },
 
     async save(buttonCb) {
-      // isSingleProduct == this is a standalone Harvester cluster
-      const isSingleProduct = this.$store.getters['isSingleProduct'];
-      let userName = 'admin';
-
-      // if this is imported Harvester, there may be users other than 'admin
-      if (!isSingleProduct) {
-        const user = this.$store.getters['auth/user'];
-
-        userName = user?.username || user?.id;
-      }
+      const userName = getHarvesterUserName(this.$store.getters);
 
       for (let i = 0; i < this.resources.length; i++) {
         const actionResource = this.resources[i];

--- a/pkg/harvester/formatters/HarvesterBackupTargetValidation.vue
+++ b/pkg/harvester/formatters/HarvesterBackupTargetValidation.vue
@@ -1,6 +1,7 @@
 <script>
 import { NORMAN } from '@shell/config/types';
 import { HCI } from '../types';
+import { getHarvesterUser } from '../utils/auth';
 
 export default {
   props: {
@@ -25,7 +26,7 @@ export default {
   },
 
   data() {
-    const user = this.$store.getters['auth/user'];
+    const user = getHarvesterUser(this.$store.getters);
 
     return {
       harvesterSettings:          [],

--- a/pkg/harvester/formatters/HarvesterBackupTargetValidation.vue
+++ b/pkg/harvester/formatters/HarvesterBackupTargetValidation.vue
@@ -25,7 +25,7 @@ export default {
   },
 
   data() {
-    const user = this.$store.getters['auth/v3User'];
+    const user = this.$store.getters['auth/user'];
 
     return {
       harvesterSettings:          [],

--- a/pkg/harvester/models/devices.harvesterhci.io.pcidevice.js
+++ b/pkg/harvester/models/devices.harvesterhci.io.pcidevice.js
@@ -2,6 +2,7 @@ import SteveModel from '@shell/plugins/steve/steve-class';
 import { escapeHtml } from '@shell/utils/string';
 import { HCI } from '../types';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
+import { getHarvesterUserName } from '../utils/auth';
 
 const STATUS_DISPLAY = {
   enabled: {
@@ -96,15 +97,8 @@ export default class PCIDevice extends SteveModel {
     if (!this.passthroughClaim) {
       return false;
     }
-    const isSingleProduct = this.$rootGetters['isSingleProduct'];
-    let userName = 'admin';
 
-    // if this is imported Harvester, there may be users other than admin
-    if (!isSingleProduct) {
-      const user = this.$rootGetters['auth/user'];
-
-      userName = user?.username || user?.id;
-    }
+    const userName = getHarvesterUserName(this.$rootGetters);
 
     return this.claimedBy === userName;
   }

--- a/pkg/harvester/models/devices.harvesterhci.io.pcidevice.js
+++ b/pkg/harvester/models/devices.harvesterhci.io.pcidevice.js
@@ -101,7 +101,7 @@ export default class PCIDevice extends SteveModel {
 
     // if this is imported Harvester, there may be users other than admin
     if (!isSingleProduct) {
-      const user = this.$rootGetters['auth/v3User'];
+      const user = this.$rootGetters['auth/user'];
 
       userName = user?.username || user?.id;
     }

--- a/pkg/harvester/models/devices.harvesterhci.io.usbdevice.js
+++ b/pkg/harvester/models/devices.harvesterhci.io.usbdevice.js
@@ -92,7 +92,7 @@ export default class USBDevice extends SteveModel {
 
     // if this is imported Harvester, there may be users other than admin
     if (!isSingleProduct) {
-      const user = this.$rootGetters['auth/v3User'];
+      const user = this.$rootGetters['auth/user'];
 
       userName = user?.username || user?.id;
     }

--- a/pkg/harvester/models/devices.harvesterhci.io.usbdevice.js
+++ b/pkg/harvester/models/devices.harvesterhci.io.usbdevice.js
@@ -1,6 +1,7 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { escapeHtml } from '@shell/utils/string';
 import { HCI } from '../types';
+import { getHarvesterUserName } from '../utils/auth';
 
 const STATUS_DISPLAY = {
   enabled: {
@@ -87,15 +88,8 @@ export default class USBDevice extends SteveModel {
     if (!this.passthroughClaim) {
       return false;
     }
-    const isSingleProduct = this.$rootGetters['isSingleProduct'];
-    let userName = 'admin';
 
-    // if this is imported Harvester, there may be users other than admin
-    if (!isSingleProduct) {
-      const user = this.$rootGetters['auth/user'];
-
-      userName = user?.username || user?.id;
-    }
+    const userName = getHarvesterUserName(this.$rootGetters);
 
     return this.claimedBy === userName;
   }

--- a/pkg/harvester/utils/auth.js
+++ b/pkg/harvester/utils/auth.js
@@ -1,0 +1,31 @@
+/**
+ * Resolve the Harvester username from Vuex getters.
+ *
+ * Works with both `this.$store.getters` (in components) and
+ * `this.$rootGetters` (in Steve models).
+ *
+ * - In single-product (standalone Harvester) mode, always returns the
+ *   default username (`admin`).
+ * - Otherwise, falls back to the authenticated user's `username` or `id`.
+ */
+export function getHarvesterUserName(getters, defaultUserName = 'admin') {
+  const isSingleProduct = getters?.['isSingleProduct'];
+
+  if (isSingleProduct) {
+    return defaultUserName;
+  }
+
+  const user = getHarvesterUser(getters);
+
+  return user?.username || user?.id || defaultUserName;
+}
+
+/**
+ * Return the authenticated user object from Vuex getters.
+ *
+ * Works with both `this.$store.getters` (in components) and
+ * `this.$rootGetters` (in Steve models).
+ */
+export function getHarvesterUser(getters) {
+  return getters?.['auth/user'];
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The missing dropdown due to [enabledDevices](https://github.com/harvester/harvester-ui-extension/blob/7d0f33f31d52e939aab48b8ea133162c4e6daed2/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue#L259) is empty array.

The root cause is the `auth/V3user` is changed to `auth/user` on Rancher side. 
See https://github.com/rancher/dashboard/pull/16526

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/10452#top

### Test screenshot or video
Standalone
<img width="1402" height="854" alt="image" src="https://github.com/user-attachments/assets/b697b148-62ab-4682-a1c0-b6566255b9f2" />


Integration mode
<img width="1495" height="752" alt="Screenshot 2026-04-22 at 1 19 05 PM" src="https://github.com/user-attachments/assets/ccb74ee2-c43f-42bd-86cf-6fe18e2bdf5e" />



