### PR TITLE
fix: VM Template UserData editor remaining editable in view-mode

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCloudConfig/DataTemplate.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCloudConfig/DataTemplate.vue
@@ -143,6 +143,7 @@ export default {
       <YamlEditor
         ref="yaml"
         v-model:value="yamlScript"
+        :mode="mode"
         class="yaml-editor"
         :editor-mode="editorMode"
       />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
DataTemplate.vue correctly detects that the page is in view mode and sets editorMode to VIEW_CODE, but it does not propagate the page mode to YamlEditor...

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->
https://github.com/harvester/harvester/issues/11033

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Before fix:

<img width="2538" height="1172" alt="templatebeforefix" src="https://github.com/user-attachments/assets/7a2a3d9e-4011-45aa-ae17-76f9f15391c1" />


After fix:

<img width="2166" height="1163" alt="datatemplateafterfix" src="https://github.com/user-attachments/assets/b2fbd9bf-5c19-4494-a65e-7e13ede75527" />


