### PR TITLE
fix: remove bootable volume validation in VM disk validator

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -487,7 +487,6 @@ harvester:
       volume:
         upperType: Volume name
         lowerType: volume name
-        needAtLeastOneBootable: 'At least one bootable volume is required!'
     image:
       ruleTip: 'The URL you have entered ends in an extension that we do not support. We only accept image files that end in .img, .iso, .qcow, .qcow2, .raw.'
       ruleFileTip: 'The file you have chosen ends in an extension that we do not support. We only accept image files that end in .img, .iso, .qcow, .qcow2, .raw.'

--- a/pkg/harvester/validators/vm.js
+++ b/pkg/harvester/validators/vm.js
@@ -69,16 +69,10 @@ export function vmDisks(spec, getters, errors, validatorArgs, displayKey, value)
     validName(getters, errors, D.name, diskNames, prefix, type, lowerType, upperType);
   });
 
-  let hasBootableVolume = false;
-
   _volumes.forEach((V, idx) => {
     const { type, typeValue } = getVolumeType(getters, V, _volumeClaimTemplates, value);
 
     const prefix = V.name || idx + 1;
-
-    if ([SOURCE_TYPE.IMAGE, SOURCE_TYPE.ATTACH_VOLUME, SOURCE_TYPE.CONTAINER].includes(type)) {
-      hasBootableVolume = true;
-    }
 
     if (type === SOURCE_TYPE.NEW || type === SOURCE_TYPE.IMAGE) {
       if (!/([1-9]|[1-9][0-9]+)[a-zA-Z]+/.test(typeValue?.spec?.resources?.requests?.storage)) {
@@ -135,13 +129,6 @@ export function vmDisks(spec, getters, errors, validatorArgs, displayKey, value)
       errors.push(getters['i18n/t']('harvester.validation.generic.tabError', { prefix, message }));
     }
   });
-
-  /**
-   *  At least one bootable volume must be provided.  (Verify only when create.)
-   */
-  if (!hasBootableVolume && !value.links) {
-    errors.push(getters['i18n/t']('harvester.validation.vm.volume.needAtLeastOneBootable'));
-  }
 
   return errors;
 }


### PR DESCRIPTION
### Summary
Remove the UI-level validation that blocks VM creation when no bootable volume is present. The check `!hasBootableVolume && !value.links` which pushed an error for `harvester.validation.vm.volume.needAtLeastOneBootable` has been removed from the `vmDisks` validator, along with the now-unused `hasBootableVolume` tracking variable.

### PR Checklist
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue #
harvester/harvester#10584

### Test screenshot or video (Required)

https://github.com/user-attachments/assets/dfc675a1-b61b-4992-9e80-7a56df641e5b


