### PR TITLE
fix: Rename to Windows Unattended & Sysprep

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -835,13 +835,13 @@ harvester:
         title: "Network Data:"
         tip: "The network-data configuration allows you to customize the instance's networking interfaces by assigning subnet configuration, virtual device creation (bonds, bridges, VLANs) routes and DNS configuration. <a href='https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v1.html' target='_blank'>Learn more</a>"
     sysprep:
-      title: Windows Sysprep Configuration
+      title: Windows Unattended & Sysprep Configuration
       description: "Configure Windows automated installation using autounattend.xml. The configuration will be stored in a Kubernetes Secret and mounted as a CD-ROM during installation. <a href='https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/automate-windows-setup' target='_blank'>Learn more</a>"
       createNew: Create new...
-      createNewTitle: Create Windows Sysprep Template
+      createNewTitle: Create Windows Unattended & Sysprep Template
       xmlContent: autounattend.xml content
       secret:
-        label: Windows Sysprep Template
+        label: Windows Unattended & Sysprep Template
       validation:
         invalidXml: Invalid XML syntax
         invalidNamespace: Invalid unattend.xml namespace. Expected 'urn:schemas-microsoft-com:unattend'


### PR DESCRIPTION
### Summary
Rename title and other mentions of Sysprep to prevent misunderstandings regarding functionality. For the average Windows administrator who simply wants to automate the installation of a Windows ISO, it isn't immediately intuitive when the term “Sysprep” is used on its own.

### Related Issue
- https://github.com/harvester/harvester/issues/1836
- https://github.com/harvester/harvester-ui-extension/pull/954
