### PR TITLE
ci: update build-extension-charts workflow reference

### DIFF
--- a/.github/workflows/build-extension-on-release.yml
+++ b/.github/workflows/build-extension-on-release.yml
@@ -43,12 +43,10 @@ jobs:
     needs:
       - setup-release-tag
       - check-version
-    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@3b26a36bad555e5e2b8634b24823be29732f287c # master
+    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@9bf23dff6650116673346447bcf0b088e0edb27f # creators-pkg-v3.0.12
     permissions:
-      actions: write
       contents: write
-      deployments: write
-      pages: write
+      pull-requests: write
     with:
       target_branch: gh-pages
       tagged_release: '${{ needs.setup-release-tag.outputs.release_tag }}'


### PR DESCRIPTION
Updates were done on the reusable workflow https://github.com/rancher/dashboard/blob/master/.github/workflows/build-extension-charts.yml in terms of security hardening, reducing the set of permissions needed to the minimum required for the workflow to run.

With that change in mind, we've done testing on `elemental-ui` with this new version https://github.com/rancher/elemental-ui/blob/main/.github/workflows/build-extension-charts.yml#L15 + https://github.com/rancher/elemental-ui/actions/runs/28600678629 and we will need to update all the official extensions repositories to consume this new version/hash of the workflow
