### PR TITLE
perf: improve vm list page performance

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -408,7 +408,7 @@ export default {
       for (let i = 1; i <= this.count; i++) {
         this.value['spec'] = cloneValue.spec;
         this['spec'] = cloneSpec;
-        const suffix = i < 50 ? `0${ i }` : i;
+        const suffix = i < 10 ? `0${ i }` : i;
 
         this.value.cleanForNew();
         this.value.metadata.name = `${ this.namePrefix }${ join }${ suffix }`;
@@ -510,8 +510,8 @@ export default {
     },
 
     validateCount(count) {
-      if (count > 50) {
-        this['count'] = 50;
+      if (count > 10) {
+        this['count'] = 10;
       }
     },
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -408,7 +408,7 @@ export default {
       for (let i = 1; i <= this.count; i++) {
         this.value['spec'] = cloneValue.spec;
         this['spec'] = cloneSpec;
-        const suffix = i < 10 ? `0${ i }` : i;
+        const suffix = i < 50 ? `0${ i }` : i;
 
         this.value.cleanForNew();
         this.value.metadata.name = `${ this.namePrefix }${ join }${ suffix }`;
@@ -510,8 +510,8 @@ export default {
     },
 
     validateCount(count) {
-      if (count > 10) {
-        this['count'] = 10;
+      if (count > 50) {
+        this['count'] = 50;
       }
     },
 

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -2164,6 +2164,13 @@ typeLabel:
       one { PCI Device }
       other { PCI Devices }
     }
+
+  persistentvolumeclaim: |-
+    {count, plural,
+      one { Volume }
+      other { Volumes }
+    }
+
   network.harvesterhci.io.clusternetwork: |-
     {count, plural,
       one { Cluster Network }

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -2164,11 +2164,6 @@ typeLabel:
       one { PCI Device }
       other { PCI Devices }
     }
-  persistentvolumeclaim: |-
-    {count, plural,
-      one { Volume }
-      other { Volumes }
-    }
   network.harvesterhci.io.clusternetwork: |-
     {count, plural,
       one { Cluster Network }

--- a/pkg/harvester/list/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/list/kubevirt.io.virtualmachine.vue
@@ -163,6 +163,12 @@ export default {
      */
     hasBackUpRestoreInProgress() {
       return !!this.rows.find((r) => r.restoreResource && !r.restoreResource.fromSnapshot && !r.restoreResource.isComplete);
+    },
+
+    vmRestartRequiredNames() {
+      return this.allVMs
+        .filter((vm) => vm.isRestartRequired)
+        .map((vm) => vm.metadata.name);
     }
   },
 
@@ -181,40 +187,28 @@ export default {
   },
 
   watch: {
-    allVMs: {
-      handler(neu) {
-        const vmNames = [];
+    vmRestartRequiredNames(vmNames) {
+      const count = vmNames.length;
 
-        neu.forEach((vm) => {
-          if (vm.isRestartRequired) {
-            vmNames.push(vm.metadata.name);
-          }
-        });
-        const count = vmNames.length;
+      if (count === 0 && this.restartNotificationDisplayed) {
+        this.restartNotificationDisplayed = false;
 
-        if ( count === 0 && this.restartNotificationDisplayed) {
-          this.restartNotificationDisplayed = false;
+        return;
+      }
 
-          return;
+      if (count > 0) {
+        // clear old notification before showing new one
+        if (this.restartNotificationDisplayed) {
+          this.$store.dispatch('growl/clear');
         }
 
-        if (count > 0) {
-          // clear old notification before showing new one
-          if (this.restartNotificationDisplayed) {
-            this.$store.dispatch('growl/clear');
-          }
-        }
-
-        if (count > 0 && vmNames.length > 0) {
-          this.$store.dispatch('growl/warning', {
-            title:   this.t('harvester.notification.restartRequired.title', { count }),
-            message: this.t('harvester.notification.restartRequired.message', { vmNames: vmNames.join(', ') }),
-            timeout: 10000,
-          }, { root: true });
-          this.restartNotificationDisplayed = true;
-        }
-      },
-      deep: true,
+        this.$store.dispatch('growl/warning', {
+          title:   this.t('harvester.notification.restartRequired.title', { count }),
+          message: this.t('harvester.notification.restartRequired.message', { vmNames: vmNames.join(', ') }),
+          timeout: 10000,
+        }, { root: true });
+        this.restartNotificationDisplayed = true;
+      }
     }
   },
   methods: {

--- a/pkg/harvester/list/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/list/kubevirt.io.virtualmachine.vue
@@ -12,6 +12,11 @@ import { HCI } from '../types';
 import HarvesterVmState from '../formatters/HarvesterVmState';
 import ConsoleBar from '../components/VMConsoleBar';
 
+const ENCRYPTED_VOLUME_TOOLTIP_KEYS = {
+  all:     'harvester.virtualMachine.volume.lockTooltip.all',
+  partial: 'harvester.virtualMachine.volume.lockTooltip.partial',
+};
+
 export const VM_HEADERS = [
   STATE,
   {
@@ -213,12 +218,7 @@ export default {
   },
   methods: {
     lockIconTooltipMessage(row) {
-      const tooltipKeyByEncryptedVolumeType = {
-        all:     'harvester.virtualMachine.volume.lockTooltip.all',
-        partial: 'harvester.virtualMachine.volume.lockTooltip.partial',
-      };
-
-      const key = tooltipKeyByEncryptedVolumeType[row.encryptedVolumeType];
+      const key = ENCRYPTED_VOLUME_TOOLTIP_KEYS[row.encryptedVolumeType];
 
       return key ? this.t(key) : '';
     }

--- a/pkg/harvester/list/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/list/kubevirt.io.virtualmachine.vue
@@ -219,15 +219,14 @@ export default {
   },
   methods: {
     lockIconTooltipMessage(row) {
-      const message = '';
+      const tooltipKeyByEncryptedVolumeType = {
+        all:     'harvester.virtualMachine.volume.lockTooltip.all',
+        partial: 'harvester.virtualMachine.volume.lockTooltip.partial',
+      };
 
-      if (row.encryptedVolumeType === 'all') {
-        return this.t('harvester.virtualMachine.volume.lockTooltip.all');
-      } else if (row.encryptedVolumeType === 'partial') {
-        return this.t('harvester.virtualMachine.volume.lockTooltip.partial');
-      }
+      const key = tooltipKeyByEncryptedVolumeType[row.encryptedVolumeType];
 
-      return message;
+      return key ? this.t(key) : '';
     }
   }
 };
@@ -267,7 +266,7 @@ export default {
           >
             {{ scope.row.metadata.name }}
             <i
-              v-if="lockIconTooltipMessage(scope.row)"
+              v-if="scope.row.encryptedVolumeType !== 'none'"
               v-tooltip="lockIconTooltipMessage(scope.row)"
               class="icon icon-lock"
               :class="{'green-icon': scope.row.encryptedVolumeType === 'all', 'yellow-icon': scope.row.encryptedVolumeType === 'partial'}"

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -1073,41 +1073,41 @@ export default class VirtVm extends HarvesterResource {
     return out;
   }
 
-  get warningCount() {
-    return this.resourcesStatus.warningCount;
-  }
+  // get warningCount() {
+  //   return this.resourcesStatus.warningCount;
+  // }
 
-  get errorCount() {
-    return this.resourcesStatus.errorCount;
-  }
+  // get errorCount() {
+  //   return this.resourcesStatus.errorCount;
+  // }
 
-  get resourcesStatus() {
-    const inStore = this.productInStore;
-    const vmList = this.$rootGetters[`${ inStore }/all`](HCI.VM);
-    let warningCount = 0;
-    let errorCount = 0;
+  // get resourcesStatus() {
+  //   const inStore = this.productInStore;
+  //   const vmList = this.$rootGetters[`${ inStore }/all`](HCI.VM);
+  //   let warningCount = 0;
+  //   let errorCount = 0;
 
-    vmList.forEach((vm) => {
-      const status = vm.actualState;
+  //   vmList.forEach((vm) => {
+  //     const status = vm.actualState;
 
-      if (status === VM_ERROR) {
-        errorCount += 1;
-      } else if (
-        status === 'Stopping' ||
-        status === 'Waiting' ||
-        status === 'Pending' ||
-        status === 'Starting' ||
-        status === 'Terminating'
-      ) {
-        warningCount += 1;
-      }
-    });
+  //     if (status === VM_ERROR) {
+  //       errorCount += 1;
+  //     } else if (
+  //       status === 'Stopping' ||
+  //       status === 'Waiting' ||
+  //       status === 'Pending' ||
+  //       status === 'Starting' ||
+  //       status === 'Terminating'
+  //     ) {
+  //       warningCount += 1;
+  //     }
+  //   });
 
-    return {
-      warningCount,
-      errorCount
-    };
-  }
+  //   return {
+  //     warningCount,
+  //     errorCount
+  //   };
+  // }
 
   get volumeClaimTemplates() {
     return parseVolumeClaimTemplates(this);

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -804,17 +804,6 @@ export default class VirtVm extends HarvesterResource {
       return { status: 'VMI error', detailedMessage: vmiFailureCond.message };
     }
 
-    // if ((this.vmi || this.isVMCreated) && this.podResource) {
-    //   const podStatus = this.podResource.getPodStatus;
-    //   if (POD_STATUS_ALL_ERROR.includes(podStatus?.status)) {
-    //     return {
-    //       ...podStatus,
-    //       status: 'LAUNCHER_POD_ERROR',
-    //     pod:    this.podResource,
-    //   };
-    // }
-    // }
-
     return this?.vmi?.status?.phase;
   }
 
@@ -1121,42 +1110,6 @@ export default class VirtVm extends HarvesterResource {
 
     return out;
   }
-
-  // get warningCount() {
-  //   return this.resourcesStatus.warningCount;
-  // }
-
-  // get errorCount() {
-  //   return this.resourcesStatus.errorCount;
-  // }
-
-  // get resourcesStatus() {
-  //   const inStore = this.productInStore;
-  //   const vmList = this.$rootGetters[`${ inStore }/all`](HCI.VM);
-  //   let warningCount = 0;
-  //   let errorCount = 0;
-
-  //   vmList.forEach((vm) => {
-  //     const status = vm.actualState;
-
-  //     if (status === VM_ERROR) {
-  //       errorCount += 1;
-  //     } else if (
-  //       status === 'Stopping' ||
-  //       status === 'Waiting' ||
-  //       status === 'Pending' ||
-  //       status === 'Starting' ||
-  //       status === 'Terminating'
-  //     ) {
-  //       warningCount += 1;
-  //     }
-  //   });
-
-  //   return {
-  //     warningCount,
-  //     errorCount
-  //   };
-  // }
 
   get volumeClaimTemplates() {
     return parseVolumeClaimTemplates(this);

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -89,6 +89,9 @@ let _podOwnerMapSource = null;
 function getPodByOwnerName(rootGetters, inStore, ownerName) {
   const podList = rootGetters[`${ inStore }/all`](POD);
 
+  if (!Array.isArray(podList)) {
+    return undefined;
+  }
   // if not equals (usually means the pod list has been updated), we need to rebuild the map, otherwise we can reuse the map for better performance
   if (_podOwnerMapSource !== podList) {
     _podOwnerMap = new Map(); // use Map to store ownerReference name and pod mapping
@@ -107,6 +110,10 @@ function getPodByOwnerName(rootGetters, inStore, ownerName) {
 
 function getPvcsByNames(rootGetters, inStore, names) {
   const pvcList = rootGetters[`${ inStore }/all`](PVC);
+
+  if (!Array.isArray(pvcList)) {
+    return [];
+  }
   const uniqueNames = new Set(names);
 
   return pvcList.filter((pvc) => uniqueNames.has(pvc.metadata?.name));

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -83,6 +83,64 @@ const VMIPhase = {
 
 let productInStore;
 
+let _podOwnerMap = null;
+let _podOwnerMapSource = null;
+
+function getPodByOwnerName(rootGetters, inStore, ownerName) {
+  const podList = rootGetters[`${ inStore }/all`](POD);
+
+  if (_podOwnerMapSource !== podList) {
+    _podOwnerMap = new Map();
+    for (const pod of podList) {
+      const refName = pod.metadata?.ownerReferences?.[0]?.name;
+
+      if (refName) {
+        _podOwnerMap.set(refName, pod);
+      }
+    }
+    _podOwnerMapSource = podList;
+  }
+
+  return _podOwnerMap.get(ownerName);
+}
+
+let _pvcNameMap = null;
+let _pvcNameMapSource = null;
+
+function getPvcsByNames(rootGetters, inStore, names) {
+  const pvcList = rootGetters[`${ inStore }/all`](PVC);
+
+  if (_pvcNameMapSource !== pvcList) {
+    _pvcNameMap = new Map();
+    for (const pvc of pvcList) {
+      const name = pvc.metadata?.name;
+
+      if (name) {
+        let list = _pvcNameMap.get(name);
+
+        if (!list) {
+          list = [];
+          _pvcNameMap.set(name, list);
+        }
+        list.push(pvc);
+      }
+    }
+    _pvcNameMapSource = pvcList;
+  }
+
+  const result = [];
+
+  for (const name of names) {
+    const pvcs = _pvcNameMap.get(name);
+
+    if (pvcs) {
+      result.push(...pvcs);
+    }
+  }
+
+  return result;
+}
+
 const IgnoreMessages = ['pod has unbound immediate PersistentVolumeClaims'];
 
 export default class VirtVm extends HarvesterResource {
@@ -660,16 +718,13 @@ export default class VirtVm extends HarvesterResource {
 
   get podResource() {
     const inStore = this.productInStore;
-
     const vmiResource = this.$rootGetters[`${ inStore }/byId`](HCI.VMI, this.id);
-    const podList = this.$rootGetters[`${ inStore }/all`](POD);
 
-    return podList.find((P) => {
-      return (
-        vmiResource?.metadata?.name &&
-        vmiResource?.metadata?.name === P.metadata?.ownerReferences?.[0].name
-      );
-    });
+    if (!vmiResource?.metadata?.name) {
+      return undefined;
+    }
+
+    return getPodByOwnerName(this.$rootGetters, inStore, vmiResource.metadata.name);
   }
 
   get isPaused() {
@@ -710,17 +765,13 @@ export default class VirtVm extends HarvesterResource {
   get vmi() {
     const inStore = this.productInStore;
 
-    const vmis = this.$rootGetters[`${ inStore }/all`](HCI.VMI);
-
-    return vmis.find((VMI) => VMI.id === this.id);
+    return this.$rootGetters[`${ inStore }/byId`](HCI.VMI, this.id);
   }
 
   get volumes() {
-    const pvcs = this.$rootGetters[`${ this.productInStore }/all`](PVC);
-
     const volumeClaimNames = this.spec.template.spec.volumes?.map((v) => v.persistentVolumeClaim?.claimName).filter((v) => !!v) || [];
 
-    return pvcs.filter((pvc) => volumeClaimNames.includes(pvc.metadata.name));
+    return getPvcsByNames(this.$rootGetters, this.productInStore, volumeClaimNames);
   }
 
   get lvmVolumes() {
@@ -753,16 +804,16 @@ export default class VirtVm extends HarvesterResource {
       return { status: 'VMI error', detailedMessage: vmiFailureCond.message };
     }
 
-    if ((this.vmi || this.isVMCreated) && this.podResource) {
-      // const podStatus = this.podResource.getPodStatus;
-      // if (POD_STATUS_ALL_ERROR.includes(podStatus?.status)) {
-      //   return {
-      //     ...podStatus,
-      //     status: 'LAUNCHER_POD_ERROR',
-      //     pod:    this.podResource,
-      //   };
-      // }
-    }
+    // if ((this.vmi || this.isVMCreated) && this.podResource) {
+    //   const podStatus = this.podResource.getPodStatus;
+    //   if (POD_STATUS_ALL_ERROR.includes(podStatus?.status)) {
+    //     return {
+    //       ...podStatus,
+    //       status: 'LAUNCHER_POD_ERROR',
+    //     pod:    this.podResource,
+    //   };
+    // }
+    // }
 
     return this?.vmi?.status?.phase;
   }
@@ -901,9 +952,7 @@ export default class VirtVm extends HarvesterResource {
 
     const inStore = this.productInStore;
 
-    const allRestore = this.$rootGetters[`${ inStore }/all`](HCI.RESTORE);
-
-    const res = allRestore.find((O) => O.id === id);
+    const res = this.$rootGetters[`${ inStore }/byId`](HCI.RESTORE, id);
 
     if (res) {
       const allBackups = this.$rootGetters[`${ inStore }/all`](HCI.BACKUP);
@@ -1126,7 +1175,6 @@ export default class VirtVm extends HarvesterResource {
   get rootImageId() {
     let imageId = '';
     const inStore = this.productInStore;
-    const pvcs = this.$rootGetters[`${ inStore }/all`](PVC) || [];
 
     const volumes = this.spec.template.spec.volumes || [];
 
@@ -1136,9 +1184,7 @@ export default class VirtVm extends HarvesterResource {
     });
 
     if (!isNoExistingVolume) {
-      const existingVolume = pvcs.find(
-        (P) => P.id === `${ this.metadata.namespace }/${ firstVolumeName }`
-      );
+      const existingVolume = this.$rootGetters[`${ inStore }/byId`](PVC, `${ this.metadata.namespace }/${ firstVolumeName }`);
 
       if (existingVolume) {
         return existingVolume?.metadata?.annotations?.[
@@ -1316,8 +1362,7 @@ export default class VirtVm extends HarvesterResource {
   }
 
   get isBackupTargetUnavailable() {
-    const allSettings = this.$rootGetters['harvester/all'](HCI.SETTING) || [];
-    const backupTargetSetting = allSettings.find( (O) => O.id === 'backup-target');
+    const backupTargetSetting = this.$rootGetters['harvester/byId'](HCI.SETTING, 'backup-target');
 
     return isBackupTargetSettingUnavailable(backupTargetSetting);
   }

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -89,8 +89,9 @@ let _podOwnerMapSource = null;
 function getPodByOwnerName(rootGetters, inStore, ownerName) {
   const podList = rootGetters[`${ inStore }/all`](POD);
 
+  // if not equals (usually means the pod list has been updated), we need to rebuild the map, otherwise we can reuse the map for better performance
   if (_podOwnerMapSource !== podList) {
-    _podOwnerMap = new Map();
+    _podOwnerMap = new Map(); // use Map to store ownerReference name and pod mapping
     for (const pod of podList) {
       const refName = pod.metadata?.ownerReferences?.[0]?.name;
 
@@ -104,41 +105,11 @@ function getPodByOwnerName(rootGetters, inStore, ownerName) {
   return _podOwnerMap.get(ownerName);
 }
 
-let _pvcNameMap = null;
-let _pvcNameMapSource = null;
-
 function getPvcsByNames(rootGetters, inStore, names) {
   const pvcList = rootGetters[`${ inStore }/all`](PVC);
+  const uniqueNames = new Set(names);
 
-  if (_pvcNameMapSource !== pvcList) {
-    _pvcNameMap = new Map();
-    for (const pvc of pvcList) {
-      const name = pvc.metadata?.name;
-
-      if (name) {
-        let list = _pvcNameMap.get(name);
-
-        if (!list) {
-          list = [];
-          _pvcNameMap.set(name, list);
-        }
-        list.push(pvc);
-      }
-    }
-    _pvcNameMapSource = pvcList;
-  }
-
-  const result = [];
-
-  for (const name of names) {
-    const pvcs = _pvcNameMap.get(name);
-
-    if (pvcs) {
-      result.push(...pvcs);
-    }
-  }
-
-  return result;
+  return pvcList.filter((pvc) => uniqueNames.has(pvc.metadata?.name));
 }
 
 const IgnoreMessages = ['pod has unbound immediate PersistentVolumeClaims'];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Some code level performance improvments we can do.

1. Remove dead (unused functions): 
 - `warningCount` 
 - `errorCount` 
 - `resourcesStatus`
---
2. Improve 
`[${ inStore }/all](resource) +  filter/find by target condition`  to
`[${ inStore }/byId](resource, target id)`

Perf Improvment : **O(n) -> O(1)** 

---

4. getPvcsByNames() extraction
```
original : O( P * V )
improved: O( P + V ) , where P is PVC total count, V is the volumeClaimNames attached in VM count.
```
e.g. P = 1000, V = 5, original: 5000, improved: 1005 (5 times faster)

---

6. watch `allVMs` to detect restart required VM (quite big list if created lots of VM) -> only watch VM.isRestartRequired=true array list

--- 
7. `lockIconTooltipMessage(scope.row)` appears twice


--- 


8. `podResource()` was called in lots of places when calculating the VM status.
- The VM will calculate each column of the list.
- Other getters will repeatedly depend on it. 
- Vue reactivity will repeatedly trigger the fetching of values.

Improve performance by using `new Map()`, see `getPodByOwnerName()`.
```
original : O(Q  x P),  where Q is podResource() call time, P is podList length
improved : O (Q + P), where Q is podResource() call time, P is recalculate if podList changed.

if 
P = 200 (pods), Q = 1 (call times), orginal = 200, improved = 201, almost same
but if 
P = 200 (pods) Q = 50 (call times), original =10,000, improved = 205  (40 times faster)
P = 200 (pods) Q = 100 (call times), original = 20,000, improved = 300 (60 times faster)
```


In real world, let's see the performance recording when sorting status column.
**Before**
<img width="1486" height="847" alt="Screenshot 2026-04-29 at 2 32 55 PM" src="https://github.com/user-attachments/assets/efbcde55-7ac0-4ff8-8627-ecfc23654b8c" />

**After**
<img width="1493" height="847" alt="Screenshot 2026-04-29 at 2 36 26 PM" src="https://github.com/user-attachments/assets/05eb1f53-961e-4957-9c86-2fcbe155d40f" />

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
Two Jira issues

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


