### PR TITLE
feat: support mgmt vlanconfig view on UI

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -3,6 +3,7 @@ generic:
   resourceExternalLinkTips: 'External Link'
   namespace: Namespace
   notReady: Not Ready
+  managed: Managed
   labels: Labels
   inProgress: In Progress
   basic: Basic

--- a/pkg/harvester/models/network.harvesterhci.io.vlanconfig.js
+++ b/pkg/harvester/models/network.harvesterhci.io.vlanconfig.js
@@ -54,8 +54,16 @@ export default class HciVlanConfig extends HarvesterResource {
     return 'VLAN';
   }
 
+  get isMgmtVlanConfig() {
+    return this.spec?.clusterNetwork === 'mgmt';
+  }
+
   get _availableActions() {
     const out = super._availableActions;
+
+    if (this.isMgmtVlanConfig) {
+      return out;
+    }
 
     const canMigrate = !!this.$getters?.['schemaFor']?.(HCI.VLAN_CONFIG)?.collectionMethods?.find((x) => ['post'].includes(x.toLowerCase()));
 
@@ -64,6 +72,30 @@ export default class HciVlanConfig extends HarvesterResource {
     }
 
     return out;
+  }
+
+  get canUpdate() {
+    if (this.isMgmtVlanConfig) {
+      return false;
+    }
+
+    return super.canUpdate;
+  }
+
+  get canDelete() {
+    if (this.isMgmtVlanConfig) {
+      return false;
+    }
+
+    return super.canDelete;
+  }
+
+  get canClone() {
+    if (this.isMgmtVlanConfig) {
+      return false;
+    }
+
+    return super.canClone;
   }
 
   get migrateAction() {
@@ -127,6 +159,10 @@ export default class HciVlanConfig extends HarvesterResource {
   }
 
   get stateDisplay() {
+    if (this.isMgmtVlanConfig) {
+      return this.t('generic.managed');
+    }
+
     if (!this.isReady) {
       return NOT_READY;
     }
@@ -135,6 +171,10 @@ export default class HciVlanConfig extends HarvesterResource {
   }
 
   get stateBackground() {
+    if (this.isMgmtVlanConfig) {
+      return 'bg-info';
+    }
+
     if (!this.isReady) {
       return 'bg-warning';
     }


### PR DESCRIPTION

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is: @rrajendran17 

### Related Issue #
https://github.com/harvester/harvester/issues/10718
backend issue : https://github.com/harvester/harvester/issues/6110

### Test screenshot or video
<img width="2223" height="439" alt="mgmt-vlanconfigui2" src="https://github.com/user-attachments/assets/61b97de0-d4ae-4536-a1f2-4d7caab84b5f" />

1.Skip ready status based on vlanstatus (return managed for mgmt vlanconfig)
2.Skip update/delete/clone and edit option as yaml for mgmt vlanconfig