### PR TITLE
ci: disable digest dependency update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,10 +14,17 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "deps",
   "prHourlyLimit": 12,
+  "digest": {
+    "enabled": false
+  },
   "timezone": "Asia/Taipei",
   "schedule": ["after 10am on sunday"],
   "postUpdateOptions": ["yarnDedupeFewer"],
   "packageRules": [
+    {
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
+    },
     {
       "matchUpdateTypes": ["major"],
       "enabled": false
@@ -44,14 +51,6 @@
       "minimumReleaseAge": "7 days",
       "groupName": "patch dependencies",
       "labels": ["patch-update"],
-      "reviewers": ["a110605", "houhoucoop"]
-    },
-    {
-      "matchUpdateTypes": ["digest", "pinDigest"],
-      "automerge": false,
-      "groupName": "digest dependencies",
-      "labels": ["digest-update"],
-      "schedule": ["on the first day of the month"],
       "reviewers": ["a110605", "houhoucoop"]
     }
   ]


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Disable digest dependency update because it's annoying to update to latest digest every first day of the month.
- https://github.com/harvester/harvester-ui-extension/pull/965
- https://github.com/harvester/harvester-ui-extension/pull/963
- https://github.com/harvester/harvester-ui-extension/pull/962

We can manually update the digest once all the harvester repos need to do that.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


