### PR TITLE
fix: project resource quota not set in POST API payload

### DIFF
--- a/pkg/harvester/edit/management.cattle.io.project.vue
+++ b/pkg/harvester/edit/management.cattle.io.project.vue
@@ -195,7 +195,7 @@ export default {
       this.isQuotasValid = isValid;
     },
 
-    onQuotasInput({ projectLimit, nsLimit }) {
+    onQuotasInput({ projectLimit, nsLimit } = {}) {
       this.value.spec.resourceQuota = { ...this.value.spec.resourceQuota, limit: projectLimit };
       this.value.spec.namespaceDefaultResourceQuota = { ...this.value.spec.namespaceDefaultResourceQuota, limit: nsLimit };
     }

--- a/pkg/harvester/edit/management.cattle.io.project.vue
+++ b/pkg/harvester/edit/management.cattle.io.project.vue
@@ -63,6 +63,7 @@ export default {
       RANCHER_TYPES,
       fvFormRuleSets:     [{ path: 'spec.displayName', rules: ['required'] }],
       canEditPSPBindings: true,
+      isQuotasValid:      true,
     };
   },
   computed: {
@@ -190,15 +191,13 @@ export default {
       this['membershipUpdate'] = update;
     },
 
-    removeQuota(key) {
-      ['resourceQuota', 'namespaceDefaultResourceQuota'].forEach((specProp) => {
-        if (this.value?.spec[specProp]?.limit && this.value?.spec[specProp]?.limit[key]) {
-          delete this.value?.spec[specProp]?.limit[key];
-        }
-        if (this.value?.spec[specProp]?.usedLimit && this.value?.spec[specProp]?.usedLimit[key]) {
-          delete this.value?.spec[specProp]?.usedLimit[key];
-        }
-      });
+    validateQuotas(isValid) {
+      this.isQuotasValid = isValid;
+    },
+
+    onQuotasInput({ projectLimit, nsLimit }) {
+      this.value.spec.resourceQuota = { ...this.value.spec.resourceQuota, limit: projectLimit };
+      this.value.spec.namespaceDefaultResourceQuota = { ...this.value.spec.namespaceDefaultResourceQuota, limit: nsLimit };
     }
   },
 };
@@ -212,7 +211,7 @@ export default {
     :resource="value"
     :subtypes="[]"
     :can-yaml="false"
-    :validation-passed="fvFormIsValid"
+    :validation-passed="fvFormIsValid && isQuotasValid"
     @error="e=>errors=e"
     @finish="save"
     @cancel="done"
@@ -267,10 +266,11 @@ export default {
         :weight="9"
       >
         <ResourceQuota
-          v-model:value="value"
+          :value="value"
           :mode="canEditTabElements"
           :types="isStandaloneHarvester ? HARVESTER_TYPES : RANCHER_TYPES"
-          @remove="removeQuota"
+          @input="onQuotasInput"
+          @validationChanged="validateQuotas"
         />
       </Tab>
       <Tab


### PR DESCRIPTION
### Summary
<!-- Give the fix root cause or feature requirement, at least list what this PR changes  -->

Root cause

- Rancher/dashboard refactored the project resource quota logic in https://github.com/rancher/dashboard/pull/16780/changes.

- The `ResourceQuota/Project` component no longer mutates `value` directly via `v-model`. Instead it emits `input` with `{ projectLimit, nsLimit }` and reports validity via `validationChanged`. 

- Because this page still used the old `v-model:value` + `@remove` contract, the project resource quota limit and namespace default limit were never written into `spec`, so they were missing from the create Project POST payload.

### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue #
 <!-- Link the issue as harvester/harvester#<issue_number> -->
harvester/harvester#10556
https://github.com/harvester/harvester/issues/10556#issuecomment-5139885109


### Test screenshot or video (Required)


https://github.com/user-attachments/assets/af7d1199-159d-4769-a693-dee0a6669111


