### PR TITLE
feat: validate migration plan name against existing providers and plans

### DIFF
--- a/pkg/harvester/components/vm-migration/ReviewMigrationStep.vue
+++ b/pkg/harvester/components/vm-migration/ReviewMigrationStep.vue
@@ -35,6 +35,8 @@ const storageMappings = ref([]);
 const planName = ref('');
 const targetNamespace = ref('');
 const namespaceOptions = ref([]);
+const existingProviderNames = ref([]);
+const existingPlanNames = ref([]);
 const errors = ref([]);
 const loading = ref(true);
 
@@ -44,6 +46,24 @@ targetNamespace.value = props.stepData.targetNamespace || '';
 
 const NS = FORKLIFT_NAMESPACE;
 
+const nameConflictError = computed(() => {
+  const name = (planName.value || '').trim();
+
+  if (!name) {
+    return '';
+  }
+
+  if (existingProviderNames.value.includes(name)) {
+    return t('harvester.addons.vmMigration.reviewMigration.planNameProviderConflict', { name });
+  }
+
+  if (existingPlanNames.value.includes(name)) {
+    return t('harvester.addons.vmMigration.reviewMigration.planNamePlanConflict', { name });
+  }
+
+  return '';
+});
+
 watch(planName, (val) => {
   props.stepData.planName = val;
 }, { immediate: true });
@@ -52,8 +72,8 @@ watch(targetNamespace, (val) => {
   props.stepData.targetNamespace = val;
 });
 
-watch([planName, targetNamespace], ([name, namespace]) => {
-  emit('ready', !!name && !!namespace);
+watch([planName, targetNamespace, nameConflictError], () => {
+  emit('ready', !!planName.value && !!targetNamespace.value && !nameConflictError.value);
 }, { immediate: true });
 
 const formatNetworkTarget = (target = '') => {
@@ -282,6 +302,22 @@ const init = async() => {
     namespaceOptions.value = [];
   }
 
+  try {
+    await store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_PROVIDER });
+  } catch (e) {}
+
+  existingProviderNames.value = (store.getters[`${ inStore }/all`](HCI.FORKLIFT_PROVIDER) || [])
+    .map((p) => p.metadata?.name)
+    .filter(Boolean);
+
+  try {
+    await store.dispatch(`${ inStore }/findAll`, { type: HCI.FORKLIFT_PLAN });
+  } catch (e) {}
+
+  existingPlanNames.value = (store.getters[`${ inStore }/all`](HCI.FORKLIFT_PLAN) || [])
+    .map((p) => p.metadata?.name)
+    .filter(Boolean);
+
   if (props.mappingEntries) {
     networkMappings.value = (props.mappingEntries.networkEntries || []).map((entry) => ({
       source: entry.name || entry.id,
@@ -313,6 +349,12 @@ defineExpose({ startMigration: startMigrationAction });
     <div
       class="review-migration-content"
     >
+      <Banner
+        v-if="nameConflictError"
+        color="error"
+        :label="nameConflictError"
+      />
+
       <!-- Migration Details Summary -->
       <div class="migration-details">
         <div class="section-header">

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1984,6 +1984,8 @@ harvester:
         description: Confirm your migration settings before starting the transfer of VMs to the target cluster.
         planName: Name
         planNamePlaceholder: "e.g. my-migration-plan"
+        planNameProviderConflict: 'The name “{name}” is already used by an existing provider. Please input a different plan name.'
+        planNamePlanConflict: 'The name “{name}” is already used by an existing migration plan. Please input a different plan name.'
         migrationDetails: Migration Details
         migrationDetailsDescription: Name this plan and choose the namespace where migrated VMs will be created.
         totalVms: Total VMs


### PR DESCRIPTION
### Summary
Validate the migration plan name on the Review step (Step 4) of the VM Migration wizard.

- When the entered plan name matches an existing **provider** name, or an existing **migration plan** name, an error banner is shown above the Migration Details section.
- While a conflict exists, the **Create and Start** action is disabled.
- Existing provider/plan names are loaded independently so a failure loading one list does not suppress validation for the other.

### PR Checklist
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue #
harvester/harvester#10417

### Test screenshot or video (Required)
<img width="1258" height="732" alt="Screenshot 2026-07-24 at 4 31 31 PM" src="https://github.com/user-attachments/assets/b07f5b90-c21c-445a-8d7a-63b86e861dd7" />
<img width="1266" height="730" alt="Screenshot 2026-07-24 at 4 31 26 PM" src="https://github.com/user-attachments/assets/b27cebb6-21db-494b-9095-a6cbb6e14406" />

