### PR TITLE
fix: prevent VM detail page hang when static IP assigned

### DIFF
--- a/pkg/harvester/formatters/HarvesterIpAddress.vue
+++ b/pkg/harvester/formatters/HarvesterIpAddress.vue
@@ -132,16 +132,28 @@ export default {
 </script>
 
 <template>
-  <div v-if="showIP">
-    <span
+  <div
+    v-if="showIP"
+    class="ip-list"
+  >
+    <div
       v-for="{ ip, name, isCustom } in ips"
       :key="`${ip}-${name}`"
+      class="ip-item"
     >
       <CopyToClipboardText
         v-clean-tooltip="isCustom ? t('harvester.formatters.harvesterIpAddress.customIpTooltip') : name"
         :text="ip"
         :plain="isCustom"
       />
-    </span>
+    </div>
   </div>
 </template>
+
+<style lang="scss" scoped>
+.ip-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+</style>

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -791,17 +791,40 @@ export default {
       }
 
       const staticIpPrefix = `${ HCI_ANNOTATIONS.STATIC_IP }/`;
+      const annotations = vm.metadata.annotations;
 
-      Object.keys(vm.metadata.annotations).forEach((key) => {
-        if (key.startsWith(staticIpPrefix)) {
-          delete vm.metadata.annotations[key];
-        }
-      });
+      const desired = {};
 
       this.networkRows.forEach((row) => {
         if (row.name && row.staticIp) {
-          vm.metadata.annotations[`${ staticIpPrefix }${ row.name }`] = row.staticIp;
+          desired[`${ staticIpPrefix }${ row.name }`] = row.staticIp;
         }
+      });
+
+      const current = {};
+
+      Object.keys(annotations).forEach((key) => {
+        if (key.startsWith(staticIpPrefix)) {
+          current[key] = annotations[key];
+        }
+      });
+
+      // Skip mutation when already in sync to avoid triggering a reactive update loop.
+      const desiredKeys = Object.keys(desired);
+      const currentKeys = Object.keys(current);
+      const isSame = desiredKeys.length === currentKeys.length &&
+        desiredKeys.every((key) => current[key] === desired[key]);
+
+      if (isSame) {
+        return;
+      }
+
+      currentKeys.forEach((key) => {
+        delete annotations[key];
+      });
+
+      Object.entries(desired).forEach(([key, value]) => {
+        annotations[key] = value;
       });
     },
 


### PR DESCRIPTION
### Summary

This PR changes:

- Fix the VM detail page freezing the browser when a VM has static IP annotations assigned.
- Stack multiple IP addresses `vertically` (with spacing) in the IP Address column.

<img width="1470" height="562" alt="Screenshot 2026-07-31 at 4 23 11 PM" src="https://github.com/user-attachments/assets/6b164a75-b562-4766-980f-382a012305dd" />


Hang Root cause: an infinite reactive update loop. 
- The detail page has a `deep` watcher on the VM `value` that recomputes `networkRows`, and the `harvester-vm` mixin has a `deep` watcher on `networkRows` that calls `syncStaticIpAnnotations(vm)`.
-  The old `syncStaticIpAnnotations` unconditionally deleted and re-added all `static-ip/*` annotations, mutating `value.metadata.annotations` even when nothing changed. 
- This triggered the value watcher again → recompute networkRows → sync mutates annotations → ... an endless loop that hung the browser (only when static IP annotations exist).


### PR Checklist
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is @starbops
    - [ ] No, frontend-only.

### Related Issue #
 harvester/harvester#6087

### Test screenshot or video (Required)
**Tested with multiple static ips, single static ip, mgmt inferface VM creation**

https://github.com/user-attachments/assets/7d5cb5c1-5384-4100-87d7-415e9f7ac157


**Tested with created VM can edit the static IP**

https://github.com/user-attachments/assets/e93dd97b-997c-430e-945d-5db0676067f7




