### PR TITLE
feat: support filesystem volume in create VM page

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -67,7 +67,6 @@ const FEATURE_FLAGS = {
     'rwxNetworkSetting',
     'createPVCWithDataVolume',
     'clusterPodSecurityStandardSetting',
-    'supportFilesystem',
   ],
   'v1.8.1': [],
   'v1.9.0': [

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -69,7 +69,9 @@ const FEATURE_FLAGS = {
     'clusterPodSecurityStandardSetting'
   ],
   'v1.8.1': [],
-  'v1.9.0': [],
+  'v1.9.0': [
+    'supportFilesystem',
+  ],
 };
 
 const generateFeatureFlags = () => {

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -66,7 +66,8 @@ const FEATURE_FLAGS = {
     'instanceManagerResourcesSetting',
     'rwxNetworkSetting',
     'createPVCWithDataVolume',
-    'clusterPodSecurityStandardSetting'
+    'clusterPodSecurityStandardSetting',
+    'supportFilesystem',
   ],
   'v1.8.1': [],
   'v1.9.0': [

--- a/pkg/harvester/config/types.js
+++ b/pkg/harvester/config/types.js
@@ -46,3 +46,9 @@ export const CDI_POPULATOR_KIND = {
   VOLUME_IMPORT_SOURCE: 'VolumeImportSource',
   VOLUME_CLONE_SOURCE:  'VolumeCloneSource',
 };
+
+export const FILESYSTEM_SOURCE_TYPE = {
+  CONFIGMAP:      'configmap',
+  SECRET:         'secret',
+  SERVICEACCOUNT: 'serviceaccount',
+};

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -160,7 +160,7 @@ export default {
 
   mounted() {
     this.imageId = this.diskRows[0]?.image || '';
-    this['filesystemRows'] = this.getFilesystemRows(this.value);
+    this['filesystemRows'] = this.getFilesystemRows(this.value.spec.vm);
   },
 
   methods: {

--- a/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/edit/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -26,6 +26,7 @@ import CpuMemory from './kubevirt.io.virtualmachine/VirtualMachineCpuMemory';
 import CpuModel from './kubevirt.io.virtualmachine/VirtualMachineCpuModel';
 import CloudConfig from './kubevirt.io.virtualmachine/VirtualMachineCloudConfig';
 import SSHKey from './kubevirt.io.virtualmachine/VirtualMachineSSHKey';
+import Filesystem from './kubevirt.io.virtualmachine/VirtualMachineFilesystem';
 
 export default {
   name: 'HarvesterEditVMTemplate',
@@ -51,6 +52,7 @@ export default {
     UnitInput,
     Banner,
     KeyValue,
+    Filesystem,
   },
 
   mixins: [CreateEditView, VM_MIXIN],
@@ -94,6 +96,10 @@ export default {
 
     secretNamePrefix() {
       return this.templateValue?.metadata?.name;
+    },
+
+    filesystemEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('supportFilesystem');
     },
   },
 
@@ -154,6 +160,7 @@ export default {
 
   mounted() {
     this.imageId = this.diskRows[0]?.image || '';
+    this['filesystemRows'] = this.getFilesystemRows(this.value);
   },
 
   methods: {
@@ -347,6 +354,19 @@ export default {
             :overwrite-labels="affinityLabels"
           />
         </template>
+      </Tab>
+
+      <Tab
+        v-if="filesystemEnabled"
+        name="filesystem"
+        :label="t('harvester.tab.filesystem')"
+        :weight="-8"
+      >
+        <Filesystem
+          v-model:value="filesystemRows"
+          :mode="mode"
+          :namespace="templateValue.metadata.namespace"
+        />
       </Tab>
 
       <Tab

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
@@ -36,6 +36,8 @@ function emptyRow() {
 export default {
   name: 'VirtualMachineFilesystem',
 
+  emits: ['update:value'],
+
   components: {
     Banner,
     LabeledSelect,
@@ -65,7 +67,7 @@ export default {
 
   watch: {
     value(newVal) {
-      if (newVal && newVal.length > 0) {
+      if (newVal) {
         const incoming = JSON.stringify(newVal);
         const current = JSON.stringify(this.rows);
 

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
@@ -4,17 +4,18 @@ import { Banner } from '@components/Banner';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { CONFIG_MAP, SECRET, SERVICE_ACCOUNT } from '@shell/config/types';
+import { _VIEW } from '@shell/config/query-params';
+import CopyToClipboard from '@shell/components/CopyToClipboard';
+import { FILESYSTEM_SOURCE_TYPE } from '@pkg/harvester/config/types';
 
 const MAX_FILESYSTEMS = 3;
 
-const FS_TYPE_CONFIGMAP = 'configmap';
-const FS_TYPE_SECRET = 'secret';
-const FS_TYPE_SERVICEACCOUNT = 'serviceaccount';
+const { CONFIGMAP: FS_TYPE_CONFIGMAP, SECRET: FS_TYPE_SECRET, SERVICEACCOUNT: FS_TYPE_SERVICEACCOUNT } = FILESYSTEM_SOURCE_TYPE;
 
 const DEFAULT_VOLUME_NAMES = {
-  [FS_TYPE_CONFIGMAP]:      'configfs',
-  [FS_TYPE_SECRET]:         'secretfs',
-  [FS_TYPE_SERVICEACCOUNT]: 'serviceaccountfs',
+  [FS_TYPE_CONFIGMAP]:      'appConfigfs',
+  [FS_TYPE_SECRET]:         'appSecretfs',
+  [FS_TYPE_SERVICEACCOUNT]: 'appServiceAccountfs',
 };
 
 const FS_TYPE_OPTIONS = [
@@ -38,6 +39,7 @@ export default {
     Banner,
     LabeledSelect,
     LabeledInput,
+    CopyToClipboard,
   },
 
   props: {
@@ -49,10 +51,34 @@ export default {
       type:    String,
       default: '',
     },
+    value: {
+      type:    Array,
+      default: () => [],
+    },
   },
 
   data() {
-    return { rows: [emptyRow()] };
+    return { rows: this.value.length > 0 ? this.value.map((r) => ({ ...r })) : [emptyRow()] };
+  },
+
+  watch: {
+    value(newVal) {
+      if (newVal && newVal.length > 0) {
+        const incoming = JSON.stringify(newVal);
+        const current = JSON.stringify(this.rows);
+
+        if (incoming !== current) {
+          this.rows = newVal.map((r) => ({ ...r }));
+        }
+      }
+    },
+
+    rows: {
+      deep: true,
+      handler(val) {
+        this.$emit('update:value', val.map((r) => ({ ...r })));
+      },
+    },
   },
 
   computed: {
@@ -85,17 +111,25 @@ export default {
     },
 
     isView() {
-      return this.mode === 'view';
+      return this.mode === _VIEW;
     },
 
     completedRows() {
       return this.rows.filter((r) => r.fsType && r.volumeName && r.resourceName);
     },
+
+    allMountCommands() {
+      return this.completedRows.map((r) => this.mountCommands(r)).join('\n');
+    },
   },
 
   methods: {
-    fsTypeOptions() {
-      return FS_TYPE_OPTIONS;
+    fsTypeOptions(currentIndex) {
+      const usedTypes = this.rows
+        .filter((_, i) => i !== currentIndex)
+        .map((r) => r.fsType);
+
+      return FS_TYPE_OPTIONS.filter((opt) => !usedTypes.includes(opt.value));
     },
 
     resourceOptions(fsType) {
@@ -114,7 +148,14 @@ export default {
 
     addRow() {
       if (this.canAddRow) {
-        this.rows.push(emptyRow());
+        const usedTypes = this.rows.map((r) => r.fsType);
+        const nextType = FS_TYPE_OPTIONS.find((opt) => !usedTypes.includes(opt.value))?.value || FS_TYPE_CONFIGMAP;
+
+        this.rows.push({
+          fsType:       nextType,
+          volumeName:   DEFAULT_VOLUME_NAMES[nextType] || '',
+          resourceName: '',
+        });
       }
     },
 
@@ -147,8 +188,9 @@ export default {
           <LabeledSelect
             :value="row.fsType"
             :label="t('harvester.virtualMachine.filesystem.type')"
-            :options="fsTypeOptions()"
+            :options="fsTypeOptions(index)"
             :mode="mode"
+            required
             @update:value="onFsTypeChange(row, $event)"
           />
         </div>
@@ -158,6 +200,7 @@ export default {
             v-model:value="row.volumeName"
             :label="t('harvester.virtualMachine.filesystem.volume')"
             :mode="mode"
+            required
           />
         </div>
 
@@ -167,6 +210,7 @@ export default {
             :label="t('harvester.virtualMachine.filesystem.resource')"
             :options="resourceOptions(row.fsType)"
             :mode="mode"
+            required
           />
         </div>
 
@@ -183,17 +227,30 @@ export default {
           </button>
         </div>
       </div>
-
-      <Banner
-        v-if="row.fsType && row.volumeName && row.resourceName"
-        color="warning"
-        class="mt-10"
-      >
-        <p>{{ t('harvester.virtualMachine.filesystem.mountBannerHint') }}</p>
-        <pre class="mt-5 mb-0">- mkdir -p /mnt/{{ row.volumeName }}
-- mount -t virtiofs {{ row.volumeName }} /mnt/{{ row.volumeName }}</pre>
-      </Banner>
     </div>
+
+    <Banner
+      v-if="completedRows.length > 0"
+      color="warning"
+      class="mt-10"
+    >
+      <div>
+        <p>
+          {{ t('harvester.virtualMachine.filesystem.mountBannerHint') }}
+          <a href="/harvester/c/local/kubevirt.io.virtualmachine/create#advanced">{{ t('harvester.virtualMachine.filesystem.mountBannerHintLink') }}</a>
+          {{ t('harvester.virtualMachine.filesystem.mountBannerHintSuffix') }}
+        </p>
+        <div class="pre-wrapper">
+          <pre class="mt-5 mb-0">{{ allMountCommands }}</pre>
+          <CopyToClipboard
+            :text="allMountCommands"
+            :show-label="false"
+            class="icon-btn"
+            action-color="bg-transparent"
+          />
+        </div>
+      </div>
+    </Banner>
 
     <button
       v-if="!isView && canAddRow"
@@ -224,5 +281,27 @@ export default {
 
 .remove-btn {
   padding: 0;
+}
+
+.pre-wrapper {
+  position: relative;
+
+  pre {
+    padding-right: 36px;
+  }
+
+  .icon-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    padding: 2px 4px;
+    line-height: 1;
+
+    :deep(.btn.role-primary) {
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.1);
+      }
+    }
+  }
 }
 </style>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
@@ -1,0 +1,228 @@
+<script>
+import { mapGetters } from 'vuex';
+import { Banner } from '@components/Banner';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import { CONFIG_MAP, SECRET, SERVICE_ACCOUNT } from '@shell/config/types';
+
+const MAX_FILESYSTEMS = 3;
+
+const FS_TYPE_CONFIGMAP = 'configmap';
+const FS_TYPE_SECRET = 'secret';
+const FS_TYPE_SERVICEACCOUNT = 'serviceaccount';
+
+const DEFAULT_VOLUME_NAMES = {
+  [FS_TYPE_CONFIGMAP]:      'configfs',
+  [FS_TYPE_SECRET]:         'secretfs',
+  [FS_TYPE_SERVICEACCOUNT]: 'serviceaccountfs',
+};
+
+const FS_TYPE_OPTIONS = [
+  { label: 'ConfigMap', value: FS_TYPE_CONFIGMAP },
+  { label: 'Secret', value: FS_TYPE_SECRET },
+  { label: 'ServiceAccount', value: FS_TYPE_SERVICEACCOUNT },
+];
+
+function emptyRow() {
+  return {
+    fsType:       FS_TYPE_CONFIGMAP,
+    volumeName:   DEFAULT_VOLUME_NAMES[FS_TYPE_CONFIGMAP],
+    resourceName: '',
+  };
+}
+
+export default {
+  name: 'VirtualMachineFilesystem',
+
+  components: {
+    Banner,
+    LabeledSelect,
+    LabeledInput,
+  },
+
+  props: {
+    mode: {
+      type:    String,
+      default: 'create',
+    },
+    namespace: {
+      type:    String,
+      default: '',
+    },
+  },
+
+  data() {
+    return { rows: [emptyRow()] };
+  },
+
+  computed: {
+    ...mapGetters({ t: 'i18n/t' }),
+
+    inStore() {
+      return this.$store.getters['currentProduct'].inStore;
+    },
+
+    configMaps() {
+      return this.$store.getters[`${ this.inStore }/all`](CONFIG_MAP)
+        .filter((cm) => !this.namespace || cm.metadata.namespace === this.namespace)
+        .map((cm) => ({ label: cm.metadata.name, value: cm.metadata.name }));
+    },
+
+    secrets() {
+      return this.$store.getters[`${ this.inStore }/all`](SECRET)
+        .filter((s) => !this.namespace || s.metadata.namespace === this.namespace)
+        .map((s) => ({ label: s.metadata.name, value: s.metadata.name }));
+    },
+
+    serviceAccounts() {
+      return this.$store.getters[`${ this.inStore }/all`](SERVICE_ACCOUNT)
+        .filter((sa) => !this.namespace || sa.metadata.namespace === this.namespace)
+        .map((sa) => ({ label: sa.metadata.name, value: sa.metadata.name }));
+    },
+
+    canAddRow() {
+      return this.rows.length < MAX_FILESYSTEMS;
+    },
+
+    isView() {
+      return this.mode === 'view';
+    },
+
+    completedRows() {
+      return this.rows.filter((r) => r.fsType && r.volumeName && r.resourceName);
+    },
+  },
+
+  methods: {
+    fsTypeOptions() {
+      return FS_TYPE_OPTIONS;
+    },
+
+    resourceOptions(fsType) {
+      if (fsType === FS_TYPE_CONFIGMAP) return this.configMaps;
+      if (fsType === FS_TYPE_SECRET) return this.secrets;
+      if (fsType === FS_TYPE_SERVICEACCOUNT) return this.serviceAccounts;
+
+      return [];
+    },
+
+    onFsTypeChange(row, newType) {
+      row.fsType = newType;
+      row.volumeName = DEFAULT_VOLUME_NAMES[newType] || '';
+      row.resourceName = '';
+    },
+
+    addRow() {
+      if (this.canAddRow) {
+        this.rows.push(emptyRow());
+      }
+    },
+
+    removeRow(index) {
+      this.rows.splice(index, 1);
+    },
+
+    mountCommands(row) {
+      const vol = row.volumeName || '<volume-name>';
+
+      return `- mkdir -p /mnt/${ vol }\n- mount -t virtiofs ${ vol } /mnt/${ vol }`;
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="vm-filesystem">
+    <p class="mb-20">
+      {{ t('harvester.virtualMachine.filesystem.description') }}
+    </p>
+
+    <div
+      v-for="(row, index) in rows"
+      :key="index"
+      class="filesystem-row mb-15"
+    >
+      <div class="row">
+        <div class="col span-3">
+          <LabeledSelect
+            :value="row.fsType"
+            :label="t('harvester.virtualMachine.filesystem.type')"
+            :options="fsTypeOptions()"
+            :mode="mode"
+            @update:value="onFsTypeChange(row, $event)"
+          />
+        </div>
+
+        <div class="col span-3">
+          <LabeledInput
+            v-model:value="row.volumeName"
+            :label="t('harvester.virtualMachine.filesystem.volume')"
+            :mode="mode"
+          />
+        </div>
+
+        <div class="col span-5">
+          <LabeledSelect
+            v-model:value="row.resourceName"
+            :label="t('harvester.virtualMachine.filesystem.resource')"
+            :options="resourceOptions(row.fsType)"
+            :mode="mode"
+          />
+        </div>
+
+        <div
+          v-if="!isView"
+          class="col span-1 remove-col"
+        >
+          <button
+            type="button"
+            class="btn role-link remove-btn"
+            @click="removeRow(index)"
+          >
+            {{ t('generic.remove') }}
+          </button>
+        </div>
+      </div>
+
+      <Banner
+        v-if="row.fsType && row.volumeName && row.resourceName"
+        color="warning"
+        class="mt-10"
+      >
+        <p>{{ t('harvester.virtualMachine.filesystem.mountBannerHint') }}</p>
+        <pre class="mt-5 mb-0">- mkdir -p /mnt/{{ row.volumeName }}
+- mount -t virtiofs {{ row.volumeName }} /mnt/{{ row.volumeName }}</pre>
+      </Banner>
+    </div>
+
+    <button
+      v-if="!isView && canAddRow"
+      type="button"
+      class="btn role-tertiary add"
+      @click="addRow"
+    >
+      {{ t('harvester.virtualMachine.filesystem.add') }}
+    </button>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.vm-filesystem {
+  padding: 10px 0;
+}
+
+.filesystem-row {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 15px;
+}
+
+.remove-col {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.remove-btn {
+  padding: 0;
+}
+</style>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
@@ -6,6 +6,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import { CONFIG_MAP, SECRET, SERVICE_ACCOUNT } from '@shell/config/types';
 import { _VIEW } from '@shell/config/query-params';
 import CopyToClipboard from '@shell/components/CopyToClipboard';
+import MessageLink from '@shell/components/MessageLink';
 import { FILESYSTEM_SOURCE_TYPE } from '@pkg/harvester/config/types';
 
 const MAX_FILESYSTEMS = 3;
@@ -13,9 +14,9 @@ const MAX_FILESYSTEMS = 3;
 const { CONFIGMAP: FS_TYPE_CONFIGMAP, SECRET: FS_TYPE_SECRET, SERVICEACCOUNT: FS_TYPE_SERVICEACCOUNT } = FILESYSTEM_SOURCE_TYPE;
 
 const DEFAULT_VOLUME_NAMES = {
-  [FS_TYPE_CONFIGMAP]:      'appConfigfs',
-  [FS_TYPE_SECRET]:         'appSecretfs',
-  [FS_TYPE_SERVICEACCOUNT]: 'appServiceAccountfs',
+  [FS_TYPE_CONFIGMAP]:      'appconfigfs',
+  [FS_TYPE_SECRET]:         'appsecretfs',
+  [FS_TYPE_SERVICEACCOUNT]: 'appserviceaccountfs',
 };
 
 const FS_TYPE_OPTIONS = [
@@ -40,6 +41,7 @@ export default {
     LabeledSelect,
     LabeledInput,
     CopyToClipboard,
+    MessageLink,
   },
 
   props: {
@@ -235,12 +237,13 @@ export default {
       class="mt-10"
     >
       <div>
-        <p>
-          {{ t('harvester.virtualMachine.filesystem.mountBannerHint') }}
-          <a href="/harvester/c/local/kubevirt.io.virtualmachine/create#advanced">{{ t('harvester.virtualMachine.filesystem.mountBannerHintLink') }}</a>
-          {{ t('harvester.virtualMachine.filesystem.mountBannerHintSuffix') }}
-        </p>
-        <div class="pre-wrapper">
+        <MessageLink
+          :to="{ hash: '#advanced' }"
+          prefix-label="harvester.virtualMachine.filesystem.mountBannerHint"
+          middle-label="harvester.virtualMachine.filesystem.mountBannerHintLink"
+          suffix-label="harvester.virtualMachine.filesystem.mountBannerHintSuffix"
+        />
+        <div class="pre-wrapper mt-10">
           <pre class="mt-5 mb-0">{{ allMountCommands }}</pre>
           <CopyToClipboard
             :text="allMountCommands"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
@@ -295,15 +295,13 @@ export default {
 
   .icon-btn {
     position: absolute;
-    top: 4px;
-    right: 4px;
+    top: 0px;
+    right: 5px;
     padding: 2px 4px;
     line-height: 1;
 
-    :deep(.btn.role-primary) {
-      &:hover {
-        background-color: rgba(0, 0, 0, 0.1);
-      }
+    &:active {
+      background-color: var(--success) !important;
     }
   }
 }

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -37,6 +37,7 @@ import Network from './VirtualMachineNetwork';
 import Volume from './VirtualMachineVolume';
 import SSHKey from './VirtualMachineSSHKey';
 import Reserved from './VirtualMachineReserved';
+import Filesystem from './VirtualMachineFilesystem';
 import { Banner } from '@components/Banner';
 import MessageLink from '@shell/components/MessageLink';
 
@@ -72,6 +73,7 @@ export default {
     Banner,
     MessageLink,
     UsbDevices,
+    Filesystem,
   },
 
   mixins: [CreateEditView, VM_MIXIN],
@@ -321,6 +323,7 @@ export default {
     const diskRows = this.getDiskRows(this.value);
 
     this['diskRows'] = diskRows;
+    this['filesystemRows'] = this.getFilesystemRows(this.value);
     const templateId = this.$route.query.templateId;
     const templateVersionId = this.$route.query.versionId;
 
@@ -784,9 +787,21 @@ export default {
       </Tab>
 
       <Tab
+        name="filesystem"
+        :label="t('harvester.tab.filesystem')"
+        :weight="-9"
+      >
+        <Filesystem
+          v-model:value="filesystemRows"
+          :mode="mode"
+          :namespace="value.metadata.namespace"
+        />
+      </Tab>
+
+      <Tab
         name="labels"
         :label="t('generic.labels')"
-        :weight="-9"
+        :weight="-10"
       >
         <Banner color="info">
           <t k="harvester.virtualMachine.labels.banner" />
@@ -805,7 +820,7 @@ export default {
       <Tab
         name="instanceLabel"
         :label="t('harvester.tab.instanceLabel')"
-        :weight="-10"
+        :weight="-11"
       >
         <Banner color="info">
           <t k="harvester.virtualMachine.instanceLabels.banner" />
@@ -826,7 +841,7 @@ export default {
       <Tab
         name="annotations"
         :label="t('harvester.tab.annotations')"
-        :weight="-11"
+        :weight="-12"
       >
         <Banner color="info">
           <t k="harvester.virtualMachine.annotations.banner" />
@@ -847,7 +862,7 @@ export default {
       <Tab
         name="advanced"
         :label="t('harvester.tab.advanced')"
-        :weight="-12"
+        :weight="-13"
       >
         <div class="row mb-20">
           <div class="col span-6">

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -220,6 +220,9 @@ export default {
     usbPassthroughEnabled() {
       return this.$store.getters['harvester-common/getFeatureEnabled']('usbPassthrough');
     },
+    filesystemEnabled() {
+      return this.$store.getters['harvester-common/getFeatureEnabled']('supportFilesystem');
+    },
   },
 
   watch: {
@@ -787,6 +790,7 @@ export default {
       </Tab>
 
       <Tab
+        v-if="filesystemEnabled"
         name="filesystem"
         :label="t('harvester.tab.filesystem')"
         :weight="-9"

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -355,6 +355,7 @@ harvester:
     snapshots: Snapshots
     instanceLabel: Instance Labels
     annotations: Annotations
+    filesystem: FileSystem
   fields:
     version: Version
     name: Name
@@ -830,6 +831,15 @@ harvester:
       username: Username
       password: Password
       reservedMemory: Reserved Memory
+    filesystem:
+      description: Harvester exposes the volume as a filesystem to the VM via virtiofs.
+      type: Filesystem Type
+      volume: Volume
+      resource: Resource
+      add: Add Filesystem
+      mountBannerHint: "Please update the mount path (e.g. /mnt/appConfigfs) based on your VM environment. Remember to add those commands in"
+      mountBannerHintLink: "User Data runcmd"
+      mountBannerHintSuffix: "in the Advanced tab."
     machineTypeTip: 'Specify a processor architecture to emulate. To see a list of supported architectures, run: qemu-system-x86_64 -cpu ?'
     detail:
       tabs:

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -832,14 +832,14 @@ harvester:
       password: Password
       reservedMemory: Reserved Memory
     filesystem:
-      description: Harvester exposes the volume as a filesystem to the VM via virtiofs.
+      description: Harvester supports filesystem disk for VM via virtiofs.
       type: Filesystem Type
       volume: Volume
       resource: Resource
       add: Add Filesystem
-      mountBannerHint: "Please update the mount path (e.g. /mnt/appConfigfs) based on your VM environment. Remember to add those commands in"
-      mountBannerHintLink: "User Data runcmd"
-      mountBannerHintSuffix: "in the Advanced tab."
+      mountBannerHint: "Please update the mount path (e.g. /mnt/appconfigfs) to your preferred location, then add the corresponding commands to the"
+      mountBannerHintLink: "runcmd"
+      mountBannerHintSuffix: "in Advanced tab User Data."
     machineTypeTip: 'Specify a processor architecture to emulate. To see a list of supported architectures, run: qemu-system-x86_64 -cpu ?'
     detail:
       tabs:
@@ -1445,6 +1445,12 @@ harvester:
       allowWorkloadDisruption: "Allow Workload Disruption"
       disableTLS: "Disable TLS"
       matchSELinuxLevelOnMigration: "Match SELinux Level On Migration"
+
+  configMap:
+    label: ConfigMaps
+
+  serviceAccount:
+    label: Service Accounts
 
   cloudTemplate:
     label: Cloud Configuration Templates

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1446,12 +1446,6 @@ harvester:
       disableTLS: "Disable TLS"
       matchSELinuxLevelOnMigration: "Match SELinux Level On Migration"
 
-  configMap:
-    label: ConfigMaps
-
-  serviceAccount:
-    label: Service Accounts
-
   cloudTemplate:
     label: Cloud Configuration Templates
     templateType: Template Type

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -355,7 +355,7 @@ harvester:
     snapshots: Snapshots
     instanceLabel: Instance Labels
     annotations: Annotations
-    filesystem: FileSystem
+    filesystem: Filesystem Volume
   fields:
     version: Version
     name: Name
@@ -832,11 +832,11 @@ harvester:
       password: Password
       reservedMemory: Reserved Memory
     filesystem:
-      description: Harvester supports filesystem disk for VM via virtiofs.
+      description: Harvester supports filesystem volumes for VM via virtiofs.
       type: Filesystem Type
       volume: Volume
       resource: Resource
-      add: Add Filesystem
+      add: Add
       mountBannerHint: "Please update the mount path (e.g. /mnt/appconfigfs) to your preferred location, then add the corresponding commands to the"
       mountBannerHintLink: "runcmd"
       mountBannerHintSuffix: "in Advanced tab User Data."

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -12,7 +12,7 @@ import { base64Decode } from '@shell/utils/crypto';
 import { formatSi, parseSi } from '@shell/utils/units';
 import { _CLONE, _CREATE, _VIEW } from '@shell/config/query-params';
 import {
-  PV, PVC, STORAGE_CLASS, NODE, SECRET, CONFIG_MAP, NETWORK_ATTACHMENT, NAMESPACE, LONGHORN
+  PV, PVC, STORAGE_CLASS, NODE, SECRET, CONFIG_MAP, SERVICE_ACCOUNT, NETWORK_ATTACHMENT, NAMESPACE, LONGHORN
 } from '@shell/config/types';
 import { HOSTNAME } from '@shell/config/labels-annotations';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
@@ -25,7 +25,7 @@ import { HCI } from '../../types';
 import { parseVolumeClaimTemplates, EMPTY_IMAGE } from '../../utils/vm';
 import impl, { QGA_JSON, USB_TABLET } from './impl';
 import { GIBIBYTE } from '../../utils/unit';
-import { VOLUME_MODE } from '@pkg/harvester/config/types';
+import { VOLUME_MODE, FILESYSTEM_SOURCE_TYPE } from '@pkg/harvester/config/types';
 
 const LONGHORN_V2_DATA_ENGINE = 'longhorn-system/v2-data-engine';
 
@@ -102,6 +102,8 @@ export default {
       vmims:             this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.VMIM }),
       vms:               this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.VM }),
       secrets:           this.$store.dispatch(`${ inStore }/findAll`, { type: SECRET }),
+      configMaps:        this.$store.dispatch(`${ inStore }/findAll`, { type: CONFIG_MAP }),
+      serviceAccounts:   this.$store.dispatch(`${ inStore }/findAll`, { type: SERVICE_ACCOUNT }),
       addons:            this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.ADD_ONS }),
       longhornV2Engine:  this.$store.dispatch(`${ inStore }/find`, { type: LONGHORN.SETTINGS, id: LONGHORN_V2_DATA_ENGINE }),
     };
@@ -156,6 +158,7 @@ export default {
       imageId:                       '',
       diskRows:                      [],
       networkRows:                   [],
+      filesystemRows:                [],
       machineType:                   '',
       machineTypes:                  [],
       secretName:                    '',
@@ -440,6 +443,7 @@ export default {
       this['imageId'] = imageId;
 
       this['diskRows'] = diskRows;
+      this['filesystemRows'] = this.getFilesystemRows(vm);
 
       this.refreshYamlEditor();
     },
@@ -641,6 +645,80 @@ export default {
       this.parseAccessCredentials();
       this.parseNetworkRows(this.networkRows);
       this.parseDiskRows(this.diskRows);
+      this.parseFilesystemRows();
+    },
+
+    getFilesystemRows(vm) {
+      const _filesystems = vm.spec.template.spec.domain.devices?.filesystems || [];
+      const _volumes = vm.spec.template.spec.volumes || [];
+
+      return _filesystems.map((fs) => {
+        const volume = _volumes.find((v) => v.name === fs.name);
+        let fsType = FILESYSTEM_SOURCE_TYPE.CONFIGMAP;
+        let resourceName = '';
+
+        if (volume?.configMap) {
+          fsType = FILESYSTEM_SOURCE_TYPE.CONFIGMAP;
+          resourceName = volume.configMap.name;
+        } else if (volume?.secret) {
+          fsType = FILESYSTEM_SOURCE_TYPE.SECRET;
+          resourceName = volume.secret.secretName;
+        } else if (volume?.serviceAccount) {
+          fsType = FILESYSTEM_SOURCE_TYPE.SERVICEACCOUNT;
+          resourceName = volume.serviceAccount.serviceAccountName;
+        }
+
+        return {
+          fsType,
+          volumeName: fs.name,
+          resourceName,
+        };
+      });
+    },
+
+    parseFilesystemRows() {
+      const completedRows = this.filesystemRows.filter(
+        (r) => r.fsType && r.volumeName && r.resourceName
+      );
+
+      const filesystems = completedRows.map((r) => ({
+        name:     r.volumeName,
+        virtiofs: {},
+      }));
+
+      const fsVolumes = completedRows.map((r) => {
+        if (r.fsType === FILESYSTEM_SOURCE_TYPE.CONFIGMAP) {
+          return {
+            name:      r.volumeName,
+            configMap: { name: r.resourceName },
+          };
+        } else if (r.fsType === FILESYSTEM_SOURCE_TYPE.SECRET) {
+          return {
+            name:   r.volumeName,
+            secret: { secretName: r.resourceName },
+          };
+        } else if (r.fsType === FILESYSTEM_SOURCE_TYPE.SERVICEACCOUNT) {
+          return {
+            name:           r.volumeName,
+            serviceAccount: { serviceAccountName: r.resourceName },
+          };
+        }
+
+        return null;
+      }).filter(Boolean);
+
+      if (filesystems.length > 0) {
+        this.spec.template.spec.domain.devices['filesystems'] = filesystems;
+      } else {
+        delete this.spec.template.spec.domain.devices['filesystems'];
+      }
+
+      if (fsVolumes.length > 0) {
+        if (!this.spec.template.spec.volumes) {
+          this.spec.template.spec['volumes'] = [];
+        }
+        this.spec.template.spec.volumes.push(...fsVolumes);
+      }
     },
 
     parseOther() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
1. add Filesystem tab in VM create page and VM template page
2. show the cloud init command based on user selection and allow copy and paste commands to user data
3. add feature flag only render FileSystem tab after v1.9.0.


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @WebberHuang1118 

### Related Issue #
https://github.com/harvester/harvester/issues/9896

### Test screenshot or video
Create VM

https://github.com/user-attachments/assets/f76cbd42-78ad-4a5b-a25e-5d6f9b6552e6



Test in VM

https://github.com/user-attachments/assets/ce2cca3b-2725-4e88-9db5-804c88738e04


Edit / View mode
<img width="1493" height="818" alt="image" src="https://github.com/user-attachments/assets/56d77264-8783-4d3c-9681-faf92bf3bfb8" />
