### PR TITLE
fix: stale cloud-init secret name reused after VM name change

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -484,6 +484,18 @@ export default {
         await value.save();
         await this.applyHooks(AFTER_SAVE_HOOKS);
       } catch (e) {
+        // Reset the generated secret name(s) so a retried create (e.g. after correcting an
+        // invalid/duplicate VM name) always regenerates them from the current name instead of
+        // reusing names derived from this failed attempt. Only do this for create: in edit mode
+        // secretName/sysprep.secretName may reference an existing secret loaded from the VM,
+        // which must not be discarded. See harvester/harvester#11174.
+        if (this.isCreate) {
+          this.secretName = '';
+          this.secretNamePrefixUsed = '';
+          this.sysprep.secretName = '';
+          this.sysprepSecretNamePrefixUsed = '';
+        }
+
         this.errors.push(...exceptionToErrorsArray(e));
         buttonCb(false);
       }

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -492,8 +492,11 @@ export default {
         if (this.isCreate) {
           this.secretName = '';
           this.secretNamePrefixUsed = '';
-          this.sysprep.secretName = '';
-          this.sysprepSecretNamePrefixUsed = '';
+          if (this.sysprepSecretNamePrefixUsed !== '') {
+            this.sysprep.secretName = '';
+            this.sysprepSecretNamePrefixUsed = '';
+          }
+          console.log('create ')
         }
 
         this.errors.push(...exceptionToErrorsArray(e));

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -496,7 +496,6 @@ export default {
             this.sysprep.secretName = '';
             this.sysprepSecretNamePrefixUsed = '';
           }
-          console.log('create ')
         }
 
         this.errors.push(...exceptionToErrorsArray(e));

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -162,6 +162,12 @@ export default {
       machineType:                   '',
       machineTypes:                  [],
       secretName:                    '',
+      // Tracks the name prefix that `secretName` was generated from, so it can be
+      // regenerated if the VM name changes (e.g. after a failed create attempt is retried
+      // with a different name). See harvester/harvester#11174.
+      secretNamePrefixUsed:          '',
+      // Same purpose as secretNamePrefixUsed, but for the Windows sysprep secret name.
+      sysprepSecretNamePrefixUsed:   '',
       secretRef:                     null,
       showAdvanced:                  false,
       deleteAgent:                   true,
@@ -866,18 +872,30 @@ export default {
         }
       });
 
-      if (this.needNewSecret || !this.secretName) {
+      // Regenerate the cloud-init secret name whenever it hasn't been generated yet, or the VM
+      // name has changed since it was last generated (e.g. a previous create attempt failed with
+      // an invalid/duplicate name and the user corrected it). Without this, a stale secret name
+      // derived from a rejected attempt gets reused for the VM that's actually created.
+      // See harvester/harvester#11174.
+      if (this.needNewSecret || !this.secretName || (this.isCreate && this.secretNamePrefixUsed !== this.secretNamePrefix)) {
         this.secretName = this.generateSecretName(this.secretNamePrefix);
+        this.secretNamePrefixUsed = this.secretNamePrefix;
       }
 
       if (!disks.find((D) => D.name === 'sysprep') && this.isWindows) {
         const hasSysprepContent = !!this.sysprep.xmlContent?.trim?.();
 
-        // If we have content but no secret name, it's a new secret that needs a name.
-        if (hasSysprepContent && !this.sysprep.secretName?.trim?.()) {
+        // If we have content but no secret name, it's a new secret that needs a name. Also
+        // regenerate when creating a VM if the name prefix has changed since it was last
+        // generated (see the secretName regeneration comment above for context).
+        const sysprepNeedsNewSecretName = !this.sysprep.secretName?.trim?.() ||
+          (this.isCreate && this.sysprepSecretNamePrefixUsed !== this.secretNamePrefix);
+
+        if (hasSysprepContent && sysprepNeedsNewSecretName) {
           const prefix = this.secretNamePrefix ? `${ this.secretNamePrefix }-windows-sysprep` : 'windows-sysprep';
 
           this.sysprep.secretName = `${ this.value.metadata.namespace }/${ this.generateSecretName(prefix) }`;
+          this.sysprepSecretNamePrefixUsed = this.secretNamePrefix;
         }
 
         // Preserve/attach sysprep whenever a secret is selected/known.

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -881,15 +881,16 @@ export default {
         this.secretName = this.generateSecretName(this.secretNamePrefix);
         this.secretNamePrefixUsed = this.secretNamePrefix;
       }
+      console.log('secretNamePrefixUsed=', this.secretNamePrefixUsed, 'secretNamePrefix=', this.secretNamePrefix);
 
       if (!disks.find((D) => D.name === 'sysprep') && this.isWindows) {
         const hasSysprepContent = !!this.sysprep.xmlContent?.trim?.();
 
         // If we have content but no secret name, it's a new secret that needs a name. Also
         // regenerate when creating a VM if the name prefix has changed since it was last
-        // generated (see the secretName regeneration comment above for context).
+        // generated.
         const sysprepNeedsNewSecretName = !this.sysprep.secretName?.trim?.() ||
-          (this.isCreate && this.sysprepSecretNamePrefixUsed !== this.secretNamePrefix);
+          (this.isCreate && this.sysprepSecretNamePrefixUsed !== '' && this.sysprepSecretNamePrefixUsed !== this.secretNamePrefix);
 
         if (hasSysprepContent && sysprepNeedsNewSecretName) {
           const prefix = this.secretNamePrefix ? `${ this.secretNamePrefix }-windows-sysprep` : 'windows-sysprep';

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -881,7 +881,6 @@ export default {
         this.secretName = this.generateSecretName(this.secretNamePrefix);
         this.secretNamePrefixUsed = this.secretNamePrefix;
       }
-      console.log('secretNamePrefixUsed=', this.secretNamePrefixUsed, 'secretNamePrefix=', this.secretNamePrefix);
 
       if (!disks.find((D) => D.name === 'sysprep') && this.isWindows) {
         const hasSysprepContent = !!this.sysprep.xmlContent?.trim?.();


### PR DESCRIPTION
### Summary
Root cause: in `pkg/harvester/mixins/harvester-vm/index.js`, `secretName` (and the Windows sysprep secret name) is generated once via `parseDiskRows()` and cached for the component's lifetime during create, since `needNewSecret` is always `false` while creating. It was never regenerated when the VM name changed between save attempts.

Fix:
- Track the name prefix that was used to generate `secretName` / the sysprep secret name, and regenerate whenever the current VM name no longer matches it (create mode only).
- Proactively reset the secret name state in the `_save()` catch block on a failed create attempt, so any retry always starts fresh, regardless of why the previous attempt failed.

### PR Checklists
- Are backend engineers aware of UI changes ?
    - [ ] N/A - frontend-only fix.

### Related Issue #
harvester/harvester#11174

### Test screenshot or video

https://github.com/user-attachments/assets/1cdec3e4-8de1-4914-8ede-1244dd8914c0


Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
