### PR TITLE
fix: 'No Media' image selection removes 'harvesterhci.io/os' label from VM CR

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -1742,7 +1742,7 @@ export default {
 
           const oldImageId = old[0]?.image;
 
-          if (this.isCreate && oldImageId === imageId && imageId) {
+          if (this.isCreate && oldImageId !== imageId && imageId && osType) {
             this.osType = osType;
           }
         }


### PR DESCRIPTION
When editing a Virtual Machine's volumes, if the user selects `No media` for the Image, the `harvesterhci.io/os` label is incorrectly removed from the VM's metadata.

### Summary
Apply the new OS type only, if it is NOT empty and the old and new image IDs are NOT equal.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/10947

### Test screenshot or video
***Case 1***
1. Create a Virtual Machine.
5. Navigate to the `Volumes` tab.
3. Press `Edit as YAML` and make sure, the label `harvesterhci.io/os=linux` exists.
4. Press `Back to Form`.
5. Choose `No media` for the `Image` field.
6. Press `Edit as YAML` again. The label `harvesterhci.io/os` MUST still exist.

***Case 2***
1. Download the image `https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img`.
2. Create a Virtual Machine.
3. Navigate to the `Advanced Options`tab.
4. Choose `Windows` in `OS Type`.
5. Navigate to the `Volumes` tab.
6. Press `Edit as YAML` and make sure, the label `harvesterhci.io/os=windows` exists.
7. Press `Back to Form`.
8. Choose the Cirros image for the `Image` field.
9. Press `Edit as YAML` again. The label `harvesterhci.io/os` MUST exist and the value MUST be `windows`.

***Case 3***
1. Download the image `https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img`.
2. Create a Virtual Machine.
3. Navigate to the `Advanced Options`tab.
4. Choose `Windows` in `OS Type`.
5. Navigate to the `Volumes` tab.
6. Press `Edit as YAML` and make sure, the label `harvesterhci.io/os=windows` exists.
7. Press `Back to Form`.
8. Choose the Ubuntu image for the `Image` field.
9. Press `Edit as YAML` again. The label `harvesterhci.io/os` MUST exist and the value MUST be `ubuntu`.