### PR TITLE
fix: clear keyword should clear highlight

### DIFF
--- a/pkg/harvester/components/SerialConsole/index.vue
+++ b/pkg/harvester/components/SerialConsole/index.vue
@@ -213,9 +213,15 @@ export default {
     },
 
     clearSearchHighlights() {
-      this.terminal?.clearSelection();
       this.searchAddon?.clearActiveDecoration();
       this.searchAddon?.clearDecorations();
+      this.terminal?.clearSelection();
+
+      // Disposing the search decorations doesn't repaint the webgl/canvas
+      // layer, so force a refresh to remove the lingering highlight.
+      if (this.terminal) {
+        this.terminal.refresh(0, this.terminal.rows - 1);
+      }
     },
 
     findNext() {


### PR DESCRIPTION
### Summary

Clearing the search keyword in the serial console did not remove the highlight of the first matched character (e.g. the leading `u` of `ubuntu` remained highlighted after deleting the keyword).

<img width="1270" height="492" alt="Screenshot 2026-08-05 at 12 00 19 AM" src="https://github.com/user-attachments/assets/933b6a5d-4a15-458e-b49d-cff82037c18c" />

Root cause: `@xterm/addon-search`'s `clearActiveDecoration()` / `clearDecorations()` dispose the decoration objects, but the webgl/canvas renderer does not repaint those cells, so the stale highlight frame stays on screen.

This PR forces a terminal repaint after clearing the search decorations so the lingering highlight is removed.

### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue #
 <!-- Link the issue as harvester/harvester#<issue_number> -->
 harvester/harvester#


### Test screenshot or video (Required)
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

