### PR TITLE
refactor: remove unused pluralization for persistent volume claim in localization file

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -2180,12 +2180,6 @@ typeLabel:
       other { PCI Devices }
     }
 
-  persistentvolumeclaim: |-
-    {count, plural,
-      one { Volume }
-      other { Volumes }
-    }
-
   network.harvesterhci.io.clusternetwork: |-
     {count, plural,
       one { Cluster Network }


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

refactor: remove unused pluralization persistentvolumeclaim key to not override other Rancher cluster.


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/10574

### Test screenshot or video

Before
<img width="669" height="472" alt="Screenshot 2026-05-14 at 11 35 48 AM" src="https://github.com/user-attachments/assets/cacb016a-f15f-4338-97b2-454096b3ddf6" />


After
<img width="461" height="495" alt="Screenshot 2026-05-14 at 11 54 10 AM" src="https://github.com/user-attachments/assets/de03db9d-f0e2-4129-aadc-bf15ce410f9d" />




