### PR TITLE
fix: support None option for VLAN dropdown

### DIFF
--- a/pkg/harvester/edit/kubeovn.io.subnet/index.vue
+++ b/pkg/harvester/edit/kubeovn.io.subnet/index.vue
@@ -9,7 +9,7 @@ import Loading from '@shell/components/Loading';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { RadioGroup } from '@components/Form/Radio';
 import { NETWORK_PROTOCOL, NETWORK_TYPE } from '@pkg/harvester/config/types';
-import { set } from '@shell/utils/object';
+import { set, remove } from '@shell/utils/object';
 import ArrayList from '@shell/components/form/ArrayList';
 import { allHash } from '@shell/utils/promise';
 import { HCI } from '../../types';
@@ -142,10 +142,12 @@ export default {
       const inStore = this.$store.getters['currentProduct'].inStore;
       const vlans = this.$store.getters[`${ inStore }/all`](HCI.VLAN) || [];
 
-      return vlans.map((vlan) => ({
+      const options = vlans.map((vlan) => ({
         label: vlan.id,
         value: vlan.id,
       }));
+
+      return [{ label: this.t('generic.none'), value: '' }, ...options];
     }
   },
 
@@ -160,6 +162,14 @@ export default {
     }
   },
   methods: {
+    onVlanChange(value) {
+      if (value === '') {
+        remove(this.value.spec, 'vlan');
+      } else {
+        set(this.value, 'spec.vlan', value);
+      }
+    },
+
     async saveSubnet(buttonCb) {
       const errors = [];
       const name = this.value?.metadata?.name;
@@ -283,12 +293,13 @@ export default {
           </div>
           <div class="col span-6">
             <LabeledSelect
-              v-model:value="value.spec.vlan"
+              :value="value.spec.vlan ?? ''"
               class="mb-20"
               :options="vlanOptions"
               :placeholder="t('harvester.subnet.vlan.placeholder')"
               :label="t('harvester.subnet.vlan.label')"
               :mode="mode"
+              @update:value="onVlanChange"
             />
           </div>
         </div>


### PR DESCRIPTION
### Summary
<!-- Give the fix root cause or feature requirement, at least list what this PR changes  -->

Fix VLAN selection behavior on the subnet edit page:
- Add a `None` option to the VLAN dropdown. (also as default option) 
- When `None` is selected, remove `spec.vlan` from the subnet spec.


### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is @rrajendran17 
    - [ ] No, frontend-only.

### Related Issue #
 <!-- Link the issue as harvester/harvester#<issue_number> -->
 harvester/harvester#9695


### Test screenshot or video (Required)

https://github.com/user-attachments/assets/0a6d5685-8b5d-4330-a34c-8f084ae927c9


