### PR TITLE
feat: add tooltip for route connectivity in network attachment definition

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -298,6 +298,7 @@ harvester:
     phase: Phase
     attachedVM: Attached Virtual Machine
     cpuManager: CPU Manager
+    routeConnectivityTooltip: Connectivity between the VM network and the management network, which the Harvester nodes are connected to.
     fingerprint: Fingerprint
     value: Value
     actions: Actions

--- a/pkg/harvester/list/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/list/harvesterhci.io.networkattachmentdefinition.vue
@@ -112,6 +112,7 @@ export default {
           value:         'connectivity',
           labelKey:      'tableHeaders.routeConnectivity',
           formatter:     'NetworkRouteConnectivity',
+          tooltip:       'harvester.tableHeaders.routeConnectivityTooltip',
           formatterOpts: { arbitrary: true },
           width:         130,
         },


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Add tooltip for route connectivity in VM network page

BTW, the rancher table header doesn't support adding document link in the tooltip (user is unable to click that doc link)
If we really want to show the doc link, we can add a info banner.


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/9028

### Test screenshot or video
<img width="1292" height="628" alt="Screenshot 2026-05-11 at 11 41 59 AM" src="https://github.com/user-attachments/assets/ef3ba101-3a5c-4dcc-a36e-5af230d76d41" />


