### PR TITLE
ci: support manual standalone build trigger and PR comment

### DIFF
--- a/.github/workflows/build-standalone-on-merge.yaml
+++ b/.github/workflows/build-standalone-on-merge.yaml
@@ -1,6 +1,7 @@
 name: Build Standalone on PR Merge
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -29,3 +30,49 @@ jobs:
       id-token: write
     with:
       CI_BRANCH: ${{github.ref_name}}
+  comment-on-pr:
+    name: Comment build result on PR
+    # Only for manual runs so the existing push / pull_request flows are untouched.
+    if: github.event_name == 'workflow_dispatch'
+    #needs:
+    #  - build
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add build artifact comment to the PR opened from this branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${branch}`,
+              base: 'main',
+            });
+            if (prs.length === 0) {
+              core.info(`No open PR found for branch ${branch}, skipping comment.`);
+              return;
+            }
+            // Match scripts/version: sanitize the branch and map main -> latest.
+            const dir = branch === 'main'
+              ? 'latest'
+              : branch.replace(/[^a-zA-Z0-9.-]+/g, '-');
+            const url = `https://releases.rancher.com/harvester-ui/dashboard/${dir}/index.html`;
+            const body = [
+              'Successfully build UI artifact as below',
+              '```',
+              `ui-index: ${url}`,
+              'ui-source : external',
+              '```',
+            ].join('\n');
+            for (const pr of prs) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+            }

--- a/.github/workflows/build-standalone-on-merge.yaml
+++ b/.github/workflows/build-standalone-on-merge.yaml
@@ -34,8 +34,8 @@ jobs:
     name: Comment build result on PR
     # Only for manual runs so the existing push / pull_request flows are untouched.
     if: github.event_name == 'workflow_dispatch'
-    #needs:
-    #  - build
+    needs:
+      - build
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -62,11 +62,9 @@ jobs:
               : branch.replace(/[^a-zA-Z0-9.-]+/g, '-');
             const url = `https://releases.rancher.com/harvester-ui/dashboard/${dir}/index.html`;
             const body = [
-              'Successfully build UI artifact as below',
-              '```',
-              `ui-index: ${url}`,
-              'ui-source : external',
-              '```',
+              '🚀 **UI Artifact Build Status:** `SUCCESS` ✅',
+              `> ui-index: ${url}`,
+              `> ui-source: external`
             ].join('\n');
             for (const pr of prs) {
               await github.rest.issues.createComment({


### PR DESCRIPTION
### Summary
<!-- Give the fix root cause or feature requirement, at least list what this PR changes  -->

- Add `workflow_dispatch` to the standalone build workflow so it can be manually triggered from the GitHub Actions web UI for any branch, without affecting the existing `push` / `pull_request` flows.
- Add a `comment-on-pr` job that runs only on manual (`workflow_dispatch`) runs and only after `build` succeeds. It finds the open PR opened from the triggered upstream branch into `main` and posts a comment with the built UI artifact URL.
- The branch name in the artifact URL is sanitized to match `scripts/version` (`[^a-zA-Z0-9.-]+` -> `-`, and `main` -> `latest`) so the linked URL always matches the actual upload path.
- The comment job uses the pre-installed `gh` CLI instead of `actions/github-script` to comply with the org's allowed-actions policy.

### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue
 <!-- Link the issue as harvester/harvester#<issue_number> -->
 harvester/harvester#


### Test Steps
 <!-- Provide the test steps for reviewer to verify the issue -->
1. Merge this workflow change into `main` (required for the manual trigger button to appear).
2. Create a branch in the upstream repo and open a PR from it into `main`.
3. Go to **Actions** -> **Build Standalone on PR Merge** -> click **Run workflow**, and select that branch.
4. Wait for the `Build and Upload Package` job to finish successfully.
5. Verify the `Comment build result on PR` job runs and a comment is posted on the PR, e.g.:
   ```
   🚀 UI Artifact Build Status: SUCCESS ✅
   > ui-index: https://releases.rancher.com/harvester-ui/dashboard/<branch>/index.html
   > ui-source: external
   ```
6. Open the `ui-index` URL and confirm the built dashboard loads.
7. Verify the existing flows are unaffected: pushing to / merging a PR into `main` still triggers the build as before, and the comment job is skipped (only runs on manual `workflow_dispatch`).
8. If the build fails, verify no success comment is posted (the comment job is skipped).

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison -->
