### PR TITLE
feat: support adding VM display name in creation page

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -19,6 +19,7 @@ export const HCI = {
   NETWORK_TYPE:                     'network.harvesterhci.io/type',
   VM_NAME:                          'harvesterhci.io/vmName',
   VM_NAME_PREFIX:                   'harvesterhci.io/vmNamePrefix',
+  VM_DISPLAY_NAME:                  'harvesterhci.io/vmDisplayName',
   VM_RESERVED_MEMORY:               'harvesterhci.io/reservedMemory',
   MAINTENANCE_STATUS:               'harvesterhci.io/maintain-status',
   HOST_CUSTOM_NAME:                 'harvesterhci.io/host-custom-name',

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -93,6 +93,13 @@ export default {
 
     const hostname = this.value.spec.template.spec.hostname || '';
 
+    // In edit mode, surface the VM display name annotation as `_displayName`
+    // on the resource so NameNsDescription can bind to it via `name-key`
+    // without mutating `metadata.name` (which would break the k8s PUT).
+    if (this.mode !== 'create') {
+      this.value._displayName = this.value.metadata?.annotations?.[HCI_ANNOTATIONS.VM_DISPLAY_NAME] || this.value.metadata?.name || '';
+    }
+
     return {
       cloneVM,
       count:             2,
@@ -292,6 +299,21 @@ export default {
         this.templateVersionId = '';
         this.value.applyDefaults();
         this.getInitConfig({ value: this.value, init: this.isCreate });
+      }
+    },
+
+    // In create mode, sync metadata.name → VM_DISPLAY_NAME annotation
+    'value.metadata.name'(name) {
+      if (this.isCreate) {
+        this.value.setAnnotation(HCI_ANNOTATIONS.VM_DISPLAY_NAME, name);
+      }
+    },
+
+    // In edit mode, NameNsDescription writes to `_displayName` (via name-key);
+    // mirror it into the VM_DISPLAY_NAME annotation.
+    'value._displayName'(val) {
+      if (!this.isCreate) {
+        this.value.setAnnotation(HCI_ANNOTATIONS.VM_DISPLAY_NAME, val);
       }
     },
   },
@@ -597,6 +619,8 @@ export default {
       :value="value"
       :mode="mode"
       :has-extra="!isSingle"
+      :name-editable="true"
+      :name-key="isCreate ? null : '_displayName'"
       :name-label="nameLabel"
       :namespaced="true"
       :name-placeholder="isSingle ? 'nameNsDescription.name.placeholder' : 'harvester.virtualMachine.instance.multiple.nameNsDescription'"

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -93,28 +93,35 @@ export default {
 
     const hostname = this.value.spec.template.spec.hostname || '';
 
-    // In edit mode, surface the VM display name annotation as `_displayName`
-    // on the resource so NameNsDescription can bind to it via `name-key`
-    // without mutating `metadata.name` (which would break the k8s PUT).
-    if (this.mode !== 'create') {
-      this.value._displayName = this.value.metadata?.annotations?.[HCI_ANNOTATIONS.VM_DISPLAY_NAME] || this.value.metadata?.name || '';
-    }
+    const customizeDisplayName = !!(this.value.metadata?.annotations?.[HCI_ANNOTATIONS.VM_DISPLAY_NAME]);
 
     return {
       cloneVM,
-      count:             2,
-      templateId:        '',
-      templateVersionId: '',
-      namePrefix:        '',
-      isSingle:          true,
-      isOpen:            false,
+      count:                2,
+      templateId:           '',
+      templateVersionId:    '',
+      namePrefix:           '',
+      isSingle:             true,
+      isOpen:               false,
       hostname,
       isRestartImmediately,
+      customizeDisplayName,
     };
   },
 
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
+
+    // VM display name is stored as an annotation; bind a dedicated input to it
+    // so we don't have to mutate metadata.name (which would break the k8s PUT).
+    displayName: {
+      get() {
+        return this.value.metadata?.annotations?.[HCI_ANNOTATIONS.VM_DISPLAY_NAME] || '';
+      },
+      set(val) {
+        this.value.setAnnotation(HCI_ANNOTATIONS.VM_DISPLAY_NAME, val);
+      },
+    },
 
     to() {
       return {
@@ -302,18 +309,9 @@ export default {
       }
     },
 
-    // In create mode, sync metadata.name → VM_DISPLAY_NAME annotation
-    'value.metadata.name'(name) {
-      if (this.isCreate) {
-        this.value.setAnnotation(HCI_ANNOTATIONS.VM_DISPLAY_NAME, name);
-      }
-    },
-
-    // In edit mode, NameNsDescription writes to `_displayName` (via name-key);
-    // mirror it into the VM_DISPLAY_NAME annotation.
-    'value._displayName'(val) {
-      if (!this.isCreate) {
-        this.value.setAnnotation(HCI_ANNOTATIONS.VM_DISPLAY_NAME, val);
+    customizeDisplayName(neu) {
+      if (!neu) {
+        this.value.setAnnotation(HCI_ANNOTATIONS.VM_DISPLAY_NAME, '');
       }
     },
   },
@@ -619,8 +617,6 @@ export default {
       :value="value"
       :mode="mode"
       :has-extra="!isSingle"
-      :name-editable="true"
-      :name-key="isCreate ? null : '_displayName'"
       :name-label="nameLabel"
       :namespaced="true"
       :name-placeholder="isSingle ? 'nameNsDescription.name.placeholder' : 'harvester.virtualMachine.instance.multiple.nameNsDescription'"
@@ -639,6 +635,33 @@ export default {
         />
       </template>
     </NameNsDescription>
+
+    <div v-if="isSingle">
+      <div class="row mb-20">
+        <div class="col span-12">
+          <Checkbox
+            v-model:value="customizeDisplayName"
+            class="check"
+            type="checkbox"
+            :label="t('harvester.virtualMachine.input.customizeDisplayName')"
+            :mode="mode"
+          />
+        </div>
+      </div>
+      <div
+        v-if="customizeDisplayName"
+        class="row mb-20"
+      >
+        <div class="col span-6">
+          <LabeledInput
+            v-model:value="displayName"
+            :mode="mode"
+            :label="t('harvester.virtualMachine.input.displayName')"
+            :placeholder="t('harvester.virtualMachine.input.displayNamePlaceholder')"
+          />
+        </div>
+      </div>
+    </div>
 
     <Checkbox
       v-if="isCreate"

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -818,6 +818,9 @@ harvester:
       username: Username
       password: Password
       reservedMemory: Reserved Memory
+      customizeDisplayName: Customize virtual machine display name
+      displayNamePlaceholder: Virtual machine alias name
+      displayName: Display Name
     filesystem:
       description: Harvester supports filesystem volumes for VM via virtiofs.
       type: Filesystem Type

--- a/pkg/harvester/list/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/list/kubevirt.io.virtualmachine.vue
@@ -22,6 +22,8 @@ export const VM_HEADERS = [
   {
     ...NAME,
     width: 350,
+    value: 'nameDisplay',
+    sort:  ['nameDisplay'],
   },
   NAMESPACE,
   {
@@ -244,7 +246,7 @@ export default {
             v-if="scope.row.type !== HCI.VMI"
             :to="scope.row.detailLocation"
           >
-            {{ scope.row.metadata.name }}
+            {{ scope.row.nameDisplay }}
             <i
               v-if="scope.row.encryptedVolumeType !== 'none'"
               v-tooltip="lockIconTooltipMessage(scope.row)"
@@ -253,7 +255,7 @@ export default {
             />
           </router-link>
           <span v-else>
-            {{ scope.row.metadata.name }}
+            {{ scope.row.nameDisplay }}
           </span>
           <ConsoleBar
             :resource-type="scope.row"

--- a/pkg/harvester/models/kubevirt.io.virtualmachine.js
+++ b/pkg/harvester/models/kubevirt.io.virtualmachine.js
@@ -1274,6 +1274,10 @@ export default class VirtVm extends HarvesterResource {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('schedulingVMBackup');
   }
 
+  get nameDisplay() {
+    return this.metadata?.annotations?.[HCI_ANNOTATIONS.VM_DISPLAY_NAME] || this.metadata?.name || this.id;
+  }
+
   get volumeEncryptionFeatureEnabled() {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('volumeEncryption');
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Add a checkbox allow user to add VM display name when creating single VM.
- Display name will save in `harvesterhci.io/vmDisplayName` annotation.


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/10423

### Test screenshot or video


https://github.com/user-attachments/assets/3d026a25-ddc1-49f1-b833-2e4ba0a321a3





