### PR TITLE
feat(vm-migration): show elapsed duration for in-progress plans

### DIFF
--- a/pkg/harvester/pages/c/_cluster/vm-migration/index.vue
+++ b/pkg/harvester/pages/c/_cluster/vm-migration/index.vue
@@ -99,12 +99,12 @@ const formatPipelineTooltip = (pipeline = []) => {
 };
 
 const formatDuration = (started, completed) => {
-  if (!started || !completed) {
+  if (!started) {
     return { display: null, seconds: -1 };
   }
 
   const startMs = new Date(started).getTime();
-  const endMs = new Date(completed).getTime();
+  const endMs = completed ? new Date(completed).getTime() : Date.now();
 
   if (isNaN(startMs) || isNaN(endMs) || endMs < startMs) {
     return { display: null, seconds: -1 };


### PR DESCRIPTION
### Summary
Fix the VM migration duration column so in-progress plans show elapsed runtime instead of an em-dash.

Root cause: `formatDuration` required both `started` and `completed`, so active migrations with only `started` set returned an empty display value.

Changes in this PR:
- Use `Date.now()` as the end time when `completed` is missing
- Keep the placeholder behavior only when `started` is missing or timestamps are invalid

### PR Checklist
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue #
harvester/harvester#10417

### Test screenshot or video (Required)
<img width="1462" height="807" alt="Screenshot 2026-07-20 at 4 53 53 PM" src="https://github.com/user-attachments/assets/5eb7eedd-68bf-4f83-b828-597853a83433" />

