### PR TITLE
ci: disable body-max-line-length eslint rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -33,7 +33,7 @@ module.exports = {
     'subject-full-stop':      [2, 'never', '.'],
     'subject-max-length':     [0, 'never'],
     'body-leading-blank':     [2, 'always'],
-    'body-max-line-length':   [2, 'always', 100],
+    'body-max-line-length':   [0, 'always', 100],
     'footer-leading-blank':   [2, 'always'],
     'footer-max-line-length': [2, 'always', 100],
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Disable `body-max-line-length` rule  to fix https://github.com/harvester/harvester-ui-extension/actions/runs/26431860913/job/77806535065
<img width="1212" height="780" alt="Screenshot 2026-05-26 at 1 39 06 PM" src="https://github.com/user-attachments/assets/cb3a9880-f1fe-4117-afee-d2e92f7ef2a1" />

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


