### PR TITLE
feat: allow Cloud Config for Windows guests (Cloudbase-Init)

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCloudConfig/DataTemplate.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCloudConfig/DataTemplate.vue
@@ -68,12 +68,6 @@ export default {
   },
 
   watch: {
-    osType(neu) {
-      if (neu === 'windows') {
-        this.id = '';
-      }
-    },
-
     value(neu) {
       this.yamlScript = neu;
     },

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -1062,7 +1062,6 @@ export default {
         </div>
 
         <CloudConfig
-          v-if="!isWindows"
           ref="yamlEditor"
           :user-script="userScript"
           :mode="mode"

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -1929,8 +1929,6 @@ export default {
     isWindows(val) {
       if (val) {
         this['sshKey'] = [];
-        this['userScript'] = undefined;
-        this['networkScript'] = undefined;
         this['installAgent'] = false;
       }
     },

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -1354,13 +1354,22 @@ export default {
      */
     deleteYamlDocProp(doc, paths) {
       try {
-        const item = doc.getIn([])?.items[0];
-        const key = item?.key;
-        const hasCloudConfigComment = !!key?.commentBefore?.includes('cloud-config');
-        const isMatchProp = key.source === paths[paths.length - 1];
+        const items = doc.getIn([])?.items;
+        const firstKey = items?.[0]?.key;
+        const hasCloudConfigComment = !!firstKey?.commentBefore?.includes('cloud-config');
+        const isFirstProp = firstKey?.source === paths[paths.length - 1];
 
-        if (key && hasCloudConfigComment && isMatchProp) {
-          // Comments are mounted on the next node and we should not delete the node containing cloud-config
+        if (firstKey && hasCloudConfigComment && isFirstProp) {
+          const comment = firstKey.commentBefore;
+
+          doc.deleteIn(paths);
+
+          // Move the comment to the new first key; if no keys remain the comment is lost.
+          const newFirstKey = doc.getIn([])?.items?.[0]?.key;
+
+          if (newFirstKey) {
+            newFirstKey.commentBefore = comment;
+          }
         } else {
           doc.deleteIn(paths);
         }
@@ -1411,7 +1420,6 @@ export default {
       if (packages.length > 0) {
         userDataDoc.setIn(['packages'], packages);
       } else {
-        userDataDoc.setIn(['packages'], []); // It needs to be set empty first, as it is possible that cloud-init comments are mounted on this node
         this.deleteYamlDocProp(userDataDoc, ['packages']);
         this.deleteYamlDocProp(userDataDoc, ['package_update']);
       }
@@ -1426,7 +1434,7 @@ export default {
     },
 
     deleteQGA(config) {
-      const { osType, userDataDoc, deletePackage = false } = config;
+      const { osType, userDataDoc } = config;
 
       const userDataTemplateValue = this.$store.getters['harvester/byId'](CONFIG_MAP, this.userDataTemplateId)?.data?.cloudInit || '';
 
@@ -1434,6 +1442,15 @@ export default {
       const userDataJSON = YAML.parse(userDataYAML);
       const packages = userDataJSON?.packages || [];
       const runcmd = userDataJSON?.runcmd || [];
+
+      // Special handling of OS types.
+      let deletePackage = config.deletePackage ?? false;
+
+      switch (osType) {
+      case 'windows':
+        deletePackage = true;
+        break;
+      }
 
       if (Array.isArray(packages) && deletePackage) {
         const templateHasQGAPackage = this.convertToJson(userDataTemplateValue);
@@ -1460,7 +1477,6 @@ export default {
       if (packages.length > 0) {
         userDataDoc.setIn(['packages'], packages);
       } else {
-        userDataDoc.setIn(['packages'], []);
         this.deleteYamlDocProp(userDataDoc, ['packages']);
         this.deleteYamlDocProp(userDataDoc, ['package_update']);
       }
@@ -1494,21 +1510,6 @@ export default {
 
     async saveSecret(vm) {
       if (!vm?.spec || !this.secretName) {
-        return true;
-      }
-
-      // Don't create a Secret unless the VM spec actually references it.
-      // A cloudinitdisk can carry user/network data either inline (clear
-      // text) or via secretRef/networkDataSecretRef — only in the latter
-      // cases does saveSecret need to run. Preserve the existing edit-mode
-      // cleanup path so a previously-populated secret still gets its data
-      // cleared when the user removes the Cloud Config content.
-      const cloudInitVol = vm.spec?.template?.spec?.volumes?.find((v) => v.name === 'cloudinitdisk');
-      const referencesSecret =
-        cloudInitVol?.cloudInitNoCloud?.secretRef?.name === this.secretName ||
-        cloudInitVol?.cloudInitNoCloud?.networkDataSecretRef?.name === this.secretName;
-
-      if (!referencesSecret && !(this.isEdit && this.secretRef)) {
         return true;
       }
 
@@ -1988,9 +1989,8 @@ export default {
 
     osType(neu, old) {
       this.installAgent = old === 'windows' ? true : this.installAgent;
-      const out = old === 'windows' ? this.getInitUserData({ osType: neu }) : this.getUserData({ installAgent: this.installAgent, osType: neu });
+      this.userScript = this.getUserData({ installAgent: this.installAgent, osType: neu });
 
-      this['userScript'] = out;
       this.refreshYamlEditor();
     },
 

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -917,32 +917,30 @@ export default {
       }
 
       if (!disks.find( (D) => D.name === 'cloudinitdisk') && (this.userData || this.networkScript)) {
-        if (!this.isWindows) {
-          disks.push({
-            name: 'cloudinitdisk',
-            disk: { bus: 'virtio' }
-          });
+        disks.push({
+          name: 'cloudinitdisk',
+          disk: { bus: 'virtio' }
+        });
 
-          const userData = this.getUserData({ osType: this.osType, installAgent: this.installAgent });
-          const cloudinitdisk = {
-            name:             'cloudinitdisk',
-            cloudInitNoCloud: {}
-          };
+        const userData = this.getUserData({ osType: this.osType, installAgent: this.installAgent });
+        const cloudinitdisk = {
+          name:             'cloudinitdisk',
+          cloudInitNoCloud: {}
+        };
 
-          if (this.saveUserDataAsClearText) {
-            cloudinitdisk.cloudInitNoCloud.userData = userData;
-          } else {
-            cloudinitdisk.cloudInitNoCloud.secretRef = { name: this.secretName };
-          }
-
-          if (this.saveNetworkDataAsClearText) {
-            cloudinitdisk.cloudInitNoCloud.networkData = this.networkScript;
-          } else {
-            cloudinitdisk.cloudInitNoCloud.networkDataSecretRef = { name: this.secretName };
-          }
-
-          volumes.push(cloudinitdisk);
+        if (this.saveUserDataAsClearText) {
+          cloudinitdisk.cloudInitNoCloud.userData = userData;
+        } else {
+          cloudinitdisk.cloudInitNoCloud.secretRef = { name: this.secretName };
         }
+
+        if (this.saveNetworkDataAsClearText) {
+          cloudinitdisk.cloudInitNoCloud.networkData = this.networkScript;
+        } else {
+          cloudinitdisk.cloudInitNoCloud.networkDataSecretRef = { name: this.secretName };
+        }
+
+        volumes.push(cloudinitdisk);
       }
 
       const specDisks = this.spec?.template?.spec?.domain?.devices?.disks;
@@ -1144,6 +1142,16 @@ export default {
     },
 
     getInitUserData(config) {
+      // Windows guests don't use qemu-guest-agent via systemd (VMDP installs
+      // the QGA as a Windows service), and the Linux `runcmd` recipe would
+      // fail on Cloudbase-Init. Return an empty string so `this.userData`
+      // stays falsy on Windows until the user actually enters cloud-config
+      // content — this prevents emitting a spurious cloudinitdisk volume
+      // and Secret for every Windows VM (Copilot review comment on #984).
+      if (config.osType === 'windows') {
+        return '';
+      }
+
       const _QGA_JSON = this.getMatchQGA(config.osType);
 
       const out = jsyaml.dump(_QGA_JSON);
@@ -1485,7 +1493,22 @@ export default {
     },
 
     async saveSecret(vm) {
-      if (!vm?.spec || !this.secretName || this.isWindows) {
+      if (!vm?.spec || !this.secretName) {
+        return true;
+      }
+
+      // Don't create a Secret unless the VM spec actually references it.
+      // A cloudinitdisk can carry user/network data either inline (clear
+      // text) or via secretRef/networkDataSecretRef — only in the latter
+      // cases does saveSecret need to run. Preserve the existing edit-mode
+      // cleanup path so a previously-populated secret still gets its data
+      // cleared when the user removes the Cloud Config content.
+      const cloudInitVol = vm.spec?.template?.spec?.volumes?.find((v) => v.name === 'cloudinitdisk');
+      const referencesSecret =
+        cloudInitVol?.cloudInitNoCloud?.secretRef?.name === this.secretName ||
+        cloudInitVol?.cloudInitNoCloud?.networkDataSecretRef?.name === this.secretName;
+
+      if (!referencesSecret && !(this.isEdit && this.secretRef)) {
         return true;
       }
 


### PR DESCRIPTION
## Summary

Allow users to author and persist Cloud Config (cloud-init) on Windows VMs. Today the Cloud Config editor is hidden entirely when OS Type is set to Windows, and even if user-data/network-data has been supplied elsewhere the `cloudinitdisk` volume and its Secret are silently dropped from the VM spec. This is more restrictive than what Windows guests actually support: **Cloudbase-Init** reads `cloudinit`-style `NoCloud` datasources on Windows and is a common way to bootstrap Windows guests (install VMDP + qemu-guest-agent, enable OpenSSH server, drop authorized_keys, run first-boot `runcmd` scripts, join a domain, etc.).

Windows guests today have to hand-edit the VM YAML after the UI creates the VM — a workflow that is fragile, undiscoverable, and defeats the point of a UI. See the linked upstream issue for the same request from the operator side.

## Context — why did the current behavior exist?

- Prior to #954 (Unattend.xml support for Windows), the Cloud Config editor was **always** rendered, and Windows switched it to `:view-code="isWindows"` (read-only view). Users could still see the cloud-init content but not edit it.
- PR #954 introduced the WindowsSysprep editor and, in the same change, replaced the read-only view with `v-if="!isWindows"` — the editor is now hidden entirely for Windows. Two additional guards were added in the VM mixin so that the `cloudinitdisk` volume and its Secret are also skipped for Windows.
- Related issue: harvester/harvester#1836 — the original request was Windows Unattend.xml support "in place of" cloud-init, but "in place of" was a workflow preference, not a technical constraint. Sysprep and Cloudbase-Init are complementary, not mutually exclusive: Sysprep runs at Windows setup (unattend for install), Cloudbase-Init runs at first boot after install (like cloud-init on Linux).

Verified in the field: our SUSE DSA lab cluster runs Windows Server 2022 VMs that use cloud-init via `cloudInitNoCloud` with a `secretRef`, containing VMDP install + OpenSSH server setup + RDP enablement. It works — but the VMs had to be created via Terraform because the UI would drop the `cloudinitdisk` if osType was Windows.

## Changes

Three small, additive changes; no schema change, no i18n key changes, no impact on Linux:

**1.** `pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue`
Remove `v-if="!isWindows"` from `<CloudConfig>` so the editor renders for every OS type. `<WindowsSysprep>` continues to render only for Windows (unchanged), so Windows now gets both panels; Linux is visually identical.

**2.** `pkg/harvester/mixins/harvester-vm/index.js` — `parseVM` volume serialization
Drop the `if (!this.isWindows)` guard around the `cloudinitdisk` block so the disk + volume are attached whenever the user has supplied `userData` or `networkData`, regardless of OS.

**3.** `pkg/harvester/mixins/harvester-vm/index.js` — `saveSecret`
Drop the `|| this.isWindows` early-return so the cloud-init Secret is written for Windows VMs too.

**4.** `pkg/harvester/mixins/harvester-vm/index.js` — `getInitUserData`
For `osType === 'windows'`, return an empty string so `this.userData` stays falsy until the user actually enters cloud-config content. This prevents the `(this.userData || this.networkData)` gate in `parseVM` from emitting a spurious `cloudinitdisk` volume + Secret for every Windows VM. The editor still renders (empty), and users who paste cloud-config get the normal flow. Skipping the Linux `runcmd` template is intentional: it targets systemd, which Cloudbase-Init doesn't use.

## What is intentionally NOT changed

- **`installAgent` checkbox stays disabled for Windows.** That checkbox drives the Linux QGA-via-`runcmd` injection recipe (`QGA_MAP`, `mergeQGA`). VMDP installs QGA on Windows as a native Windows service, so this recipe doesn't apply. Leaving the checkbox disabled reflects that.
- **`WindowsSysprep` panel is preserved** for Windows. Sysprep and Cloudbase-Init cover different phases of a Windows first boot and can coexist. Users who only want Sysprep leave the Cloud Config editor empty.
- **`DataTemplate.vue` osType watcher** ~~(`neu === 'windows' → this.id = ''`) is left as-is. It just clears the template dropdown selection; harmless because there is no Windows cloud-init template shipped by default.~~

## Test plan

- [ ] Create Windows VM with osType Windows: Cloud Config editor is visible and empty by default, Sysprep editor is also visible.
- [ ] Create Windows VM with osType Windows and leave Cloud Config empty: verify no `cloudinitdisk` volume or `cloud-init` Secret is created (no side-effects when the panel is untouched).
- [ ] Enter a valid Cloudbase-Init user-data (`users:`, `runcmd:`, etc.) and create the VM. Verify:
  - `kubectl get vm <name> -o yaml` has a `cloudinitdisk` disk (bus: virtio) and a matching `cloudInitNoCloud.secretRef` volume.
  - `kubectl get secret <secret>` contains the base64-encoded user-data.
  - Windows guest boots and Cloudbase-Init runs the user-data (verify by e.g. an SSH key that gets planted → SSH in).
- [ ] Create Windows VM with only Sysprep + empty Cloud Config: no `cloudinitdisk` is emitted (existing empty-user-data behavior is preserved).
- [ ] Create Windows VM with both Sysprep + Cloud Config: both `sysprep` volume and `cloudinitdisk` volume appear in the spec.
- [ ] Edit an existing Windows VM created with Cloud Config: the editor shows the persisted content, edits round-trip correctly.
- [ ] Create Linux VM: no visible change; QGA-via-`runcmd` template still populates for `installAgent = true`.
- [ ] Switch osType Linux → Windows in the same session: `installAgent` becomes false and disabled, Sysprep panel appears, Cloud Config panel stays visible and its content is preserved (osType watcher).

## Related

- Resolves point 2 of harvester/harvester#11124 (multi-part enhancement request, opened by SUSE DSA covering Windows defaults across the UI + template + docs).
- Complements harvester/harvester-ui-extension#954 (Sysprep support) — this PR keeps Sysprep and additionally restores + broadens Cloud Config support for Windows.
- Original feature request: harvester/harvester#1836.

