### PR TITLE
fix: defer window.open to prevent dropdown staying open in Firefox

### DIFF
--- a/pkg/harvester/components/VMConsoleBar.vue
+++ b/pkg/harvester/components/VMConsoleBar.vue
@@ -58,11 +58,14 @@ export default {
 
       const url = `https://${ host }${ prefix }/${ PRODUCT_NAME }/c/${ params.cluster }/console/${ uid }/${ type }`;
 
-      window.open(
-        url,
-        '_blank',
-        `toolbars=0,width=${ screen.width - 200 },height=${ screen.height - 200 },left=0,top=0,noreferrer`
-      );
+      // Defer so v-select can finish closing the dropdown before the popup steals focus
+      this.$nextTick(() => {
+        window.open(
+          url,
+          '_blank',
+          `toolbars=0,width=${ screen.width - 200 },height=${ screen.height - 200 },left=0,top=0,noreferrer`
+        );
+      });
     },
 
     isEmpty(o) {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
When selecting an option from the Console dropdown (e.g. "Open in WebVNC" or "Open in Serial Console") on the Virtual Machines list page, `window.open()` was called synchronously during v-select's selection handling. The new popup window immediately stole browser focus, interrupting the dropdown's internal close sequence — causing the dropdown to remain visually stuck open. This is most evident in Firefox.

Fix: wrap `window.open()` in `this.$nextTick()` so Vue's DOM update cycle (including the dropdown closing) fully completes before the popup steals focus.



### PR Checklists
- Are backend engineers aware of UI changes ?
  - [x] Yes — this is a frontend-only change. No backend impact.

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
https://github.com/harvester/harvester/issues/10678


### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
Reproduced in Firefox  151.0.1

Before fix: dropdown remains open after selecting an option.
After fix: dropdown closes correctly after selection.


