### PR TITLE
fix: the title of the CloudConfig DataTemplate dialog

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -781,7 +781,7 @@ harvester:
       addPort:  Add Port
     cloudConfig:
       title: Cloud Configuration
-      createTemplateTitle: 'Create {name}.'
+      createTemplateTitle: 'Create {name}'
       createNew: Create new...
       cloudInit:
         label: Cloud Init


### PR DESCRIPTION
Fix the DataTemplate dialog title by removing the useless dot at the end of the title.

Before:
<img width="1177" height="716" alt="Bildschirmfoto vom 2026-06-29 11-38-46" src="https://github.com/user-attachments/assets/bd60eb66-a7e1-420a-bc48-62688e67059c" />

<img width="1177" height="716" alt="Bildschirmfoto vom 2026-06-29 11-38-52" src="https://github.com/user-attachments/assets/ca56706b-d597-4052-afa3-f5355dcf853f" />

After:
<img width="1177" height="716" alt="Bildschirmfoto vom 2026-06-29 11-40-59" src="https://github.com/user-attachments/assets/7bc17c0f-8e41-4e7e-8f5a-a2cb98dfddd2" />

<img width="1177" height="716" alt="grafik" src="https://github.com/user-attachments/assets/5a0a38d7-f5c8-49c5-8000-ce90d227d267" />

### Summary

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


