### PR TITLE
refactor: disable and hide filesystem warning banner in edit / view mode

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineFilesystem/index.vue
@@ -234,7 +234,7 @@ export default {
     </div>
 
     <Banner
-      v-if="completedRows.length > 0"
+      v-if="completedRows.length > 0 && mode === 'create'"
       color="warning"
       class="mt-10"
     >

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -21,9 +21,7 @@ import { saferDump } from '@shell/utils/create-yaml';
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@shell/mixins/child-hook';
-
 import CreateEditView from '@shell/mixins/create-edit-view';
-
 import { parseVolumeClaimTemplates } from '@pkg/utils/vm';
 import VM_MIXIN from '../../mixins/harvester-vm';
 import { HCI } from '../../types';
@@ -844,7 +842,7 @@ export default {
       >
         <Filesystem
           v-model:value="filesystemRows"
-          :mode="mode"
+          :mode="isCreate ? mode : 'view'"
           :namespace="value.metadata.namespace"
         />
       </Tab>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

As cloud init only runs on first time creating VM, this PR
- disable related fields in filesystem tab in VM edit/view mode, not allow user to edit them
- hide the warning banner in VM edit/view mode.


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/9896

### Test screenshot or video
Create VM 
<img width="1492" height="817" alt="Screenshot 2026-06-08 at 5 47 25 PM" src="https://github.com/user-attachments/assets/e27c5690-25b6-4e13-9078-5bde24024cde" />



Edit VM
<img width="1479" height="804" alt="Screenshot 2026-06-08 at 5 47 14 PM" src="https://github.com/user-attachments/assets/a212c3cc-765a-4a15-8c9b-37f840d578dd" />

View VM
<img width="1496" height="821" alt="Screenshot 2026-06-08 at 5 53 40 PM" src="https://github.com/user-attachments/assets/dd55e2eb-b475-4570-ae43-a457eae3917c" />


