### PR TITLE
feat: add exclusive VLAN field to storage network settings

### DIFF
--- a/pkg/harvester/components/settings/storage-network.vue
+++ b/pkg/harvester/components/settings/storage-network.vue
@@ -64,6 +64,9 @@ export default {
 
     try {
       parsedDefaultValue = JSON.parse(this.value.value);
+      if (typeof parsedDefaultValue.exclusiveVlan !== 'boolean') {
+        parsedDefaultValue.exclusiveVlan = false;
+      }
       networkType = 'vlan' in parsedDefaultValue ? L2VLAN : UNTAGGED; // backend doesn't provide networkType, so we check if vlan is provided instead
       openVlan = true;
     } catch (error) {
@@ -72,7 +75,8 @@ export default {
         vlan:           '',
         clusterNetwork: '',
         range:          '',
-        exclude:        []
+        exclude:        [],
+        exclusiveVlan:  false
       };
     }
     const exclude = parsedDefaultValue?.exclude?.toString().split(',') || [];
@@ -94,6 +98,10 @@ export default {
   },
 
   computed: {
+    showExclusiveVlan() {
+      return this.networkType === L2VLAN &&
+        Number(this.parsedDefaultValue.vlan) !== 1;
+    },
     showVlan() {
       return this.networkType === L2VLAN;
     },
@@ -131,6 +139,18 @@ export default {
           disabled,
         };
       });
+    },
+    exclusiveVlanOptions() {
+      return [
+        {
+          label: this.t('generic.enabled'),
+          value: true
+        },
+        {
+          label: this.t('generic.disabled'),
+          value: false
+        }
+      ];
     },
   },
 
@@ -174,7 +194,8 @@ export default {
         vlan:           '',
         clusterNetwork: '',
         range:          '',
-        exclude:        []
+        exclude:        [],
+        exclusiveVlan:  false
       };
     },
 
@@ -280,7 +301,15 @@ export default {
         label-key="harvester.setting.storageNetwork.vlan"
         @update:value="inputVlan"
       />
-
+      <LabeledSelect
+        v-if="showExclusiveVlan"
+        v-model:value="parsedDefaultValue.exclusiveVlan"
+        class="mb-20"
+        :options="exclusiveVlanOptions"
+        :mode="mode"
+        label-key="harvester.setting.storageNetwork.exclusiveVlan"
+        @update:value="update"
+      />
       <LabeledSelect
         v-model:value="parsedDefaultValue.clusterNetwork"
         label-key="harvester.setting.storageNetwork.clusterNetwork"

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1310,6 +1310,7 @@ harvester:
         invalid: '"Range" is invalid.'
       clusterNetwork: Cluster Network
       vlan: VLAN ID
+      exclusiveVlan: Exclusive VLAN
       exclude:
         label: Exclude IPs
         placeholder: CIDR format, e.g. 172.16.0.10/32


### PR DESCRIPTION
### Summary
Add new field "Exclusive VLAN" to the storage network configuration in UI

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is: @rrajendran17 

### Related Issue #
https://github.com/harvester/harvester/issues/10581

### Test screenshot or video

case Default:

<img width="576" height="652" alt="exclusive-vlan-ui1" src="https://github.com/user-attachments/assets/f9046fd8-2bd4-430b-ba3b-3870685b9a7c" />

case enabled:
<img width="605" height="466" alt="exclusive-vlan-ui2" src="https://github.com/user-attachments/assets/49e13bca-0251-4cd1-9c2b-bbe907ad18b9" />

<img width="307" height="250" alt="exclusive-vlanui3" src="https://github.com/user-attachments/assets/93537502-713c-4c4f-bf50-a4c82eaf01f6" />

```
hp-65:~ # kubectl get settings storage-network -o yaml
apiVersion: harvesterhci.io/v1beta1
kind: Setting
metadata:
  annotations:
    storage-network.settings.harvesterhci.io/hash: c0672481e68ff6b27360b3259902a47b0ba905ea
    storage-network.settings.harvesterhci.io/net-attach-def: harvester-system/storagenetwork-zk9xv
    storage-network.settings.harvesterhci.io/old-net-attach-def: ""
  creationTimestamp: "2026-05-20T22:49:55Z"
  generation: 100
  name: storage-network
  resourceVersion: "17914160"
  uid: 2a989bdc-ec0e-41c4-9acb-cdd73bd76536
status:
  conditions:
  - lastUpdateTime: "2026-06-05T16:03:59Z"
    reason: Completed
    status: "True"
    type: configured
value: '{"vlan":15,"clusterNetwork":"mgmt","range":"16.0.0.0/24","exclusiveVlan":true}'
```

case disabled:

<img width="294" height="241" alt="exclusive-vlanui4" src="https://github.com/user-attachments/assets/711ec43b-fe77-4628-81bf-0d7025261a23" />

```
hp-65:~ # kubectl get settings storage-network -o yaml
apiVersion: harvesterhci.io/v1beta1
kind: Setting
metadata:
  annotations:
    storage-network.settings.harvesterhci.io/hash: 7b5d4ec0e407fd8880bdd0be7ddadcca56df3c3b
    storage-network.settings.harvesterhci.io/net-attach-def: harvester-system/storagenetwork-tfjt6
    storage-network.settings.harvesterhci.io/old-net-attach-def: ""
  creationTimestamp: "2026-05-20T22:49:55Z"
  generation: 104
  name: storage-network
  resourceVersion: "17916033"
  uid: 2a989bdc-ec0e-41c4-9acb-cdd73bd76536
status:
  conditions:
  - lastUpdateTime: "2026-06-05T16:06:16Z"
    reason: Completed
    status: "True"
    type: configured
value: '{"vlan":15,"clusterNetwork":"mgmt","range":"16.0.0.0/24","exclusiveVlan":false}'

```

case webhook rejection when exclusive vlan is enabled and VM Network exists with same vlan id

<img width="1046" height="779" alt="exclusivevlanui5" src="https://github.com/user-attachments/assets/03af00fe-8eb3-4b6d-a066-6718401f567b" />

case Exclusive VLAN field not shown when untagged or vlan id =1 (default vlan)

<img width="773" height="486" alt="exclusiveuntaggedvlan" src="https://github.com/user-attachments/assets/3012a5e5-a33c-4537-89ba-43abc7599649" />

<img width="565" height="654" alt="exclusvievlan1" src="https://github.com/user-attachments/assets/89ef471b-7597-42fa-b663-c26c8c2bcf53" />

