### PR TITLE
fix: fetch VMIM in host detail VM tab to get VM migration state correctly

### DIFF
--- a/pkg/harvester/detail/harvesterhci.io.host/VirtualMachineInstance.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/VirtualMachineInstance.vue
@@ -27,15 +27,11 @@ export default {
     await allHash({
       vms:               this.$store.dispatch('harvester/findAll', { type: HCI.VM }),
       vmis:              this.$store.dispatch('harvester/findAll', { type: HCI.VMI }),
-      allClusterNetwork: this.$store.dispatch('harvester/findAll', { type: HCI.CLUSTER_NETWORK }),
+      vmims:             this.$store.dispatch('harvester/findAll', { type: HCI.VMIM }),
     });
   },
 
   computed: {
-    allClusterNetwork() {
-      return this.$store.getters['harvester/all'](HCI.CLUSTER_NETWORK);
-    },
-
     rows() {
       const vms = this.$store.getters['harvester/all'](HCI.VM);
 
@@ -108,7 +104,6 @@ export default {
             <HarvesterVmState
               class="vmstate"
               :row="scope.row"
-              :all-cluster-network="allClusterNetwork"
             />
           </div>
         </template>

--- a/pkg/harvester/formatters/HarvesterMigrationState.vue
+++ b/pkg/harvester/formatters/HarvesterMigrationState.vue
@@ -20,12 +20,7 @@ export default {
 
   computed: {
     vmiResource() {
-      const vmiList = this.$store.getters['harvester/all'](HCI.VMI) || [];
-      const vmi = vmiList.find( (VMI) => {
-        return VMI?.metadata?.ownerReferences?.[0]?.uid === this.vmResource?.metadata?.uid;
-      });
-
-      return vmi;
+      return this.$store.getters['harvester/byId'](HCI.VMI, this.vmResource?.id) || null;
     },
     migrationState() {
       return this.vmiResource?.migrationState?.status || '';

--- a/pkg/harvester/formatters/HarvesterVmState.vue
+++ b/pkg/harvester/formatters/HarvesterVmState.vue
@@ -14,20 +14,6 @@ export default {
       type:     Object,
       required: true
     },
-
-    allNodeNetwork: {
-      type:    Array,
-      default: () => {
-        return [];
-      }
-    },
-
-    allClusterNetwork: {
-      type:    Array,
-      default: () => {
-        return [];
-      }
-    }
   },
 
   data() {

--- a/pkg/harvester/list/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/list/kubevirt.io.virtualmachine.vue
@@ -98,19 +98,9 @@ export default {
       this.hasNode = true;
     }
 
-    if (this.$store.getters[`${ inStore }/schemaFor`](HCI.NODE_NETWORK)) {
-      _hash.nodeNetworks = this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.NODE_NETWORK });
-    }
-
-    if (this.$store.getters[`${ inStore }/schemaFor`](HCI.CLUSTER_NETWORK)) {
-      _hash.clusterNetworks = this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.CLUSTER_NETWORK });
-    }
-
     const hash = await allHash(_hash);
 
     this.allVMs = hash.vms;
-    this.allNodeNetworks = hash.nodeNetworks || [];
-    this.allClusterNetworks = hash.clusterNetworks || [];
   },
 
   data() {
@@ -118,8 +108,6 @@ export default {
       hasNode:                      false,
       allVMs:                       [],
       allVMIs:                      [],
-      allNodeNetworks:              [],
-      allClusterNetworks:           [],
       restartNotificationDisplayed: false,
       HCI
     };
@@ -246,8 +234,6 @@ export default {
           <HarvesterVmState
             class="vmstate"
             :row="scope.row"
-            :all-node-network="allNodeNetworks"
-            :all-cluster-network="allClusterNetworks"
           />
         </div>
       </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- root cause is we didn't fetch `VMIM (kubevirt.io.virtualmachineinstancemigration)` from host details VM tab.
- remove dead code two props (allNodeNetwork, allClusterNetwork) which are not used.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/10092

### Test screenshot or video

https://github.com/user-attachments/assets/012d6589-11bc-4167-a5d9-6546db413591




