### PR TITLE
feat: remove old format pci device name checking

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/index.vue
@@ -52,31 +52,21 @@ export default {
     }
 
     const selectedDevices = [];
-    const oldFormatDevices = [];
 
     const vmDevices = this.value?.domain?.devices?.hostDevices || [];
-    const otherDevices = this.otherDevices(vmDevices).map(({ name }) => name);
     const vmDeviceNames = vmDevices.map(({ name }) => name);
 
     this.pciDevices.forEach((row) => {
       row.allowDisable = !vmDeviceNames.includes(row.metadata.name);
     });
 
-    vmDevices.forEach(({ name, deviceName }) => {
-      const checkName = (deviceName || '').split('/')?.[1];
-
-      if (checkName && name.includes(checkName) && !otherDevices.includes(name)) {
-        oldFormatDevices.push(name);
-      } else if (this.enabledDevices.find((device) => device?.metadata?.name === name)) {
+    vmDevices.forEach(({ name }) => {
+      if (this.enabledDevices.find((device) => device?.metadata?.name === name)) {
         selectedDevices.push(name);
       }
     });
 
-    if (oldFormatDevices.length > 0) {
-      this.oldFormatDevices = oldFormatDevices;
-    } else {
-      this.selectedDevices = selectedDevices;
-    }
+    this.selectedDevices = selectedDevices;
   },
 
   data() {
@@ -87,7 +77,6 @@ export default {
       selectedDevices:  [],
       pciDeviceSchema:  this.$store.getters['harvester/schemaFor'](HCI.PCI_DEVICE),
       showMatrix:       false,
-      oldFormatDevices: [],
     };
   },
 
@@ -199,11 +188,6 @@ export default {
       });
     },
 
-    oldFormatDevicesHTML() {
-      return this.oldFormatDevices.map((device) => {
-        return `<li>${ device }</li>`;
-      }).join('');
-    },
   },
 
   methods: {
@@ -227,100 +211,88 @@ export default {
 
 <template>
   <div>
-    <div
-      v-if="oldFormatDevices.length > 0"
-      class="row"
-    >
+    <div class="row">
       <div class="col span-12">
-        <Banner color="warning">
-          <p v-clean-html="t('harvester.pci.oldFormatDevices.help', {oldFormatDevicesHTML}, true)" />
+        <Banner color="info">
+          <MessageLink
+            :to="toVGpuDevicesPage"
+            prefix-label="harvester.pci.howToUseDeviceInVMCreation.prefix"
+            middle-label="harvester.pci.howToUseDeviceInVMCreation.middle"
+            suffix-label="harvester.pci.howToUseDeviceInVMCreation.suffix"
+          />
+        </Banner>
+        <Banner
+          v-if="selectedDevices.length > 0"
+          color="info"
+        >
+          <t k="harvester.pci.deviceInTheSameHost" />
         </Banner>
       </div>
     </div>
-    <div v-else>
+    <template v-if="enabledDevices.length">
       <div class="row">
-        <div class="col span-12">
-          <Banner color="info">
-            <MessageLink
-              :to="toVGpuDevicesPage"
-              prefix-label="harvester.pci.howToUseDeviceInVMCreation.prefix"
-              middle-label="harvester.pci.howToUseDeviceInVMCreation.middle"
-              suffix-label="harvester.pci.howToUseDeviceInVMCreation.suffix"
-            />
-          </Banner>
-          <Banner
-            v-if="selectedDevices.length > 0"
-            color="info"
+        <div class="col span-6">
+          <LabeledSelect
+            v-model:value="selectedDevices"
+            label="Available PCI Devices"
+            searchable
+            multiple
+            taggable
+            :options="deviceOpts"
+            :mode="mode"
           >
-            <t k="harvester.pci.deviceInTheSameHost" />
-          </Banner>
+            <template #option="option">
+              <span>{{ option.value }} <span class="text-label">({{ option.displayLabel }})</span></span>
+            </template>
+          </LabeledSelect>
         </div>
       </div>
-      <template v-if="enabledDevices.length">
-        <div class="row">
-          <div class="col span-6">
-            <LabeledSelect
-              v-model:value="selectedDevices"
-              label="Available PCI Devices"
-              searchable
-              multiple
-              taggable
-              :options="deviceOpts"
-              :mode="mode"
-            >
-              <template #option="option">
-                <span>{{ option.value }} <span class="text-label">({{ option.displayLabel }})</span></span>
-              </template>
-            </LabeledSelect>
-          </div>
+      <div
+        v-if="compatibleNodes.length && selectedDevices.length"
+        class="row"
+      >
+        <div class="col span-12 text-muted">
+          Compatible hosts:
+          <!-- eslint-disable-next-line vue/no-parsing-error -->
+          <span
+            v-for="(node, idx) in compatibleNodes"
+            :key="idx"
+          >{{ node }}{{ idx < compatibleNodes.length-1 ? ', ' : '' }}</span>
         </div>
-        <div
-          v-if="compatibleNodes.length && selectedDevices.length"
-          class="row"
-        >
-          <div class="col span-12 text-muted">
-            Compatible hosts:
-            <!-- eslint-disable-next-line vue/no-parsing-error -->
-            <span
-              v-for="(node, idx) in compatibleNodes"
-              :key="idx"
-            >{{ node }}{{ idx < compatibleNodes.length-1 ? ', ' : '' }}</span>
-          </div>
-        </div>
-        <div
-          v-else-if="selectedDevices.length"
-          class="text-error"
-        >
-          {{ t('harvester.pci.impossibleSelection') }}
-        </div>
-        <button
-          type="button"
-          class="btn btn-sm role-link pl-0"
-          @click="e=>{showMatrix = !showMatrix; e.target.blur()}"
-        >
-          {{ showMatrix ? t('harvester.pci.hideCompatibility') : t('harvester.pci.showCompatibility') }}
-        </button>
-        <div
-          v-if="showMatrix"
-          class="row mt-20"
-        >
-          <div class="col span-12">
-            <CompatibilityMatrix
-              :enabled-devices="enabledDevices"
-              :devices-by-node="devicesByNode"
-              :devices-in-use="devicesInUse"
-            />
-          </div>
-        </div>
-      </template>
-      <div class="row mt-20">
+      </div>
+      <div
+        v-else-if="selectedDevices.length"
+        class="text-error"
+      >
+        {{ t('harvester.pci.impossibleSelection') }}
+      </div>
+      <button
+        type="button"
+        class="btn btn-sm role-link pl-0"
+        @click="e=>{showMatrix = !showMatrix; e.target.blur()}"
+      >
+        {{ showMatrix ? t('harvester.pci.hideCompatibility') : t('harvester.pci.showCompatibility') }}
+      </button>
+      <div
+        v-if="showMatrix"
+        class="row mt-20"
+      >
         <div class="col span-12">
-          <DeviceList
-            :schema="pciDeviceSchema"
-            :devices="pciDevices"
-            @submit.prevent
+          <CompatibilityMatrix
+            :enabled-devices="enabledDevices"
+            :devices-by-node="devicesByNode"
+            :devices-in-use="devicesInUse"
           />
         </div>
+      </div>
+    </template>
+    <div class="row mt-20">
+      <div class="col span-12">
+        <DeviceList
+          :schema="pciDeviceSchema"
+          :devices="pciDevices"
+          @submit.prevent
+        />
       </div>
     </div>
   </div>

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -392,21 +392,6 @@ harvester:
       middle: vGPU Devices
       suffix: page.
     deviceInTheSameHost: 'You can only select devices on the same host.'
-    oldFormatDevices:
-      help: |-
-        <p>
-          The following PCI devices are using the old naming convention and need to be updated in the YAML file:
-        </p>
-        <ul>
-          {oldFormatDevicesHTML}
-        </ul>
-        <p>
-          Please use the following instructions to update the virtual machine:
-        </p>
-        <ol>
-          <li>Stop the virtual machine, edit the virtual machine YAML, and remove the <Code>hostDevices</Code> section, and save virtual machine the changes to the YAML file.</li>
-          <li>Edit the virtual machine, and add the already enabled PCI Device from the list of available PCIDevices, and save and start VM.</li>
-        </ol>
     showCompatibility: Show device compatibility matrix
     hideCompatibility: Hide device compatibility matrix
     claimError: Error enabling passthrough on {name}


### PR DESCRIPTION
when implementing the first version pci device passthrough, we didn't have our own device plugin, then resource name was changed after upgrade.

Right now, we already have our own device plugin, which we can control resource name by our ourselves. So, we can remove old mechanism.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @Yu-Jack 

### Related Issue #
backend: https://github.com/harvester/pcidevices/pull/191
original issue: https://github.com/harvester/harvester/issues/6724

### Test screenshot or video


Before:

<img width="1025" height="269" alt="image" src="https://github.com/user-attachments/assets/0b727d46-bf2a-4f74-83bf-7873b4adfc67" />


After:

<img width="1335" height="697" alt="image" src="https://github.com/user-attachments/assets/f69522b6-c2cc-44d0-8b80-238fe0b461e5" />



