### PR TITLE
refactor: add customized migration plan delete model

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -2002,6 +2002,8 @@ harvester:
           start: Start
           restart: Restart
           stop: Stop
+      deleteDialog:
+        warning: Deleting this migration plan will also delete the following related resources
 
     vmImport:
       titles:

--- a/pkg/harvester/models/forklift.konveyor.io.plan.js
+++ b/pkg/harvester/models/forklift.konveyor.io.plan.js
@@ -46,6 +46,10 @@ export default class ForkliftPlan extends HarvesterResource {
   }
 
   get stateDescription() {
+    if (this.metadata?.deletionTimestamp) {
+      return null;
+    }
+
     const messages = [];
     const conditions = this.status?.conditions || [];
 
@@ -67,7 +71,7 @@ export default class ForkliftPlan extends HarvesterResource {
   get stateObj() {
     return {
       error:         this.planFailed || this.planCritical,
-      transitioning: this.isMigrating,
+      transitioning: this.isMigrating || this.isPendingMigrationStart || !!this.metadata?.deletionTimestamp,
       message:       this.stateDescription,
     };
   }
@@ -76,6 +80,14 @@ export default class ForkliftPlan extends HarvesterResource {
     const migration = this.status?.migration;
 
     return !!migration?.started && !migration?.completed;
+  }
+
+  // Right after creating a plan, controller status can lag briefly.
+  // Treat this window as in-progress so we don't flash a succeeded badge.
+  get isPendingMigrationStart() {
+    const vmCount = this.spec?.vms?.length || 0;
+
+    return vmCount > 0 && !this.planFailed && !this.planCritical && !this.planCanceled && !this.planSucceeded && !this.isMigrating;
   }
 
   get planCanceled() {
@@ -98,6 +110,10 @@ export default class ForkliftPlan extends HarvesterResource {
   }
 
   get stateDisplay() {
+    if (this.metadata?.deletionTimestamp) {
+      return 'Terminating';
+    }
+
     if (this.planFailed) {
       return this.t('harvester.addons.vmMigration.plan.states.error');
     }
@@ -114,10 +130,18 @@ export default class ForkliftPlan extends HarvesterResource {
       return this.t('harvester.addons.vmMigration.plan.states.inProgress');
     }
 
+    if (this.isPendingMigrationStart) {
+      return this.t('harvester.addons.vmMigration.plan.states.inProgress');
+    }
+
     return this.t('harvester.addons.vmMigration.plan.states.active');
   }
 
   get stateBackground() {
+    if (this.metadata?.deletionTimestamp) {
+      return 'bg-info';
+    }
+
     if (this.planFailed) {
       return 'bg-error';
     }
@@ -131,6 +155,10 @@ export default class ForkliftPlan extends HarvesterResource {
     }
 
     if (this.isMigrating) {
+      return 'bg-info';
+    }
+
+    if (this.isPendingMigrationStart) {
       return 'bg-info';
     }
 
@@ -254,16 +282,5 @@ export default class ForkliftPlan extends HarvesterResource {
 
   async deletePlan() {
     await this.remove();
-  }
-
-  /**
-   * Deleting a Plan cascades via ownerReferences set at creation time.
-   * Kubernetes GC will automatically delete: Migration, NetworkMap, StorageMap.
-   * Use foreground propagation to ensure children are deleted before the parent.
-   */
-  remove(opt = {}) {
-    opt.params = { ...(opt.params || {}), propagationPolicy: 'Foreground' };
-
-    return this._remove(opt);
   }
 }

--- a/pkg/harvester/pages/c/_cluster/vm-migration/vm-migration-wizard.vue
+++ b/pkg/harvester/pages/c/_cluster/vm-migration/vm-migration-wizard.vue
@@ -9,6 +9,7 @@ import ConfigureMappingsStep from '@pkg/harvester/components/vm-migration/Config
 import ReviewMigrationStep from '@pkg/harvester/components/vm-migration/ReviewMigrationStep.vue';
 import { PRODUCT_NAME } from '@pkg/harvester/config/harvester';
 import { currentRouter } from '@pkg/harvester/utils/router';
+import { exceptionToErrorsArray, stringify } from '@shell/utils/error';
 
 const store = useStore();
 const { t } = useI18n(store);
@@ -220,7 +221,13 @@ const onFinish = async(buttonCb) => {
     buttonCb(true);
     currentRouter().push(migrationListLocation);
   } catch (err) {
-    errors.value = [err instanceof Error ? err.message : String(err)];
+    errors.value = exceptionToErrorsArray(err).map((e) => {
+      if (typeof e === 'string') {
+        return e;
+      }
+
+      return stringify(e);
+    });
     buttonCb(false);
   }
 };

--- a/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
+++ b/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
@@ -107,6 +107,20 @@ export default defineComponent({
     },
   },
 
+  async mounted() {
+    const inStore = this.$store.getters['currentProduct'].inStore;
+
+    try {
+      await Promise.all([
+        this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_MIGRATION }),
+        this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_NETWORK_MAP }),
+        this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_STORAGE_MAP }),
+      ]);
+    } catch {
+      // Best-effort: the dialog can still function without this prefetch.
+    }
+  },
+
   methods: {
     resourceNames,
 
@@ -243,7 +257,7 @@ export default defineComponent({
 
     <div
       v-for="summary in relatedSummary"
-      :key="summary.planName"
+      :key="`${ summary.namespace }/${ summary.planName }`"
       class="mb-10"
     >
       <div>• {{ t('harvester.addons.vmMigration.labels.migration') }}:</div>

--- a/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
+++ b/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
@@ -93,6 +93,7 @@ export default defineComponent({
 
         return {
           planName,
+          namespace,
           migrations: [...migrationsMap.values()],
           networkMap: matchedNetworkMap ? {
             namespace: networkMap.namespace || namespace,

--- a/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
+++ b/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
@@ -41,11 +41,6 @@ export default defineComponent({
     return {
       errors:        [],
       removing:      false,
-      deletedCounts: {
-        migration:  0,
-        networkMap: 0,
-        storageMap: 0,
-      },
     };
   },
 
@@ -155,12 +150,18 @@ export default defineComponent({
       if (!targets.length) {
         return;
       }
+      let cache = {};
 
-      const cache = {
-        [HCI.FORKLIFT_MIGRATION]:   await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_MIGRATION }),
-        [HCI.FORKLIFT_NETWORK_MAP]: await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_NETWORK_MAP }),
-        [HCI.FORKLIFT_STORAGE_MAP]: await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_STORAGE_MAP }),
-      };
+      try {
+        cache = {
+          [HCI.FORKLIFT_MIGRATION]:   await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_MIGRATION }),
+          [HCI.FORKLIFT_NETWORK_MAP]: await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_NETWORK_MAP }),
+          [HCI.FORKLIFT_STORAGE_MAP]: await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_STORAGE_MAP }),
+        };
+      } catch (err) {
+        // Best-effort cleanup; don't block closing the dialog if listing related resources fails.
+        return;
+      }
 
       for (const target of targets) {
         const matched = (cache[target.type] || []).find((resource) => resource?.metadata?.name === target.name && resource?.metadata?.namespace === target.namespace
@@ -172,14 +173,6 @@ export default defineComponent({
 
         try {
           await matched.remove({ params: { propagationPolicy: 'Background' } });
-
-          if (target.type === HCI.FORKLIFT_MIGRATION) {
-            this.deletedCounts.migration += 1;
-          } else if (target.type === HCI.FORKLIFT_NETWORK_MAP) {
-            this.deletedCounts.networkMap += 1;
-          } else if (target.type === HCI.FORKLIFT_STORAGE_MAP) {
-            this.deletedCounts.storageMap += 1;
-          }
         } catch (err) {
           // Continue deleting remaining resources and let final plan deletion fail if needed.
         }
@@ -191,8 +184,15 @@ export default defineComponent({
       this.removing = true;
 
       try {
-        await Promise.all((this.value || []).map((resource) => resource.remove({ params: { propagationPolicy: 'Background' } })));
+        const results = await Promise.allSettled((this.value || []).map((resource) => resource.remove({ params: { propagationPolicy: 'Background' } })));
+
         await this.deleteRelatedResources();
+        const rejected = results.filter((r) => r.status === 'rejected');
+
+        if (rejected.length) {
+          throw rejected[0].reason;
+        }
+
         this.close(buttonDone);
       } catch (err) {
         this.errors = exceptionToErrorsArray(err);

--- a/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
+++ b/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
@@ -1,0 +1,282 @@
+<script>
+import { defineComponent } from 'vue';
+import { mapState, mapGetters } from 'vuex';
+import { resourceNames } from '@shell/utils/string';
+import { exceptionToErrorsArray } from '@shell/utils/error';
+import { HCI } from '../types';
+
+export default defineComponent({
+  name: 'PromptRemoveForkliftPlanDialog',
+
+  emits: ['errors'],
+
+  props: {
+    value: {
+      type:    Array,
+      default: () => []
+    },
+
+    names: {
+      type:    Array,
+      default: () => []
+    },
+
+    type: {
+      type:     String,
+      required: true
+    },
+
+    close: {
+      type:     Function,
+      required: true
+    },
+
+    doneLocation: {
+      type:    Object,
+      default: () => {}
+    }
+  },
+
+  data() {
+    return {
+      errors:        [],
+      removing:      false,
+      deletedCounts: {
+        migration:  0,
+        networkMap: 0,
+        storageMap: 0,
+      },
+    };
+  },
+
+  computed: {
+    ...mapState('action-menu', ['toRemove']),
+    ...mapGetters({ t: 'i18n/t' }),
+
+    resourceType() {
+      return this.t('typeLabel."forklift.konveyor.io.plan"', { count: this.names?.length || 1 });
+    },
+
+    relatedSummary() {
+      return (this.value || []).map((plan) => {
+        const planName = plan?.metadata?.name || '-';
+        const namespace = plan?.metadata?.namespace || '';
+        const networkMap = plan?.spec?.map?.network;
+        const storageMap = plan?.spec?.map?.storage;
+        const history = plan?.status?.migration?.history || [];
+
+        const migrationsMap = new Map();
+
+        history
+          .map((entry) => ({
+            name:      entry?.migration?.name,
+            namespace: entry?.migration?.namespace || namespace,
+          }))
+          .filter((entry) => !!entry.name)
+          .forEach((entry) => {
+            migrationsMap.set(`${ entry.namespace }/${ entry.name }`, entry);
+          });
+
+        return {
+          planName,
+          migrations: [...migrationsMap.values()],
+          networkMap: networkMap?.name ? {
+            namespace: networkMap.namespace || namespace,
+            name:      networkMap.name,
+          } : null,
+          storageMap: storageMap?.name ? {
+            namespace: storageMap.namespace || namespace,
+            name:      storageMap.name,
+          } : null,
+        };
+      });
+    },
+  },
+
+  methods: {
+    resourceNames,
+
+    buildDeleteTargets() {
+      const targets = new Map();
+
+      for (const plan of this.value || []) {
+        const namespace = plan?.metadata?.namespace || '';
+        const networkMap = plan?.spec?.map?.network;
+        const storageMap = plan?.spec?.map?.storage;
+        const history = plan?.status?.migration?.history || [];
+
+        if (networkMap?.name) {
+          const ns = networkMap.namespace || namespace;
+          const key = `${ HCI.FORKLIFT_NETWORK_MAP }|${ ns }|${ networkMap.name }`;
+
+          targets.set(key, {
+            type:      HCI.FORKLIFT_NETWORK_MAP,
+            name:      networkMap.name,
+            namespace: ns,
+          });
+        }
+
+        if (storageMap?.name) {
+          const ns = storageMap.namespace || namespace;
+          const key = `${ HCI.FORKLIFT_STORAGE_MAP }|${ ns }|${ storageMap.name }`;
+
+          targets.set(key, {
+            type:      HCI.FORKLIFT_STORAGE_MAP,
+            name:      storageMap.name,
+            namespace: ns,
+          });
+        }
+
+        for (const entry of history) {
+          const migrationName = entry?.migration?.name;
+
+          if (!migrationName) {
+            continue;
+          }
+
+          const migrationNs = entry?.migration?.namespace || namespace;
+          const key = `${ HCI.FORKLIFT_MIGRATION }|${ migrationNs }|${ migrationName }`;
+
+          targets.set(key, {
+            type:      HCI.FORKLIFT_MIGRATION,
+            name:      migrationName,
+            namespace: migrationNs,
+          });
+        }
+      }
+
+      return [...targets.values()];
+    },
+
+    async deleteRelatedResources() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+      const targets = this.buildDeleteTargets();
+
+      if (!targets.length) {
+        return;
+      }
+
+      const cache = {
+        [HCI.FORKLIFT_MIGRATION]:   await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_MIGRATION }),
+        [HCI.FORKLIFT_NETWORK_MAP]: await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_NETWORK_MAP }),
+        [HCI.FORKLIFT_STORAGE_MAP]: await this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_STORAGE_MAP }),
+      };
+
+      for (const target of targets) {
+        const matched = (cache[target.type] || []).find((resource) => resource?.metadata?.name === target.name && resource?.metadata?.namespace === target.namespace
+        );
+
+        if (!matched) {
+          continue;
+        }
+
+        try {
+          await matched.remove({ params: { propagationPolicy: 'Background' } });
+
+          if (target.type === HCI.FORKLIFT_MIGRATION) {
+            this.deletedCounts.migration += 1;
+          } else if (target.type === HCI.FORKLIFT_NETWORK_MAP) {
+            this.deletedCounts.networkMap += 1;
+          } else if (target.type === HCI.FORKLIFT_STORAGE_MAP) {
+            this.deletedCounts.storageMap += 1;
+          }
+        } catch (err) {
+          // Continue deleting remaining resources and let final plan deletion fail if needed.
+        }
+      }
+    },
+
+    async remove(buttonDone) {
+      this.errors = [];
+      this.removing = true;
+
+      try {
+        await Promise.all((this.value || []).map((resource) => resource.remove({ params: { propagationPolicy: 'Background' } })));
+        await this.deleteRelatedResources();
+        this.close(buttonDone);
+      } catch (err) {
+        this.errors = exceptionToErrorsArray(err);
+        this.$emit('errors', err);
+        if (buttonDone) {
+          buttonDone(false);
+        }
+      } finally {
+        this.removing = false;
+      }
+    },
+  }
+});
+</script>
+
+<template>
+  <div class="mt-10">
+    <div class="mb-10">
+      {{ t('promptRemove.attemptingToRemove', { type: resourceType }) }}
+      <span v-clean-html="resourceNames(names, null, t)" />
+    </div>
+
+    <hr class="mb-10">
+
+    <div class="mb-10 text-warning">
+      <i class="icon icon-warning icon-lg mr-5" />
+      {{ t('harvester.addons.vmMigration.deleteDialog.warning') }}
+    </div>
+
+    <div
+      v-for="summary in relatedSummary"
+      :key="summary.planName"
+      class="mb-10"
+    >
+      <div>• {{ t('harvester.addons.vmMigration.labels.migration') }}:</div>
+      <template v-if="summary.migrations.length">
+        <div
+          v-for="migration in summary.migrations"
+          :key="`${ migration.namespace }/${ migration.name }`"
+        >
+          <div class="ml-20">
+            - {{ migration.name }}
+          </div>
+        </div>
+      </template>
+      <div
+        v-else
+        class="ml-20"
+      >
+        - -
+      </div>
+
+      <div>• {{ t('harvester.addons.vmMigration.labels.networkMap') }}:</div>
+      <template v-if="summary.networkMap">
+        <div class="ml-20">
+          - {{ summary.networkMap.name }}
+        </div>
+      </template>
+      <div
+        v-else
+        class="ml-20"
+      >
+        - -
+      </div>
+
+      <div>• {{ t('harvester.addons.vmMigration.labels.storageMap') }}:</div>
+      <template v-if="summary.storageMap">
+        <div class="ml-20">
+          - {{ summary.storageMap.name }}
+        </div>
+      </template>
+      <div
+        v-else
+        class="ml-20"
+      >
+        - -
+      </div>
+    </div>
+
+    <Banner
+      v-for="(error, i) in errors"
+      :key="i"
+      color="error"
+      :label="error"
+    />
+  </div>
+</template>

--- a/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
+++ b/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
@@ -48,11 +48,23 @@ export default defineComponent({
     ...mapState('action-menu', ['toRemove']),
     ...mapGetters({ t: 'i18n/t' }),
 
+    existingRelatedResources() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      return {
+        [HCI.FORKLIFT_MIGRATION]:   this.$store.getters[`${ inStore }/all`](HCI.FORKLIFT_MIGRATION) || [],
+        [HCI.FORKLIFT_NETWORK_MAP]: this.$store.getters[`${ inStore }/all`](HCI.FORKLIFT_NETWORK_MAP) || [],
+        [HCI.FORKLIFT_STORAGE_MAP]: this.$store.getters[`${ inStore }/all`](HCI.FORKLIFT_STORAGE_MAP) || [],
+      };
+    },
+
     resourceType() {
       return this.t('typeLabel."forklift.konveyor.io.plan"', { count: this.names?.length || 1 });
     },
 
     relatedSummary() {
+      const existing = this.existingRelatedResources;
+
       return (this.value || []).map((plan) => {
         const planName = plan?.metadata?.name || '-';
         const namespace = plan?.metadata?.namespace || '';
@@ -69,17 +81,24 @@ export default defineComponent({
           }))
           .filter((entry) => !!entry.name)
           .forEach((entry) => {
-            migrationsMap.set(`${ entry.namespace }/${ entry.name }`, entry);
+            const matched = existing[HCI.FORKLIFT_MIGRATION].find((resource) => resource?.metadata?.name === entry.name && resource?.metadata?.namespace === entry.namespace);
+
+            if (matched) {
+              migrationsMap.set(`${ entry.namespace }/${ entry.name }`, entry);
+            }
           });
+
+        const matchedNetworkMap = networkMap?.name && existing[HCI.FORKLIFT_NETWORK_MAP].find((resource) => resource?.metadata?.name === networkMap.name && resource?.metadata?.namespace === (networkMap.namespace || namespace));
+        const matchedStorageMap = storageMap?.name && existing[HCI.FORKLIFT_STORAGE_MAP].find((resource) => resource?.metadata?.name === storageMap.name && resource?.metadata?.namespace === (storageMap.namespace || namespace));
 
         return {
           planName,
           migrations: [...migrationsMap.values()],
-          networkMap: networkMap?.name ? {
+          networkMap: matchedNetworkMap ? {
             namespace: networkMap.namespace || namespace,
             name:      networkMap.name,
           } : null,
-          storageMap: storageMap?.name ? {
+          storageMap: matchedStorageMap ? {
             namespace: storageMap.namespace || namespace,
             name:      storageMap.name,
           } : null,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Add customized migration plan delete model. 
    - Change all resource delete propagationPolicy to `Background`, that related orphans resources can successfully be deleted.
- Fix the error msg in create migration plan wizard
- Show `in-progress` status when first creating plan.


### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/10417

### Test screenshot or video

https://github.com/user-attachments/assets/bcb55e09-de06-4aba-9115-0cdc4524f16d


Before
<img width="1496" height="858" alt="before_msg" src="https://github.com/user-attachments/assets/7057e5d6-3692-46b2-a971-7cbe99918ab6" />

After
<img width="1496" height="855" alt="after_msg" src="https://github.com/user-attachments/assets/5ca89637-86d6-4f31-80db-6af29ece8ba1" />
