### PR TITLE
fix: snapshot / backup / volume list page attach VM name

### DIFF
--- a/pkg/harvester/formatters/AttachVMWithName.vue
+++ b/pkg/harvester/formatters/AttachVMWithName.vue
@@ -31,6 +31,10 @@ export default {
     to() {
       return this.vm?.detailLocation;
     },
+
+    attachVMName() {
+      return this.vm?.nameDisplay || this.vm?.metadata?.name || this.value;
+    }
   }
 };
 </script>
@@ -40,10 +44,10 @@ export default {
     v-if="to"
     :to="to"
   >
-    {{ value }}
+    {{ attachVMName }}
   </router-link>
 
   <span v-else>
-    {{ value }}
+    {{ attachVMName }}
   </span>
 </template>

--- a/pkg/harvester/list/harvesterhci.io.volume.vue
+++ b/pkg/harvester/list/harvesterhci.io.volume.vue
@@ -106,8 +106,8 @@ export default {
           name:     'AttachedVM',
           labelKey: 'tableHeaders.attachedVM',
           type:     'attached',
-          value:    'spec.claimRef',
-          sort:     'name',
+          value:    'attachVMName',
+          sort:     'attachVMName',
         },
         {
           name:      'VolumeSnapshotCounts',
@@ -134,8 +134,8 @@ export default {
       return row?.attachVM?.detailLocation;
     },
 
-    getVMName(row) {
-      return row.attachVM?.metadata?.name || '';
+    getAttachedVMName(row) {
+      return row.attachVMName || '';
     },
 
     isInternalStorageClass(storageClassName) {
@@ -173,10 +173,10 @@ export default {
     <template #cell:AttachedVM="{row}">
       <div>
         <router-link
-          v-if="getVMName(row)"
+          v-if="getAttachedVMName(row)"
           :to="goTo(row)"
         >
-          {{ getVMName(row) }}
+          {{ getAttachedVMName(row) }}
         </router-link>
       </div>
     </template>

--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -235,6 +235,10 @@ export default class HciPv extends HarvesterResource {
     return allVMs.find(findAttachVM);
   }
 
+  get attachVMName() {
+    return this.attachVM?.nameDisplay || this.attachVM?.metadata?.name || '';
+  }
+
   get isAvailable() {
     const unAvailable = ['Resizing', 'Not Ready'];
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
VM `ttt` has a customized VM displayname `andy-ttt`, but volume page still shows `ttt` vm name
<img width="1276" height="487" alt="Screenshot 2026-06-08 at 4 01 19 PM" src="https://github.com/user-attachments/assets/840e83e8-aa5c-4095-bf5a-6722f7890182" />


<img width="1496" height="553" alt="Screenshot 2026-06-08 at 4 01 10 PM" src="https://github.com/user-attachments/assets/62b52262-f946-40ac-ab90-3899d641ce4d" />

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/10423

### Test screenshot or video
Backup page
<img width="1490" height="679" alt="Screenshot 2026-06-08 at 4 37 29 PM" src="https://github.com/user-attachments/assets/cb4ecbe0-dd9b-43c1-a011-6838babfce22" />


Snapshot page
<img width="1492" height="659" alt="Screenshot 2026-06-08 at 4 37 33 PM" src="https://github.com/user-attachments/assets/8d76a8b6-f4c2-4161-b58f-4aa8cbe460f4" />


Volume page
<img width="1488" height="656" alt="Screenshot 2026-06-08 at 4 37 43 PM" src="https://github.com/user-attachments/assets/020749a3-d0b1-48cd-b502-e5e8a3c4d3c8" />

