### PR TITLE
fix: Rancher vCluster editor to support version-specific valuesContent layout

### DIFF
--- a/pkg/harvester/edit/harvesterhci.io.addon/rancher-vcluster.vue
+++ b/pkg/harvester/edit/harvesterhci.io.addon/rancher-vcluster.vue
@@ -1,14 +1,38 @@
 <script>
-import merge from 'lodash/merge';
-import jsyaml from 'js-yaml';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { RadioGroup } from '@components/Form/Radio';
+import jsyaml from 'js-yaml';
+import merge from 'lodash/merge';
 
-const DEFAUL_VALUE = {
+const DEFAULT_VALUE = {
   hostname:          '',
   rancherVersion:    '',
   bootstrapPassword: '',
+  global:            {
+    hostname:          '',
+    rancherVersion:    '',
+    bootstrapPassword: '',
+  },
 };
+
+// v0.19.0 stores values at the root. All later versions store them under "global".
+function usesGlobalValuesFor(version) {
+  return version !== 'v0.19.0';
+}
+
+function pruneToActiveLayout(values, usesGlobalValues) {
+  const pruned = merge({}, values);
+
+  if (usesGlobalValues) {
+    delete pruned.hostname;
+    delete pruned.rancherVersion;
+    delete pruned.bootstrapPassword;
+  } else {
+    delete pruned.global;
+  }
+
+  return pruned;
+}
 
 export default {
   name:       'EditAddonVcluster',
@@ -24,7 +48,7 @@ export default {
 
     mode: {
       type:     String,
-      required: true
+      required: true,
     },
     registerBeforeHook: {
       type:     Function,
@@ -36,17 +60,51 @@ export default {
     let valuesContentJson = {};
 
     try {
-      valuesContentJson = merge({}, DEFAUL_VALUE, jsyaml.load(this.value.spec.valuesContent));
+      valuesContentJson = merge({}, DEFAULT_VALUE, jsyaml.load(this.value.spec.valuesContent));
     } catch (err) {
-      valuesContentJson = DEFAUL_VALUE;
+      valuesContentJson = merge({}, DEFAULT_VALUE);
 
       this.$store.dispatch('growl/fromError', {
         title: this.$store.getters['i18n/t']('generic.notification.title.error'),
         err:   err.data || err,
       }, { root: true });
     }
+    valuesContentJson = pruneToActiveLayout(valuesContentJson, usesGlobalValuesFor(this.value.spec.version));
 
     return { valuesContentJson };
+  },
+
+  computed: {
+    usesGlobalValues() {
+      return usesGlobalValuesFor(this.value.spec.version);
+    },
+
+    hostname: {
+      get() {
+        return this.getValuesRoot().hostname;
+      },
+      set(value) {
+        this.getValuesRoot().hostname = value;
+      },
+    },
+
+    rancherVersion: {
+      get() {
+        return this.getValuesRoot().rancherVersion;
+      },
+      set(value) {
+        this.getValuesRoot().rancherVersion = value;
+      },
+    },
+
+    bootstrapPassword: {
+      get() {
+        return this.getValuesRoot().bootstrapPassword;
+      },
+      set(value) {
+        this.getValuesRoot().bootstrapPassword = value;
+      },
+    },
   },
 
   created() {
@@ -56,6 +114,18 @@ export default {
   },
 
   methods: {
+    getValuesRoot() {
+      if (this.usesGlobalValues) {
+        if (!this.valuesContentJson.global || typeof this.valuesContentJson.global !== 'object' || Array.isArray(this.valuesContentJson.global)) {
+          this.valuesContentJson.global = merge({}, DEFAULT_VALUE.global);
+        }
+
+        return this.valuesContentJson.global;
+      }
+
+      return this.valuesContentJson;
+    },
+
     willSave() {
       const errors = [];
 
@@ -63,26 +133,26 @@ export default {
         return Promise.resolve();
       }
 
-      if (!this.valuesContentJson.hostname) {
+      if (!this.hostname) {
         errors.push(this.t('validation.required', { key: this.t('harvester.addons.rancherVcluster.hostname') }, true));
       }
 
-      if (!this.valuesContentJson.bootstrapPassword) {
+      if (!this.bootstrapPassword) {
         errors.push(this.t('validation.required', { key: this.t('harvester.addons.rancherVcluster.password') }, true));
       }
 
-      if (errors.length > 0) {
+      if (errors.length) {
         return Promise.reject(errors);
-      } else {
-        return Promise.resolve();
       }
+
+      return Promise.resolve();
     },
   },
 
   watch: {
     valuesContentJson: {
       handler(neu) {
-        this.value.spec['valuesContent'] = jsyaml.dump(neu);
+        this.value.spec.valuesContent = jsyaml.dump(pruneToActiveLayout(neu, this.usesGlobalValues));
       },
       deep:      true,
       immediate: true
@@ -100,7 +170,7 @@ export default {
           class="mb-20"
           name="model"
           :mode="mode"
-          :options="[true,false]"
+          :options="[true, false]"
           :labels="[t('generic.enabled'), t('generic.disabled')]"
         />
       </div>
@@ -110,7 +180,7 @@ export default {
       <div class="row mb-20">
         <div class="col span-6">
           <LabeledInput
-            v-model:value="valuesContentJson.hostname"
+            v-model:value="hostname"
             label-key="harvester.addons.rancherVcluster.hostname"
             :required="true"
             :mode="mode"
@@ -120,7 +190,7 @@ export default {
 
         <div class="col span-6">
           <LabeledInput
-            v-model:value="valuesContentJson.rancherVersion"
+            v-model:value="rancherVersion"
             label-key="harvester.addons.rancherVcluster.rancherVersion"
             :required="true"
             :disabled="true"
@@ -131,7 +201,7 @@ export default {
       <div class="row mt-20">
         <div class="col span-6">
           <LabeledInput
-            v-model:value="valuesContentJson.bootstrapPassword"
+            v-model:value="bootstrapPassword"
             label-key="harvester.addons.rancherVcluster.password"
             :mode="mode"
             :required="true"
@@ -144,10 +214,11 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  :deep() .radio-group {
-    display: flex;
-    .radio-container {
-      margin-right: 30px;
-    }
+:deep() .radio-group {
+  display: flex;
+
+  .radio-container {
+    margin-right: 30px;
   }
+}
 </style>


### PR DESCRIPTION
Fix the Rancher vCluster addon editor to correctly read and write spec.valuesContent based on the addon version.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

The Rancher vCluster addon editor always binds the editable fields (hostname, rancherVersion, and bootstrapPassword) to the root of spec.valuesContent, regardless of the addon version.

fix:

The frontend intentionally mirrors the backend validator. The backend special-cases only v0.19.0; every other version uses the global layout:

```
if newAddon.Spec.Version == vCluster0190 {
    hostname = addonContent.Hostname
} else {
    hostname = addonContent.Global.Hostname
}
```

The UI follows the same behavior to avoid diverging from the backend.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is:

### Related Issue #
https://github.com/harvester/harvester/issues/11172
<!-- Define findings related to the feature or bug issue. -->

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->




