### PR TITLE
docs: add XSS safety comment for VM display name annotation

### DIFF
--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/index.vue
@@ -93,6 +93,9 @@ export default {
 
     const hostname = this.value.spec.template.spec.hostname || '';
 
+    // Display name can contain arbitrary strings. There is no XSS risk because the value is
+    // rendered via Vue's {{ }} interpolation which auto-escapes HTML; v-html is never used for
+    // this field. See harvester/harvester#10423 for details.
     const customizeDisplayName = !!(this.value.metadata?.annotations?.[HCI_ANNOTATIONS.VM_DISPLAY_NAME]);
 
     return {


### PR DESCRIPTION
### Summary

https://github.com/harvester/harvester/issues/10423#issuecomment-4990176439

Add a code comment on the `customizeDisplayName` data property in the VM edit page to document that the display name field accepts arbitrary strings without XSS risk. The value is stored as a Kubernetes annotation (`harvesterhci.io/vmDisplayName`) and is rendered exclusively via Vue's `{{ }}` text interpolation, which auto-escapes HTML. `v-html` is never used for this field. See harvester/harvester#10423 for details.

### PR Checklist
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue #
harvester/harvester#10423

### Test screenshot or video (Required)
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
