### PR TITLE
chore: limit the rancher to 2.15.0+ for harvester v1.9.0

### DIFF
--- a/pkg/harvester/package.json
+++ b/pkg/harvester/package.json
@@ -7,7 +7,7 @@
     "annotations": {
       "catalog.cattle.io/display-name": "Harvester",
       "catalog.cattle.io/kube-version": ">= 1.16.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.14.0-0",
+      "catalog.cattle.io/rancher-version": ">= 2.15.0-0",
       "catalog.cattle.io/ui-extensions-version": ">= 3.0.0 < 4.0.0"
     }
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
We limit customer to use v1.9.0 only on rancher 2.15.0+

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


