### PR TITLE
ci: fix CI_BRANCH ternary so PR builds skip upload gate

### DIFF
--- a/.github/workflows/build-standalone-on-merge.yaml
+++ b/.github/workflows/build-standalone-on-merge.yaml
@@ -39,6 +39,9 @@ jobs:
       id-token: write
     with:
       # For PR-triggered runs github.ref_name is "<prNumber>/merge" (not a real
-      # branch), which breaks the upload gate. Leave CI_BRANCH empty for PRs so
-      # the gate is skipped; use the real branch name for push events.
-      CI_BRANCH: ${{ github.event_name == 'pull_request' && '' || github.ref_name }}
+      # branch), which breaks the upload gate. Only pass a branch for push
+      # events (github.ref_name is truthy there); PRs get '' so the gate skips.
+      # Note: the A && B || C ternary requires B to be truthy, so the push
+      # branch must be on the && side (an empty string on the && side would
+      # always fall through to C).
+      CI_BRANCH: ${{ github.event_name == 'push' && github.ref_name || '' }}

--- a/.github/workflows/build-standalone-on-merge.yaml
+++ b/.github/workflows/build-standalone-on-merge.yaml
@@ -38,10 +38,4 @@ jobs:
       packages: write
       id-token: write
     with:
-      # For PR-triggered runs github.ref_name is "<prNumber>/merge" (not a real
-      # branch), which breaks the upload gate. Only pass a branch for push
-      # events (github.ref_name is truthy there); PRs get '' so the gate skips.
-      # Note: the A && B || C ternary requires B to be truthy, so the push
-      # branch must be on the && side (an empty string on the && side would
-      # always fall through to C).
       CI_BRANCH: ${{ github.event_name == 'push' && github.ref_name || '' }}


### PR DESCRIPTION
### Summary
<!-- Give the fix root cause or feature requirement, at least list what this PR changes  -->
Follow-up fix for #1058. The `build-artifact` label trigger merged in #1058 used an incorrect GitHub Actions ternary for `CI_BRANCH`:

```yaml
CI_BRANCH: ${{ github.event_name == 'pull_request' && '' || github.ref_name }}
```

In GitHub expressions `A && B || C` only yields `B` when `B` is truthy. Since `''` is falsy, this always fell through to `github.ref_name`, which for PR runs is `<prNumber>/merge` (not a real branch). The upload gate then queried a non-existent branch and crashed (`TypeError: Cannot read properties of undefined (reading 'sha')`), failing PR-triggered standalone builds.

Fix: flip the ternary so the truthy branch name is on the `&&` side, yielding `''` for PRs so the gate is skipped:

```yaml
CI_BRANCH: ${{ github.event_name == 'push' && github.ref_name || '' }}
```

### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue #
 <!-- Link the issue as harvester/harvester#<issue_number> -->
 harvester/harvester#<issue_number>


### Test screenshot or video (Required)
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
N/A — CI workflow configuration change. Will be validated by labeling a PR with `build-artifact` once merged (pull_request runs use the base-branch workflow).
