### PR TITLE
feat: add autoattachPodInterface in edit VM mode if no network interface configured

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/index.vue
@@ -5,7 +5,7 @@ import { sortBy } from '@shell/utils/sort';
 import { clone } from '@shell/utils/object';
 import { randomStr } from '@shell/utils/string';
 import { removeObject } from '@shell/utils/array';
-import { _VIEW } from '@shell/config/query-params';
+import { _VIEW, _EDIT } from '@shell/config/query-params';
 import { HCI as HCI_ANNOTATIONS } from '../../../config/labels-annotations';
 import Base from './base';
 
@@ -51,6 +51,9 @@ export default {
   },
 
   computed: {
+    isEdit() {
+      return this.mode === _EDIT;
+    },
     isView() {
       return this.mode === _VIEW;
     },

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork/index.vue
@@ -5,7 +5,7 @@ import { sortBy } from '@shell/utils/sort';
 import { clone } from '@shell/utils/object';
 import { randomStr } from '@shell/utils/string';
 import { removeObject } from '@shell/utils/array';
-import { _VIEW, _EDIT } from '@shell/config/query-params';
+import { _VIEW } from '@shell/config/query-params';
 import { HCI as HCI_ANNOTATIONS } from '../../../config/labels-annotations';
 import Base from './base';
 
@@ -51,9 +51,6 @@ export default {
   },
 
   computed: {
-    isEdit() {
-      return this.mode === _EDIT;
-    },
     isView() {
       return this.mode === _VIEW;
     },

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -907,14 +907,22 @@ export default {
       const specInterfaces = this.spec?.template?.spec?.domain?.devices?.interfaces;
       const mergedInterfaces = this.mergeInterfaceList(specInterfaces, interfaces);
 
+      const devices = {
+        ...this.spec.template.spec.domain.devices,
+        interfaces: mergedInterfaces,
+      };
+
+      if (this.isEdit && networkRow.length === 0) {
+        devices.autoattachPodInterface = false;
+      } else {
+        delete devices.autoattachPodInterface;
+      }
+
       const spec = {
         ...this.spec.template.spec,
         domain: {
           ...this.spec.template.spec.domain,
-          devices: {
-            ...this.spec.template.spec.domain.devices,
-            interfaces: mergedInterfaces,
-          },
+          devices,
         },
         networks
       };


### PR DESCRIPTION


### Summary
 Add autoattachPodInterface in edit VM mode if no network interace configured

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @rrajendran17 

### Related Issue #
https://github.com/harvester/harvester/issues/10021 https://github.com/harvester/harvester/issues/10328

### Test screenshot or video

https://github.com/user-attachments/assets/df8c32b2-d9f4-4a90-93e7-0d4b281ee174




