### PR TITLE
feat: add NICs tab when creating overlay network

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
@@ -9,6 +9,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { HCI as HCI_LABELS_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { allHash } from '@shell/utils/promise';
+import { NAMESPACE } from '@shell/config/types';
 import { HCI } from '../types';
 import { NETWORK_TYPE, L2VLAN_MODE } from '../config/types';
 import { removeObject } from '@shell/utils/array';
@@ -70,7 +71,10 @@ export default {
   async fetch() {
     const inStore = this.$store.getters['currentProduct'].inStore;
 
-    await allHash({ clusterNetworks: this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.CLUSTER_NETWORK }) });
+    await allHash({
+      clusterNetworks: this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.CLUSTER_NETWORK }),
+      namespaces:      this.$store.dispatch(`${ inStore }/findAll`, { type: NAMESPACE }),
+    });
   },
 
   created() {
@@ -199,6 +203,16 @@ export default {
       }
 
       return this.type === UNTAGGED;
+    },
+
+    namespaceOptions() {
+      const ns = this.$store.getters['harvester/all'](NAMESPACE) || [];
+      // we allow user to select "kube-system" namespace as external subnet 
+      // from kubeovn expects provider network to be in "kube-system" namespace for vpc nat gateway functionality.
+      return ns
+        .filter((ns) => !ns.isSystem || ns.id === 'kube-system')
+        .map((ns) => ({ name: ns.id }))
+        .sort((a, b) => a.name.localeCompare(b.name));
     }
   },
 
@@ -350,6 +364,7 @@ export default {
       ref="nd"
       :value="value"
       :mode="mode"
+      :namespace-options="namespaceOptions"
       @update:value="$emit('update:value', $event)"
     />
     <Tabbed

--- a/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
@@ -9,7 +9,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { HCI as HCI_LABELS_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { allHash } from '@shell/utils/promise';
-import { NAMESPACE } from '@shell/config/types';
+import { NAMESPACE, NODE } from '@shell/config/types';
 import { HCI } from '../types';
 import { NETWORK_TYPE, L2VLAN_MODE } from '../config/types';
 import { removeObject } from '@shell/utils/array';
@@ -74,6 +74,8 @@ export default {
     await allHash({
       clusterNetworks: this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.CLUSTER_NETWORK }),
       namespaces:      this.$store.dispatch(`${ inStore }/findAll`, { type: NAMESPACE }),
+      nodes:           this.$store.dispatch(`${ inStore }/findAll`, { type: NODE }),
+      linkMonitors:    this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.LINK_MONITOR }),
     });
   },
 
@@ -207,12 +209,72 @@ export default {
 
     namespaceOptions() {
       const ns = this.$store.getters['harvester/all'](NAMESPACE) || [];
-      // we allow user to select "kube-system" namespace as external subnet 
-      // from kubeovn expects provider network to be in "kube-system" namespace for vpc nat gateway functionality.
+
+      // we allow user to select "kube-system" namespace as external subnet from kubeovn
+      // expects provider network to be in "kube-system" namespace for vpc nat gateway functionality.
       return ns
         .filter((ns) => !ns.isSystem || ns.id === 'kube-system')
         .map((ns) => ({ name: ns.id }))
         .sort((a, b) => a.name.localeCompare(b.name));
+    },
+
+    nodes() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+      const nodes = this.$store.getters[`${ inStore }/all`](NODE);
+
+      return nodes.filter((n) => n.isEtcd !== 'true');
+    },
+
+    nics() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+      const linkMonitor = this.$store.getters[`${ inStore }/byId`](HCI.LINK_MONITOR, 'nic') || {};
+      const linkStatus = linkMonitor?.status?.linkStatus || {};
+      const nodes = this.nodes.map((n) => n.id);
+
+      const out = [];
+
+      // Collect all nics from all nodes (for overlay, we select from all nodes)
+      Object.keys(linkStatus).map((nodeName) => {
+        if (nodes.includes(nodeName)) {
+          const nics = linkStatus[nodeName] || [];
+
+          nics.map((nic) => {
+            out.push({
+              ...nic,
+              nodeName,
+            });
+          });
+        }
+      });
+
+      return out;
+    },
+
+    nicOptions() {
+      const out = [];
+      const seen = new Set();
+
+      (this.nics || []).map((nic) => {
+        if (!seen.has(nic.name)) {
+          seen.add(nic.name);
+          out.push({
+            label: nic.name,
+            value: nic.name,
+          });
+        }
+      });
+
+      return out.sort((a, b) => a.label.localeCompare(b.label));
+    },
+
+    master: {
+      get() {
+        return this.config?.master || '';
+      },
+
+      set(value) {
+        this.config.master = value;
+      }
     }
   },
 
@@ -228,6 +290,7 @@ export default {
         this.config.ipam = {};
         this.config.bridge = '';
         delete this.config.provider;
+        delete this.config.master;
         delete this.config.server_socket;
       }
     },
@@ -532,6 +595,25 @@ export default {
               :placeholder="t('harvester.network.layer3Network.gateway.placeholder')"
               :mode="mode"
               required
+            />
+          </div>
+        </div>
+      </Tab>
+      <Tab
+        v-if="isOverlayNetwork"
+        name="nics"
+        :label="t('harvester.network.tabs.nics')"
+        :weight="97"
+        class="bordered-table"
+      >
+        <div class="row mt-10">
+          <div class="col span-6">
+            <LabeledSelect
+              v-model:value="master"
+              :label="t('harvester.vlanConfig.uplink.nics.label')"
+              :placeholder="t('harvester.vlanConfig.uplink.nics.overlayPlaceholder')"
+              :mode="mode"
+              :options="nicOptions"
             />
           </div>
         </div>

--- a/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/edit/harvesterhci.io.networkattachmentdefinition.vue
@@ -21,6 +21,7 @@ const { ACCESS, TRUNK } = L2VLAN_MODE;
 
 const AUTO = 'auto';
 const MANUAL = 'manual';
+const KUBE_SYSTEM = 'kube-system';
 
 export default {
   emits: ['update:value'],
@@ -207,13 +208,17 @@ export default {
       return this.type === UNTAGGED;
     },
 
+    showNicsTab() {
+      return this.isOverlayNetwork && this.value.metadata.namespace === KUBE_SYSTEM;
+    },
+
     namespaceOptions() {
       const ns = this.$store.getters['harvester/all'](NAMESPACE) || [];
 
-      // we allow user to select "kube-system" namespace as external subnet from kubeovn
-      // expects provider network to be in "kube-system" namespace for vpc nat gateway functionality.
+      // Allow users to select the "kube-system" namespace as the external subnet from Kube-OVN.
+      // This expects the provider network to be in the "kube-system" namespace for VPC NAT gateway functionality.
       return ns
-        .filter((ns) => !ns.isSystem || ns.id === 'kube-system')
+        .filter((ns) => !ns.isSystem || ns.id === KUBE_SYSTEM)
         .map((ns) => ({ name: ns.id }))
         .sort((a, b) => a.name.localeCompare(b.name));
     },
@@ -254,7 +259,7 @@ export default {
       const out = [];
       const seen = new Set();
 
-      (this.nics || []).map((nic) => {
+      (this.nics || []).forEach((nic) => {
         if (!seen.has(nic.name)) {
           seen.add(nic.name);
           out.push({
@@ -305,6 +310,13 @@ export default {
       } else { // access mode
         delete this.config.vlanTrunk;
         this.config.vlan = '';
+      }
+    },
+    'value.metadata.namespace'(newNamespace) {
+      // NIC selection is only valid for overlay in kube-system namespace.
+      if (newNamespace !== KUBE_SYSTEM) {
+        delete this.config.master;
+        this.value.spec.config = JSON.stringify({ ...this.config });
       }
     },
   },
@@ -401,6 +413,10 @@ export default {
         delete this.config.promiscMode;
         delete this.config.vlan;
         delete this.config.ipam;
+
+        if (this.value.metadata.namespace !== KUBE_SYSTEM) {
+          delete this.config.master;
+        }
       }
 
       if (this.isUntaggedNetwork) {
@@ -600,18 +616,18 @@ export default {
         </div>
       </Tab>
       <Tab
-        v-if="isOverlayNetwork"
+        v-if="showNicsTab"
         name="nics"
-        :label="t('harvester.network.tabs.nics')"
+        :label="t('harvester.network.tabs.nic')"
         :weight="97"
         class="bordered-table"
       >
         <div class="row mt-10">
-          <div class="col span-6">
+          <div class="col span-12">
             <LabeledSelect
               v-model:value="master"
               :label="t('harvester.vlanConfig.uplink.nics.label')"
-              :placeholder="t('harvester.vlanConfig.uplink.nics.overlayPlaceholder')"
+              :placeholder="t('harvester.vlanConfig.uplink.nics.overlayWarning')"
               :mode="mode"
               :options="nicOptions"
             />

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1248,6 +1248,7 @@ harvester:
     tabs:
       basics: Basics
       layer3Network: Route
+      nics: NICs
     clusterNetwork:
       label: Cluster Network
       create: Create a new cluster network
@@ -1636,6 +1637,7 @@ harvester:
       nics:
         label: NICs
         addLabel: Add NIC
+        overlayPlaceholder: Select a network interface for overlay network
         placeholder: Select a NIC that is available on all the selected nodes
         validate:
           available: NIC "{nic}" is not available on the selected nodes

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1248,7 +1248,7 @@ harvester:
     tabs:
       basics: Basics
       layer3Network: Route
-      nics: NICs
+      nic: Network Interface Card
     clusterNetwork:
       label: Cluster Network
       create: Create a new cluster network
@@ -1635,9 +1635,9 @@ harvester:
         schedulingRules: Select node(s) matching rules
     uplink:
       nics:
-        label: NICs
+        label: NIC
         addLabel: Add NIC
-        overlayPlaceholder: Select a network interface for overlay network
+        overlayWarning: The NIC selected here must match the NIC provided in the provider network.
         placeholder: Select a NIC that is available on all the selected nodes
         validate:
           available: NIC "{nic}" is not available on the selected nodes

--- a/pkg/harvester/list/harvesterhci.io.networkattachmentdefinition.vue
+++ b/pkg/harvester/list/harvesterhci.io.networkattachmentdefinition.vue
@@ -166,6 +166,7 @@ export default {
       :schema="schema"
       :groupable="true"
       :rows="filterRows"
+      :ignore-filter="true"
       key-field="_key"
     >
       <template #cell:state="{row}">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This PR 
- allow `kube-system` namespace NAD exposed to create / list page.
- add NICs tab when choosing overlay type network

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/9695

### Test screenshot or video

https://github.com/user-attachments/assets/c7d6566a-a75b-4d1b-8799-264f6d875d13


