### PR TITLE
fix: vpc topology should consume NAD labels

### DIFF
--- a/pkg/harvester/config/labels-annotations.js
+++ b/pkg/harvester/config/labels-annotations.js
@@ -16,6 +16,7 @@ export const HCI = {
   CREATOR:                          'harvesterhci.io/creator',
   OS:                               'harvesterhci.io/os',
   GOLDEN_IMAGE:                     'harvesterhci.io/goldenImage',
+  CLUSTER_NETWORK:                  'network.harvesterhci.io/clusternetwork',
   NETWORK_TYPE:                     'network.harvesterhci.io/type',
   VM_NAME:                          'harvesterhci.io/vmName',
   VM_NAME_PREFIX:                   'harvesterhci.io/vmNamePrefix',

--- a/pkg/harvester/detail/kubeovn.io.vpc.vue
+++ b/pkg/harvester/detail/kubeovn.io.vpc.vue
@@ -7,6 +7,7 @@ import { MiniMap } from '@vue-flow/minimap';
 import { allHash } from '@shell/utils/promise';
 import { NETWORK_ATTACHMENT } from '@shell/config/types';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
+import { HCI as HCI_ANNOTATIONS } from '@pkg/harvester/config/labels-annotations';
 import { HCI } from '../types';
 import { NETWORK_TYPE } from '../config/types';
 
@@ -454,10 +455,10 @@ export default {
         const overlayName = nad?.parseConfig?.name || nad?.metadata?.name;
 
         const clusterNetwork =
-          nad?.metadata?.labels?.[HCI.CLUSTER_NETWORK] || 'mgmt';
+          nad?.metadata?.labels?.[HCI_ANNOTATIONS.CLUSTER_NETWORK] || 'mgmt';
 
         const nadType =
-          nad?.metadata?.labels?.[HCI.NETWORK_TYPE] || NETWORK_TYPE.OVERLAY;
+          nad?.metadata?.labels?.[HCI_ANNOTATIONS.NETWORK_TYPE] || NETWORK_TYPE.OVERLAY;
         const overlayNodeId = `overlay-${ provider }`;
 
         nodes.push({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fix: vpc topology should consume NAD labels 
- network.harvesterhci.io/clusternetwork
- network.harvesterhci.io/type 

After created host network with `spec.overlay:true`, the NAD cluster network will change from `mgmt` to `vm`.

The VPC topoloy should honor the correct labels.


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/8651#issuecomment-4191656631

### Test screenshot or video
<img width="1496" height="846" alt="Screenshot 2026-07-08 at 10 58 43 AM" src="https://github.com/user-attachments/assets/4379b088-dcbc-4163-9858-f024e3dc265c" />
<img width="1496" height="862" alt="Screenshot 2026-07-08 at 10 58 52 AM" src="https://github.com/user-attachments/assets/6ee2a4cb-c66f-4566-b010-99929f29d5be" />

<img width="1493" height="856" alt="Screenshot 2026-07-08 at 10 55 29 AM" src="https://github.com/user-attachments/assets/f1312aee-bc3f-48c4-834d-de6d0799ddfe" />



