### PR TITLE
refactor: rename pod network to management network

### DIFF
--- a/pkg/harvester/components/vm-migration/ConfigureMappingsStep.vue
+++ b/pkg/harvester/components/vm-migration/ConfigureMappingsStep.vue
@@ -58,7 +58,7 @@ const harvesterNetworkOptions = computed(() => {
 
 const storageClassOptions = computed(() => {
   const options = storageClasses.value.filter((s) => !s.parameters?.backingImage).map((sc) => {
-    const value = sc.metadata?.name || sc.id;
+    const value = sc.name;
     let label = sc.isDefault ? `${ value } (${ t('generic.default') })` : value;
     let disabled = false;
 

--- a/pkg/harvester/components/vm-migration/ConfigureMappingsStep.vue
+++ b/pkg/harvester/components/vm-migration/ConfigureMappingsStep.vue
@@ -9,6 +9,7 @@ import { randomStr } from '@shell/utils/string';
 import { HCI } from '../../types';
 import { FORKLIFT_NAMESPACE } from '../../config/harvester-map';
 import { buildNetworkMapEntries, buildStorageMapEntries } from '../../utils/forklift';
+import { isInternalStorageClass } from '../../utils/storage-class';
 import MappingColumn from './MappingColumn.vue';
 
 const props = defineProps({
@@ -56,10 +57,22 @@ const harvesterNetworkOptions = computed(() => {
 });
 
 const storageClassOptions = computed(() => {
-  const options = storageClasses.value.map((sc) => ({
-    label: sc.metadata?.name || sc.id,
-    value: sc.metadata?.name || sc.id,
-  }));
+  const options = storageClasses.value.filter((s) => !s.parameters?.backingImage).map((sc) => {
+    const value = sc.metadata?.name || sc.id;
+    let label = sc.isDefault ? `${ value } (${ t('generic.default') })` : value;
+    let disabled = false;
+
+    if (isInternalStorageClass(value)) {
+      label += ` (${ t('harvester.storage.internal.label') })`;
+      disabled = true;
+    }
+
+    return {
+      label,
+      value,
+      disabled,
+    };
+  });
 
   if (!options.find((o) => o.value === 'harvester-longhorn')) {
     options.unshift({ label: 'harvester-longhorn', value: 'harvester-longhorn' });

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1967,7 +1967,7 @@ harvester:
           placeholder: Choose a Harvester network
           template: Use existing network mapping as template
           options:
-            podNetworking: Pod Networking
+            podNetworking: Management Network
             ignored: Ignored
         storageMapping:
           title: Storage Mapping


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

- Rename `Pod networking` to `Management Network`
   - In forklift network mapping, choose pod network([type :pod](https://github.com/harvester/harvester-ui-extension/blob/41cf44d23131ce30762fd29fe38d833d22238398/pkg/harvester/utils/forklift.js#L47)) will finally map to the VM management network ([spec.network.pod: {}](https://github.com/harvester/harvester-ui-extension/blob/41cf44d23131ce30762fd29fe38d833d22238398/pkg/harvester/mixins/harvester-vm/index.js#L1293))
- Follow harvester image edit page, 
   - disable `longhorn-static` / `vmstate-persistence` SC as they're internal used.
   - show `Default` suffix for default SC.

 
### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/10417

### Test screenshot or video
**Network mapping**

Before
<img width="1488" height="548" alt="Screenshot 2026-07-14 at 11 49 07 AM" src="https://github.com/user-attachments/assets/3a29cb2d-7298-43bc-9766-bbb6b804066c" />

After 
<img width="1492" height="607" alt="Screenshot 2026-07-14 at 12 17 55 PM" src="https://github.com/user-attachments/assets/da85ab98-4bc3-4149-9cde-bf00d57c982f" />


**Storage Mapping**
Before
<img width="1492" height="819" alt="Screenshot 2026-07-14 at 12 19 49 PM" src="https://github.com/user-attachments/assets/149c3453-ca75-4e40-b48a-8782c7fd5f83" />


After

<img width="1496" height="633" alt="Screenshot 2026-07-14 at 12 17 51 PM" src="https://github.com/user-attachments/assets/6e699a3e-4ea4-45a9-a9dd-4688993577e8" />
