### PR TITLE
feat: add volume expansion checkbox in storage class configuration

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -67,6 +67,7 @@ const FEATURE_FLAGS = {
     'rwxNetworkSetting',
     'createPVCWithDataVolume',
     'clusterPodSecurityStandardSetting',
+    'expandOnlineEncryptedVolume'
   ],
   'v1.8.1': [],
   'v1.9.0': [

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -72,6 +72,7 @@ const FEATURE_FLAGS = {
   'v1.9.0': [
     'supportFilesystem',
     'disableResourcePooling',
+    'expandOnlineEncryptedVolume'
   ],
 };
 

--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -67,7 +67,6 @@ const FEATURE_FLAGS = {
     'rwxNetworkSetting',
     'createPVCWithDataVolume',
     'clusterPodSecurityStandardSetting',
-    'expandOnlineEncryptedVolume'
   ],
   'v1.8.1': [],
   'v1.9.0': [

--- a/pkg/harvester/config/harvester-map.js
+++ b/pkg/harvester/config/harvester-map.js
@@ -88,6 +88,8 @@ export const CSI_SECRETS = {
   CSI_NODE_PUBLISH_SECRET_NAMESPACE: 'csi.storage.k8s.io/node-publish-secret-namespace',
   CSI_NODE_STAGE_SECRET_NAME:        'csi.storage.k8s.io/node-stage-secret-name',
   CSI_NODE_STAGE_SECRET_NAMESPACE:   'csi.storage.k8s.io/node-stage-secret-namespace',
+  CSI_NODE_EXPAND_SECRET_NAME:       'csi.storage.k8s.io/node-expand-secret-name',
+  CSI_NODE_EXPAND_SECRET_NAMESPACE:  'csi.storage.k8s.io/node-expand-secret-namespace'
 };
 
 // Some harvester CRD type is not equal to model file name, define the mapping here

--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
@@ -3,6 +3,7 @@ import KeyValue from '@shell/components/form/KeyValue';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import RadioGroup from '@components/Form/Radio/RadioGroup';
+import Checkbox from '@components/Form/Checkbox/Checkbox';
 import { SECRET, LONGHORN } from '@shell/config/types';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 import { CSI_SECRETS } from '@pkg/harvester/config/harvester-map';
@@ -16,7 +17,9 @@ const {
   CSI_NODE_PUBLISH_SECRET_NAME,
   CSI_NODE_PUBLISH_SECRET_NAMESPACE,
   CSI_NODE_STAGE_SECRET_NAME,
-  CSI_NODE_STAGE_SECRET_NAMESPACE
+  CSI_NODE_STAGE_SECRET_NAMESPACE,
+  CSI_NODE_EXPAND_SECRET_NAME,
+  CSI_NODE_EXPAND_SECRET_NAMESPACE
 } = CSI_SECRETS;
 
 export default {
@@ -27,6 +30,7 @@ export default {
     LabeledSelect,
     LabeledInput,
     RadioGroup,
+    Checkbox,
   },
 
   props: {
@@ -57,7 +61,10 @@ export default {
       };
     }
 
-    return { };
+    const hasExpandSecret = !!(this.value.parameters?.[CSI_NODE_EXPAND_SECRET_NAME]);
+    const volumeExpansionEnabled = this.realMode === _CREATE ? true : hasExpandSecret;
+
+    return { volumeExpansionEnabled };
   },
 
   computed: {
@@ -180,6 +187,11 @@ export default {
       set(selectedSecret) {
         const [namespace, name] = selectedSecret.split('/');
 
+        const expandSecretParams = (this.volumeExpansionEnabled && this.value.expandOnlineEncryptedVolumeFeatureEnabled) ? {
+          [CSI_NODE_EXPAND_SECRET_NAME]:      name,
+          [CSI_NODE_EXPAND_SECRET_NAMESPACE]: namespace,
+        } : {};
+
         this.value['parameters'] = {
           ...this.value.parameters,
           [CSI_PROVISIONER_SECRET_NAME]:       name,
@@ -187,7 +199,8 @@ export default {
           [CSI_NODE_STAGE_SECRET_NAME]:        name,
           [CSI_PROVISIONER_SECRET_NAMESPACE]:  namespace,
           [CSI_NODE_PUBLISH_SECRET_NAMESPACE]: namespace,
-          [CSI_NODE_STAGE_SECRET_NAMESPACE]:   namespace
+          [CSI_NODE_STAGE_SECRET_NAMESPACE]:   namespace,
+          ...expandSecretParams,
         };
       }
     },
@@ -237,6 +250,32 @@ export default {
         if (value >= 1 && value <= 3) {
           this.value.parameters.numberOfReplicas = String(value);
         }
+      }
+    },
+  },
+
+  watch: {
+    volumeExpansionEnabled(enabled) {
+      const currentSecret = this.secret;
+
+      if (!currentSecret) {
+        return;
+      }
+
+      const [namespace, name] = currentSecret.split('/');
+
+      if (enabled && this.value.expandOnlineEncryptedVolumeFeatureEnabled) {
+        this.value['parameters'] = {
+          ...this.value.parameters,
+          [CSI_NODE_EXPAND_SECRET_NAME]:      name,
+          [CSI_NODE_EXPAND_SECRET_NAMESPACE]: namespace,
+        };
+      } else {
+        const params = { ...this.value.parameters };
+
+        delete params[CSI_NODE_EXPAND_SECRET_NAME];
+        delete params[CSI_NODE_EXPAND_SECRET_NAMESPACE];
+        this.value['parameters'] = params;
       }
     },
   },
@@ -335,6 +374,13 @@ export default {
             :label="t('harvester.storage.secret')"
             :options="secretOptions"
             :mode="mode"
+          />
+        </div>
+        <div class="col span-6 flex items-center mt-20">
+          <Checkbox
+            v-model:value="volumeExpansionEnabled"
+            :label="t('harvester.storage.volumeExpansionEnabled')"
+            :disabled="!value.expandOnlineEncryptedVolumeFeatureEnabled || isView"
           />
         </div>
       </div>

--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
@@ -64,7 +64,7 @@ export default {
     const hasExpandSecret = !!(this.value.parameters?.[CSI_NODE_EXPAND_SECRET_NAME] && this.value.parameters?.[CSI_NODE_EXPAND_SECRET_NAMESPACE]);
     const volumeExpansionCheckBoxEnabled = this.realMode === _CREATE ? true : hasExpandSecret;
 
-    return { volumeExpansionCheckBoxEnabled, hasExpandSecret };
+    return { volumeExpansionCheckBoxEnabled };
   },
 
   computed: {

--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
@@ -61,7 +61,7 @@ export default {
       };
     }
 
-    const hasExpandSecret = !!(this.value.parameters?.[CSI_NODE_EXPAND_SECRET_NAME]);
+    const hasExpandSecret = !!(this.value.parameters?.[CSI_NODE_EXPAND_SECRET_NAME] && this.value.parameters?.[CSI_NODE_EXPAND_SECRET_NAMESPACE]);
     const volumeExpansionEnabled = this.realMode === _CREATE ? true : hasExpandSecret;
 
     return { volumeExpansionEnabled };

--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/driver.longhorn.io_v1.vue
@@ -5,7 +5,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import RadioGroup from '@components/Form/Radio/RadioGroup';
 import Checkbox from '@components/Form/Checkbox/Checkbox';
 import { SECRET, LONGHORN } from '@shell/config/types';
-import { _CREATE, _VIEW } from '@shell/config/query-params';
+import { _CREATE, _VIEW, _EDIT } from '@shell/config/query-params';
 import { CSI_SECRETS } from '@pkg/harvester/config/harvester-map';
 import { clone } from '@shell/utils/object';
 import { uniq } from '@shell/utils/array';
@@ -62,9 +62,9 @@ export default {
     }
 
     const hasExpandSecret = !!(this.value.parameters?.[CSI_NODE_EXPAND_SECRET_NAME] && this.value.parameters?.[CSI_NODE_EXPAND_SECRET_NAMESPACE]);
-    const volumeExpansionEnabled = this.realMode === _CREATE ? true : hasExpandSecret;
+    const volumeExpansionCheckBoxEnabled = this.realMode === _CREATE ? true : hasExpandSecret;
 
-    return { volumeExpansionEnabled };
+    return { volumeExpansionCheckBoxEnabled, hasExpandSecret };
   },
 
   computed: {
@@ -105,8 +105,11 @@ export default {
       }, []);
     },
 
+    isEdit() {
+      return this.realMode === _EDIT;
+    },
     isView() {
-      return this.mode === _VIEW;
+      return this.realMode === _VIEW;
     },
 
     migratableOptions() {
@@ -159,6 +162,10 @@ export default {
       }
     },
 
+    enableOnlineExpansionVolumeEncryption() {
+      return this.value.expandOnlineEncryptedVolumeFeatureEnabled;
+    },
+
     volumeEncryption: {
       set(neu) {
         this.value['parameters'] = {
@@ -187,7 +194,7 @@ export default {
       set(selectedSecret) {
         const [namespace, name] = selectedSecret.split('/');
 
-        const expandSecretParams = (this.volumeExpansionEnabled && this.value.expandOnlineEncryptedVolumeFeatureEnabled) ? {
+        const expandSecretParams = (this.enableOnlineExpansionVolumeEncryption && this.volumeExpansionCheckBoxEnabled) ? {
           [CSI_NODE_EXPAND_SECRET_NAME]:      name,
           [CSI_NODE_EXPAND_SECRET_NAMESPACE]: namespace,
         } : {};
@@ -255,7 +262,7 @@ export default {
   },
 
   watch: {
-    volumeExpansionEnabled(enabled) {
+    volumeExpansionCheckBoxEnabled(enabled) {
       const currentSecret = this.secret;
 
       if (!currentSecret) {
@@ -264,7 +271,7 @@ export default {
 
       const [namespace, name] = currentSecret.split('/');
 
-      if (enabled && this.value.expandOnlineEncryptedVolumeFeatureEnabled) {
+      if (enabled && this.enableOnlineExpansionVolumeEncryption) {
         this.value['parameters'] = {
           ...this.value.parameters,
           [CSI_NODE_EXPAND_SECRET_NAME]:      name,
@@ -376,11 +383,14 @@ export default {
             :mode="mode"
           />
         </div>
-        <div class="col span-6 flex items-center mt-20">
+        <div
+          v-if="enableOnlineExpansionVolumeEncryption"
+          class="col span-6 flex items-center mt-20"
+        >
           <Checkbox
-            v-model:value="volumeExpansionEnabled"
-            :label="t('harvester.storage.volumeExpansionEnabled')"
-            :disabled="!value.expandOnlineEncryptedVolumeFeatureEnabled || isView"
+            v-model:value="volumeExpansionCheckBoxEnabled"
+            :label="t('harvester.storage.volumeExpansionCheckbox')"
+            :disabled="isEdit || isView"
           />
         </div>
       </div>

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1534,7 +1534,7 @@ harvester:
     useDefault: Use the default storage
     volumeEncryption: Volume Encryption
     secret: Secret
-    volumeExpansionEnabled: Volume Expansion Enabled
+    volumeExpansionEnabled: Enable online expansion for encrypted volumes
     migratable:
       label: Migratable
     numberOfReplicas:

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1534,6 +1534,7 @@ harvester:
     useDefault: Use the default storage
     volumeEncryption: Volume Encryption
     secret: Secret
+    volumeExpansionEnabled: Volume Expansion Enabled
     migratable:
       label: Migratable
     numberOfReplicas:

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1534,7 +1534,7 @@ harvester:
     useDefault: Use the default storage
     volumeEncryption: Volume Encryption
     secret: Secret
-    volumeExpansionEnabled: Enable online expansion for encrypted volumes
+    volumeExpansionCheckbox: Enable Expansion
     migratable:
       label: Migratable
     numberOfReplicas:

--- a/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
+++ b/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
@@ -96,6 +96,10 @@ export default class HciStorageClass extends StorageClass {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('volumeEncryption');
   }
 
+  get expandOnlineEncryptedVolumeFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('expandOnlineEncryptedVolume');
+  }
+
   get thirdPartyStorageFeatureEnabled() {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('thirdPartyStorage');
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Add a checkbox in storage class volume encryption configuration
- hide the checkbox if harvester version is lower than v1.9.0.
- user allow to check/uncheck checkbox when creating a SC, once enabled add below parameters
```
csi.storage.k8s.io/node-expand-secret-name: xxx
csi.storage.k8s.io/node-expand-secret-namespace: xxx
```
- disabled to checkbox in edit / view SC mode.



### PR Checklists
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is: @WebberHuang1118 

### Related Issue #
https://github.com/harvester/harvester/issues/10635

### Test screenshot or video

Hidden checkbox (for harvester v1.8.x or v1.7.x)
<img width="1489" height="758" alt="image" src="https://github.com/user-attachments/assets/ef15a7ed-34c0-4792-b610-51071cf58a24" />

Allow user to enable checkbox

https://github.com/user-attachments/assets/fdcc74a2-49d5-4662-906e-ef157ed94dd9



Disabled in view / edit mode

<img width="1496" height="823" alt="Screenshot 2026-06-03 at 6 45 43 PM" src="https://github.com/user-attachments/assets/e0662962-be75-4e2b-8bd7-1867fa277ae6" />


