### PR TITLE
ci: trigger standalone build when PR labeled with build-artifact

### DIFF
--- a/.github/workflows/build-standalone-on-merge.yaml
+++ b/.github/workflows/build-standalone-on-merge.yaml
@@ -38,4 +38,7 @@ jobs:
       packages: write
       id-token: write
     with:
-      CI_BRANCH: ${{github.ref_name}}
+      # For PR-triggered runs github.ref_name is "<prNumber>/merge" (not a real
+      # branch), which breaks the upload gate. Leave CI_BRANCH empty for PRs so
+      # the gate is skipped; use the real branch name for push events.
+      CI_BRANCH: ${{ github.event_name == 'pull_request' && '' || github.ref_name }}

--- a/.github/workflows/build-standalone-on-merge.yaml
+++ b/.github/workflows/build-standalone-on-merge.yaml
@@ -13,13 +13,23 @@ on:
       - '*-dev'
     types:
       - merged
+      - labeled
 
 jobs:
   build-validation:
     name: Build Test
+    # allow triggering when a PR is labeled with "build-artifact"
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'build-artifact'
     uses: ./.github/workflows/run-lint.yaml
   build:
     name: Build and Upload Package
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'build-artifact'
     uses: ./.github/workflows/build-and-publish-standalone.yaml
     needs:
       - build-validation


### PR DESCRIPTION
### Summary
<!-- Give the fix root cause or feature requirement, at least list what this PR changes  -->
Adds the ability to trigger the standalone build workflow on demand for a PR branch by applying the `build-artifact` label, without having to add each branch name to `push.branches`.

Changes to `.github/workflows/build-standalone-on-merge.yaml`:
- Add `labeled` to `pull_request` activity types (existing `merged` and `push` triggers are unchanged).
- Guard both jobs with an `if` condition so that for `labeled` events the workflow only runs when the label is `build-artifact`; all other existing triggers continue to run as before.

### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue #
 <!-- Link the issue as harvester/harvester#<issue_number> -->



### Test screenshot or video (Required)

觸發情境 | (A) | (B) | (C) | 結果
-- | -- | -- | -- | --
push | true | — | — | ✅ 執行
PR merged | false | true | — | ✅ 執行
PR 貼 build-artifact | false | false | true | ✅ 執行
PR 貼其他 label(如 bug) | false | false | false | ⛔ skip


