### PR TITLE
feat: add VMware VDDK image input field to VM migration provider

### DIFF
--- a/pkg/harvester/components/vm-migration/ConfigureProviderStep.vue
+++ b/pkg/harvester/components/vm-migration/ConfigureProviderStep.vue
@@ -131,7 +131,7 @@ watch(selectedProvider, (val) => {
 });
 
 // Reset test state when any field changes (only for create new)
-watch([providerName, url, username, password, vddkInitImage], () => {
+watch([providerName, url, username, password], () => {
   if (!isExistingProvider.value) {
     testPassed.value = false;
     testResult.value = null;

--- a/pkg/harvester/components/vm-migration/ConfigureProviderStep.vue
+++ b/pkg/harvester/components/vm-migration/ConfigureProviderStep.vue
@@ -42,6 +42,7 @@ const {
   username,
   password,
   skipTlsVerify,
+  vddkInitImage,
   testPassed,
   testResult,
   testError,
@@ -97,6 +98,7 @@ watch(selectedProvider, (val) => {
     username.value = '';
     password.value = '';
     skipTlsVerify.value = false;
+    vddkInitImage.value = '';
     createdProvider.value = null;
     createdSecret.value = null;
   } else {
@@ -107,6 +109,7 @@ watch(selectedProvider, (val) => {
     if (provider) {
       providerName.value = provider.metadata.name;
       url.value = provider.spec?.url || '';
+      vddkInitImage.value = provider.spec?.settings?.vddkInitImage || '';
 
       const secretRef = provider.spec?.secret;
 
@@ -128,7 +131,7 @@ watch(selectedProvider, (val) => {
 });
 
 // Reset test state when any field changes (only for create new)
-watch([providerName, url, username, password], () => {
+watch([providerName, url, username, password, vddkInitImage], () => {
   if (!isExistingProvider.value) {
     testPassed.value = false;
     testResult.value = null;
@@ -239,6 +242,18 @@ const testConnection = async(buttonCb) => {
   if (props.editMode && createdProvider.value) {
     try {
       createdProvider.value.spec.url = url.value;
+
+      const vddkImage = vddkInitImage.value?.trim();
+
+      if (vddkImage) {
+        createdProvider.value.spec.settings = {
+          ...(createdProvider.value.spec.settings || {}),
+          vddkInitImage: vddkImage,
+        };
+      } else if (createdProvider.value.spec.settings) {
+        delete createdProvider.value.spec.settings.vddkInitImage;
+      }
+
       await createdProvider.value.save();
 
       const secretRef = createdProvider.value.spec?.secret;
@@ -283,20 +298,28 @@ const testConnection = async(buttonCb) => {
     const namespace = FORKLIFT_NAMESPACE;
     const secretName = `${ providerName.value }-creds-${ randomStr(4).toLowerCase() }`;
 
+    const spec = {
+      type:   'vsphere',
+      url:    url.value,
+      secret: {
+        name: secretName,
+        namespace,
+      },
+    };
+
+    const vddkImage = vddkInitImage.value?.trim();
+
+    if (vddkImage) {
+      spec.settings = { vddkInitImage: vddkImage };
+    }
+
     const provider = await store.dispatch(`${ inStore }/create`, {
       type:     HCI.FORKLIFT_PROVIDER,
       metadata: {
         name: providerName.value,
         namespace,
       },
-      spec: {
-        type:   'vsphere',
-        url:    url.value,
-        secret: {
-          name: secretName,
-          namespace,
-        },
-      }
+      spec,
     });
 
     await provider.save();
@@ -420,17 +443,28 @@ defineExpose({ testConnection, clickTestButton });
           />
         </div>
 
-        <div>
-          <LabeledInput
-            v-model:value="url"
-            :label="t('harvester.addons.vmMigration.configureProvider.urlLabel')"
-            :placeholder="t('harvester.addons.vmMigration.configureProvider.urlPlaceholder')"
-            :disabled="isExistingProvider && !editMode"
-            required
-          />
-          <p class="text-deemphasized mt-5">
-            {{ t('harvester.addons.vmMigration.configureProvider.urlHint') }}
-          </p>
+        <div class="row">
+          <div class="col span-6">
+            <LabeledInput
+              v-model:value="url"
+              :label="t('harvester.addons.vmMigration.configureProvider.urlLabel')"
+              :placeholder="t('harvester.addons.vmMigration.configureProvider.urlPlaceholder')"
+              :disabled="isExistingProvider && !editMode"
+              required
+            />
+            <p class="text-deemphasized mt-5">
+              {{ t('harvester.addons.vmMigration.configureProvider.urlHint') }}
+            </p>
+          </div>
+          <div class="col span-6">
+            <LabeledInput
+              v-model:value="vddkInitImage"
+              :label="t('harvester.addons.vmMigration.configureProvider.vddkImageLabel')"
+              :placeholder="t('harvester.addons.vmMigration.configureProvider.vddkImagePlaceholder')"
+              :tooltip="t('harvester.addons.vmMigration.configureProvider.vddkImageTooltip')"
+              :disabled="isExistingProvider && !editMode"
+            />
+          </div>
         </div>
 
         <div class="row">

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -1898,6 +1898,9 @@ harvester:
         urlLabel: vCenter/ESXi URL
         urlPlaceholder: "https://vcenter.example.com/sdk"
         urlHint: Enter the full URL including https://
+        vddkImageLabel: VMware VDDK Image
+        vddkImagePlaceholder: "[your-private-registry]/vddk-image:latest"
+        vddkImageTooltip: Specify the VMware VDDK (Virtual Disk Development Kit) Image to accelerate and optimize VMware virtual machine migration.
         skipSsl: Skip SSL certificate verification
         skipSslHint: Not recommended for production environments
         testConnection:

--- a/pkg/harvester/pages/c/_cluster/vm-migration/provider-wizard.vue
+++ b/pkg/harvester/pages/c/_cluster/vm-migration/provider-wizard.vue
@@ -46,6 +46,7 @@ const stepData = reactive({
     username:         '',
     password:         '',
     skipTlsVerify:    false,
+    vddkInitImage:    '',
     testPassed:       false,
     testResult:       null,
     testError:        null,
@@ -193,6 +194,7 @@ const init = async() => {
     stepData.provider.selectedProvider = fetchedProvider.metadata.name;
     stepData.provider.providerName = fetchedProvider.metadata.name;
     stepData.provider.url = fetchedProvider.spec?.url || '';
+    stepData.provider.vddkInitImage = fetchedProvider.spec?.settings?.vddkInitImage || '';
     stepData.provider.createdProvider = fetchedProvider;
 
     const secretRef = fetchedProvider.spec?.secret;

--- a/pkg/harvester/pages/c/_cluster/vm-migration/vm-migration-wizard.vue
+++ b/pkg/harvester/pages/c/_cluster/vm-migration/vm-migration-wizard.vue
@@ -41,6 +41,7 @@ const stepData = reactive({
     username:         '',
     password:         '',
     skipTlsVerify:    false,
+    vddkInitImage:    '',
     testPassed:       false,
     testResult:       null,
     testError:        null,


### PR DESCRIPTION
### Summary
Add an optional **VMware VDDK Image** field to the Configure Provider step of the VM migration wizard.

- New input placed on the same row as the vCenter/ESXi URL, with a tooltip and an example placeholder (`[your-private-registry]/vddk-image:latest`).
- When a value is provided it is bound to `spec.settings.vddkInitImage` on the Forklift provider; when left empty (or whitespace) it is not set.
- Works for both create and edit flows, and is populated from the existing provider value when editing.



### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is @ibrokethecloud 
    - [] No, frontend-only.

### Related Issue #
 harvester/harvester#10417

### Test screenshot or video (Required)

Test Steps: 
1. Configure **VMware VDDK Image** field in create provider page, the image path should set in `spec.settings.vddkInitImage`
<img width="1464" height="808" alt="image" src="https://github.com/user-attachments/assets/a5878b3a-3a0e-4aee-92fc-169f6bafc7be" />



2. Go to migration plan creatino page, choose the the provider you created in first step.
<img width="1470" height="804" alt="Screenshot 2026-07-27 at 3 54 06 PM" src="https://github.com/user-attachments/assets/9a01a432-0189-4577-9dea-121aff21b0ba" />




