### PR TITLE
fix: Creating a VM with no cloud init user data but network data only fails

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -914,7 +914,7 @@ export default {
         }
       }
 
-      if (!disks.find( (D) => D.name === 'cloudinitdisk') && (this.userData || this.networkData)) {
+      if (!disks.find( (D) => D.name === 'cloudinitdisk') && (this.userData || this.networkScript)) {
         if (!this.isWindows) {
           disks.push({
             name: 'cloudinitdisk',


### PR DESCRIPTION
### Summary
Creating a VM with the following CloudInit settings fails; the data is not stored in the ConfigMap CRs.

### Related Issue #
https://github.com/harvester/harvester/issues/11213


### Test screenshot or video (Required)
- Create a VM. Populate all necessary field in the `Basic` and `Volumes` tab.
- Go to the `Advanced`.
- Clear the `User Data` field.
- Add the following to the `Network Data` field:
```
network:
  version: 2
  ethernets: {}
```
- Press `Save`.
- Edit the VM again by using the `Edit Config` action menu.
- The field `Network Data` MUST contain the previously added content. The `User Data` field is empty.

<img width="805" height="1629" alt="grafik" src="https://github.com/user-attachments/assets/37d23a41-d98a-4386-aeae-15560239764c" />



