### PR TITLE
feat: Allow user to customize snapshot/backup deadline

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -75,6 +75,7 @@ const FEATURE_FLAGS = {
     'expandOnlineEncryptedVolume',
     'longhornV2HugepageSettings',
     'staticIPForVM',
+    'fsFreezeDeadline',
   ],
 };
 

--- a/pkg/harvester/dialog/HarvesterBackupModal.vue
+++ b/pkg/harvester/dialog/HarvesterBackupModal.vue
@@ -6,6 +6,7 @@ import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { DEFAULT_FS_FREEZE_DEADLINE, getFsFreezeDeadlineOptions } from '../utils/backup';
 
 export default {
   name: 'HarvesterBackupModal',
@@ -29,39 +30,9 @@ export default {
 
   data() {
     return {
-      backUpName:              '',
-      errors:                  [],
-      fsFreezeDeadline:        '10s',
-      fsFreezeDeadlineOptions: [
-        {
-          label: this.t('generic.duration.infinite'),
-          value: '0s'
-        },
-        {
-          label: this.t('generic.duration.5s'),
-          value: '5s'
-        },
-        {
-          label: this.t('generic.duration.10s'),
-          value: '10s'
-        },
-        {
-          label: this.t('generic.duration.30s'),
-          value: '30s'
-        },
-        {
-          label: this.t('generic.duration.1m'),
-          value: '1m'
-        },
-        {
-          label: this.t('generic.duration.3m'),
-          value: '3m'
-        },
-        {
-          label: this.t('generic.duration.5m'),
-          value: '5m'
-        }
-      ]
+      backUpName:       '',
+      errors:           [],
+      fsFreezeDeadline: DEFAULT_FS_FREEZE_DEADLINE
     };
   },
 
@@ -70,13 +41,22 @@ export default {
 
     actionResource() {
       return this.resources[0];
+    },
+
+    fsFreezeDeadlineEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('fsFreezeDeadline');
+    },
+
+    fsFreezeDeadlineOptions() {
+      return getFsFreezeDeadlineOptions(this.t);
     }
   },
 
   methods: {
     close() {
       this.backUpName = '';
-      this.fsFreezeDeadline = '';
+      this.fsFreezeDeadline = DEFAULT_FS_FREEZE_DEADLINE;
+      this.errors = [];
       this.$emit('close');
     },
 
@@ -139,10 +119,11 @@ export default {
         required
       />
       <LabeledSelect
+        v-if="fsFreezeDeadlineEnabled"
         v-model:value="fsFreezeDeadline"
         class="mt-20"
         :options="fsFreezeDeadlineOptions"
-        :label="t('harvester.modal.backup.fsFreezeDeadline')"
+        :label="t('harvester.modal.backup.fileSystemFreezeDeadline.label')"
         required
       />
       <Banner

--- a/pkg/harvester/dialog/HarvesterBackupModal.vue
+++ b/pkg/harvester/dialog/HarvesterBackupModal.vue
@@ -5,6 +5,7 @@ import { Card } from '@components/Card';
 import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
 import { LabeledInput } from '@components/Form/LabeledInput';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
 
 export default {
   name: 'HarvesterBackupModal',
@@ -15,6 +16,7 @@ export default {
     AsyncButton,
     Card,
     LabeledInput,
+    LabeledSelect,
     Banner
   },
 
@@ -27,8 +29,39 @@ export default {
 
   data() {
     return {
-      backUpName: '',
-      errors:     []
+      backUpName:              '',
+      errors:                  [],
+      fsFreezeDeadline:        '10s',
+      fsFreezeDeadlineOptions: [
+        {
+          label: this.t('generic.duration.infinite'),
+          value: '0s'
+        },
+        {
+          label: this.t('generic.duration.5s'),
+          value: '5s'
+        },
+        {
+          label: this.t('generic.duration.10s'),
+          value: '10s'
+        },
+        {
+          label: this.t('generic.duration.30s'),
+          value: '30s'
+        },
+        {
+          label: this.t('generic.duration.1m'),
+          value: '1m'
+        },
+        {
+          label: this.t('generic.duration.3m'),
+          value: '3m'
+        },
+        {
+          label: this.t('generic.duration.5m'),
+          value: '5m'
+        }
+      ]
     };
   },
 
@@ -43,6 +76,7 @@ export default {
   methods: {
     close() {
       this.backUpName = '';
+      this.fsFreezeDeadline = '';
       this.$emit('close');
     },
 
@@ -51,7 +85,7 @@ export default {
         try {
           const res = await this.actionResource.doAction(
             'backup',
-            { name: this.backUpName },
+            { name: this.backUpName, fsFreezeDeadline: this.fsFreezeDeadline },
             {},
             false
           );
@@ -100,7 +134,15 @@ export default {
     <template #body>
       <LabeledInput
         v-model:value="backUpName"
+        class="mt-20"
         :label="t('generic.name')"
+        required
+      />
+      <LabeledSelect
+        v-model:value="fsFreezeDeadline"
+        class="mt-20"
+        :options="fsFreezeDeadlineOptions"
+        :label="t('harvester.modal.backup.fsFreezeDeadline')"
         required
       />
       <Banner

--- a/pkg/harvester/dialog/HarvesterVMSnapshotDialog.vue
+++ b/pkg/harvester/dialog/HarvesterVMSnapshotDialog.vue
@@ -5,6 +5,7 @@ import { Card } from '@components/Card';
 import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
 import { LabeledInput } from '@components/Form/LabeledInput';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { HCI } from '../types';
 import { BACKUP_TYPE } from '../config/types';
 
@@ -17,6 +18,7 @@ export default {
     AsyncButton,
     Card,
     LabeledInput,
+    LabeledSelect,
     Banner
   },
 
@@ -29,9 +31,40 @@ export default {
 
   data() {
     return {
-      snapshotName:      '',
-      snapshotNamespace: '',
-      errors:            []
+      snapshotName:            '',
+      snapshotNamespace:       '',
+      errors:                  [],
+      fsFreezeDeadline:        '10s',
+      fsFreezeDeadlineOptions: [
+        {
+          label: this.t('generic.duration.infinite'),
+          value: '0s'
+        },
+        {
+          label: this.t('generic.duration.5s'),
+          value: '5s'
+        },
+        {
+          label: this.t('generic.duration.10s'),
+          value: '10s'
+        },
+        {
+          label: this.t('generic.duration.30s'),
+          value: '30s'
+        },
+        {
+          label: this.t('generic.duration.1m'),
+          value: '1m'
+        },
+        {
+          label: this.t('generic.duration.3m'),
+          value: '3m'
+        },
+        {
+          label: this.t('generic.duration.5m'),
+          value: '5m'
+        }
+      ]
     };
   },
 
@@ -45,6 +78,7 @@ export default {
 
   methods: {
     close() {
+      this.fsFreezeDeadline = '';
       this.snapshotNamespace = '';
       this.snapshotName = '';
       this.$emit('close');
@@ -60,7 +94,8 @@ export default {
               ownerReferences: this.getOwnerReferencesFromVM(this.actionResource)
             },
             spec: {
-              source: {
+              fsFreezeDeadline: this.fsFreezeDeadline,
+              source:           {
                 apiGroup: 'kubevirt.io',
                 kind:     'VirtualMachine',
                 name:     this.actionResource.metadata.name
@@ -130,6 +165,13 @@ export default {
         v-model:value="snapshotName"
         class="mt-20"
         :label="t('generic.name')"
+        required
+      />
+      <LabeledSelect
+        v-model:value="fsFreezeDeadline"
+        class="mt-20"
+        :options="fsFreezeDeadlineOptions"
+        :label="t('harvester.modal.vmSnapshot.fsFreezeDeadline')"
         required
       />
       <Banner

--- a/pkg/harvester/dialog/HarvesterVMSnapshotDialog.vue
+++ b/pkg/harvester/dialog/HarvesterVMSnapshotDialog.vue
@@ -8,6 +8,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { HCI } from '../types';
 import { BACKUP_TYPE } from '../config/types';
+import { DEFAULT_FS_FREEZE_DEADLINE, getFsFreezeDeadlineOptions } from '../utils/backup';
 
 export default {
   name: 'HarvesterVMSnapshotDialog',
@@ -31,40 +32,10 @@ export default {
 
   data() {
     return {
-      snapshotName:            '',
-      snapshotNamespace:       '',
-      errors:                  [],
-      fsFreezeDeadline:        '10s',
-      fsFreezeDeadlineOptions: [
-        {
-          label: this.t('generic.duration.infinite'),
-          value: '0s'
-        },
-        {
-          label: this.t('generic.duration.5s'),
-          value: '5s'
-        },
-        {
-          label: this.t('generic.duration.10s'),
-          value: '10s'
-        },
-        {
-          label: this.t('generic.duration.30s'),
-          value: '30s'
-        },
-        {
-          label: this.t('generic.duration.1m'),
-          value: '1m'
-        },
-        {
-          label: this.t('generic.duration.3m'),
-          value: '3m'
-        },
-        {
-          label: this.t('generic.duration.5m'),
-          value: '5m'
-        }
-      ]
+      snapshotName:      '',
+      snapshotNamespace: '',
+      errors:            [],
+      fsFreezeDeadline:  DEFAULT_FS_FREEZE_DEADLINE
     };
   },
 
@@ -73,14 +44,23 @@ export default {
 
     actionResource() {
       return this.resources[0];
+    },
+
+    fsFreezeDeadlineEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('fsFreezeDeadline');
+    },
+
+    fsFreezeDeadlineOptions() {
+      return getFsFreezeDeadlineOptions(this.t);
     }
   },
 
   methods: {
     close() {
-      this.fsFreezeDeadline = '';
+      this.fsFreezeDeadline = DEFAULT_FS_FREEZE_DEADLINE;
       this.snapshotNamespace = '';
       this.snapshotName = '';
+      this.errors = [];
       this.$emit('close');
     },
 
@@ -168,10 +148,11 @@ export default {
         required
       />
       <LabeledSelect
+        v-if="fsFreezeDeadlineEnabled"
         v-model:value="fsFreezeDeadline"
         class="mt-20"
         :options="fsFreezeDeadlineOptions"
-        :label="t('harvester.modal.vmSnapshot.fsFreezeDeadline')"
+        :label="t('harvester.modal.vmSnapshot.fileSystemFreezeDeadline.label')"
         required
       />
       <Banner

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -10,6 +10,7 @@ generic:
   none: None
   duration:
     infinite: Infinite
+    1s: 1 second
     5s: 5 seconds
     10s: 10 seconds
     30s: 30 seconds
@@ -83,7 +84,8 @@ harvester:
     backup:
       success: 'Backup { backUpName } has been initiated.'
       addBackup: Add Backup
-      fsFreezeDeadline: 'File system freeze deadline'
+      fileSystemFreezeDeadline:
+        label: 'File System Freeze Deadline'
     quota:
       editVMQuota: Edit VM Quota
       editQuota: Edit Quota
@@ -223,7 +225,8 @@ harvester:
       title: Take Virtual Machine Snapshot
       name: Name
       success: 'Take virtual machine Snapshot { name } successfully.'
-      fsFreezeDeadline: 'File system freeze deadline'
+      fileSystemFreezeDeadline:
+        label: 'File System Freeze Deadline'
     restart:
       title: Restart Virtual Machine
       tip: Restart the virtual machine for configuration changes to take effect.

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -8,6 +8,14 @@ generic:
   basic: Basic
   loading: Loading...
   none: None
+  duration:
+    infinite: Infinite
+    5s: 5 seconds
+    10s: 10 seconds
+    30s: 30 seconds
+    1m: 1 minute
+    3m: 3 minutes
+    5m: 5 minutes
 
 unsupported:
   serverVersion: 'Current version: <code>{serverVersion}</code>'
@@ -75,6 +83,7 @@ harvester:
     backup:
       success: 'Backup { backUpName } has been initiated.'
       addBackup: Add Backup
+      fsFreezeDeadline: 'File system freeze deadline'
     quota:
       editVMQuota: Edit VM Quota
       editQuota: Edit Quota
@@ -214,6 +223,7 @@ harvester:
       title: Take Virtual Machine Snapshot
       name: Name
       success: 'Take virtual machine Snapshot { name } successfully.'
+      fsFreezeDeadline: 'File system freeze deadline'
     restart:
       title: Restart Virtual Machine
       tip: Restart the virtual machine for configuration changes to take effect.

--- a/pkg/harvester/utils/backup.js
+++ b/pkg/harvester/utils/backup.js
@@ -1,0 +1,43 @@
+export const DEFAULT_FS_FREEZE_DEADLINE = '1s';
+
+/**
+ * Generate filesystem freeze deadline options with i18n translations
+ * @param {Function} t - i18n translation function
+ * @returns {Array} Array of deadline options
+ */
+export function getFsFreezeDeadlineOptions(t) {
+  return [
+    {
+      label: t('generic.duration.infinite'),
+      value: '0s'
+    },
+    {
+      label: t('generic.duration.1s'),
+      value: '1s'
+    },
+    {
+      label: t('generic.duration.5s'),
+      value: '5s'
+    },
+    {
+      label: t('generic.duration.10s'),
+      value: '10s'
+    },
+    {
+      label: t('generic.duration.30s'),
+      value: '30s'
+    },
+    {
+      label: t('generic.duration.1m'),
+      value: '1m'
+    },
+    {
+      label: t('generic.duration.3m'),
+      value: '3m'
+    },
+    {
+      label: t('generic.duration.5m'),
+      value: '5m'
+    }
+  ];
+}


### PR DESCRIPTION
Add a dropdown menu to the dialogs for creating VM backups and snapshots to select the “Filesystem Freeze Deadline.”

<img width="1169" height="681" alt="grafik" src="https://github.com/user-attachments/assets/34757554-067f-479d-b216-516d22ca43ac" />

<img width="1169" height="681" alt="grafik" src="https://github.com/user-attachments/assets/e997ebaa-36eb-4416-83f1-248e616428c2" />

### Related Issue #
https://github.com/harvester/harvester/issues/4098

API changes done by: https://github.com/harvester/harvester/pull/10545

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


