### PR TITLE
fix: add namespace filtering when updating namespaces

### DIFF
--- a/pkg/harvester/store/harvester-store/actions.ts
+++ b/pkg/harvester/store/harvester-store/actions.ts
@@ -3,7 +3,8 @@ import { ClusterNotFoundError } from '@shell/utils/error';
 import { SETTING } from '@shell/config/settings';
 import { COUNT, NAMESPACE, MANAGEMENT } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
-import { DEV } from '@shell/store/prefs';
+import { DEV, NAMESPACE_FILTERS } from '@shell/store/prefs';
+import { createNamespaceFilterKeyWithId } from '@shell/utils/namespace-filter';
 import { HCI } from '../../types';
 
 export default {
@@ -121,8 +122,11 @@ export default {
 
     await dispatch('cleanNamespaces', null, { root: true });
 
+    const namespaceFilterKey = createNamespaceFilterKeyWithId(id, 'harvester');
+    const savedFilters = rootGetters['prefs/get'](NAMESPACE_FILTERS)?.[namespaceFilterKey];
+
     commit('updateNamespaces', {
-      filters: [],
+      filters: savedFilters || [],
       all:     getters.filterNamespace(),
       getters
     }, { root: true });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The selected namespace is saved in `ns-by-cluster` with format  
```
${clusterId}__%%__harvester
```
but harvester ui extension doesn't read and apply it when loadCluster, while [rancher dashboard](https://github.com/rancher/dashboard/blob/7ce39a917def1d55162db6824d1949a23afdeb7e/shell/store/index.js#L1115-L1122) did that.


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/10942

### Test screenshot or video


https://github.com/user-attachments/assets/84ca3bd7-cfc1-4878-be37-8728e28d02b1




