### PR TITLE
fix: CloudConfigTemplate UserData editor remaining editable in view-mode

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.cloudtemplate.vue
+++ b/pkg/harvester/edit/harvesterhci.io.cloudtemplate.vue
@@ -108,6 +108,7 @@ export default {
           <YamlEditor
             ref="yamlUser"
             v-model:value="config"
+            :mode="mode"
             class="yaml-editor"
             :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
             @onChanges="update"


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
CloudConfigTemplate UserData editor remained editable when viewing a cloud template resource.

The `harvesterhci.io.cloudtemplate` page rendered YamlEditor with `editorMode="VIEW_CODE"` but did not pass the page mode prop and the next CodeMirror component relies on the mode prop to determine whether the editor should be read-only, hence mode was not propagated...

Solution:

Pass `mode` to YamlEditor in the `harvesterhci.io.cloudtemplate` editor component.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

https://github.com/harvester/harvester/issues/10941

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Before fix:

<img width="1610" height="795" alt="image" src="https://github.com/user-attachments/assets/05aff791-9737-49b6-adf6-ec042771a508" />


After fix:


<img width="1620" height="757" alt="image" src="https://github.com/user-attachments/assets/bdfd4fec-537c-40e2-b16b-d542b84d23a2" />


