### PR TITLE
ci: support scoped commit prefixes in PR label extraction

### DIFF
--- a/scripts/extract-release-label.mjs
+++ b/scripts/extract-release-label.mjs
@@ -7,7 +7,11 @@ if (process.argv.length < 3) {
 }
 
 const prTitle = process.argv[2];
-const prLabel = prTitle.split(':')[0].trim();
+
+// Parse the conventional-commit prefix `type(scope)!:`, keeping only the type
+// and dropping an optional scope and breaking-change marker.
+const prefixMatch = prTitle.match(/^\s*([a-zA-Z]+)(?:\([^)]*\))?!?:/);
+const prLabel = prefixMatch ? prefixMatch[1].toLowerCase() : '';
 
 const config = await load({ extends: ["./commitlint.config.js"] });
 const commitPrefix = config?.rules?.['type-enum']?.[2] || [];


### PR DESCRIPTION
### Summary
<!-- Give the fix root cause or feature requirement, at least list what this PR changes  -->
`extract-release-label.mjs` split the PR title on `:` only, so scoped conventional-commit titles like `refactor(host): ...` produced the label `refactor(host)`, which is not in the `type-enum` list and therefore fell back to `other`.

This PR also strips the scope in parentheses so the extracted label matches the base type (e.g. `refactor(host): ...` → `refactor`). Titles without a scope are unaffected.

### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue #
 <!-- Link the issue as harvester/harvester#<issue_number> -->
 N/A

### Test screenshot or video (Required)
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
_To be attached._
