### PR TITLE
fix: remove map ownerref writeback and delete maps via plan refs

### DIFF
--- a/pkg/harvester/components/vm-migration/ReviewMigrationStep.vue
+++ b/pkg/harvester/components/vm-migration/ReviewMigrationStep.vue
@@ -273,19 +273,6 @@ const startMigrationAction = async() => {
 
   await plan.save();
 
-  const planOwnerRef = {
-    apiVersion:         FORKLIFT_API_VERSION,
-    kind:               'Plan',
-    name:               plan.metadata.name,
-    uid:                plan.metadata.uid,
-    blockOwnerDeletion: true,
-  };
-
-  networkMap.metadata.ownerReferences = [planOwnerRef];
-  await networkMap.save();
-  storageMap.metadata.ownerReferences = [planOwnerRef];
-  await storageMap.save();
-
   // Kick off the first migration through the model so the Migration payload
   // lives in a single place (also reused by the dashboard start/restart action).
   await plan.startMigration();

--- a/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
+++ b/pkg/harvester/promptRemove/forklift.konveyor.io.plan.vue
@@ -68,29 +68,35 @@ export default defineComponent({
       return (this.value || []).map((plan) => {
         const planName = plan?.metadata?.name || '-';
         const namespace = plan?.metadata?.namespace || '';
+        const networkMapRef = this.getPlanMapRef(plan, 'network');
+        const storageMapRef = this.getPlanMapRef(plan, 'storage');
 
         const migrations = existing[HCI.FORKLIFT_MIGRATION]
           .filter((resource) => this.ownedByPlan(resource, plan))
-          .map((resource) => ({
-            name:      resource?.metadata?.name,
-            namespace: resource?.metadata?.namespace || namespace,
-          }));
+          .map((resource) => resource?.metadata?.name)
+          .filter(Boolean);
 
-        const matchedNetworkMap = existing[HCI.FORKLIFT_NETWORK_MAP].find((resource) => this.ownedByPlan(resource, plan));
-        const matchedStorageMap = existing[HCI.FORKLIFT_STORAGE_MAP].find((resource) => this.ownedByPlan(resource, plan));
+        const matchedNetworkMap = networkMapRef ? existing[HCI.FORKLIFT_NETWORK_MAP].find((resource) => resource?.metadata?.name === networkMapRef.name && resource?.metadata?.namespace === networkMapRef.namespace) : null;
+        const matchedStorageMap = storageMapRef ? existing[HCI.FORKLIFT_STORAGE_MAP].find((resource) => resource?.metadata?.name === storageMapRef.name && resource?.metadata?.namespace === storageMapRef.namespace) : null;
 
         return {
           planName,
           namespace,
           migrations,
           networkMap: matchedNetworkMap ? {
-            namespace: matchedNetworkMap?.metadata?.namespace || namespace,
+            namespace: matchedNetworkMap?.metadata?.namespace || networkMapRef?.namespace || namespace,
             name:      matchedNetworkMap?.metadata?.name,
-          } : null,
+          } : (networkMapRef ? {
+            namespace: networkMapRef.namespace,
+            name:      networkMapRef.name,
+          } : null),
           storageMap: matchedStorageMap ? {
-            namespace: matchedStorageMap?.metadata?.namespace || namespace,
+            namespace: matchedStorageMap?.metadata?.namespace || storageMapRef?.namespace || namespace,
             name:      matchedStorageMap?.metadata?.name,
-          } : null,
+          } : (storageMapRef ? {
+            namespace: storageMapRef.namespace,
+            name:      storageMapRef.name,
+          } : null),
         };
       });
     },
@@ -112,6 +118,20 @@ export default defineComponent({
 
   methods: {
     resourceNames,
+
+    getPlanMapRef(plan, mapType) {
+      const ref = plan?.spec?.map?.[mapType];
+      const name = ref?.name;
+
+      if (!name) {
+        return null;
+      }
+
+      return {
+        name,
+        namespace: ref?.namespace || plan?.metadata?.namespace || '',
+      };
+    },
 
     /**
      * Determine whether a related resource (migration / network map / storage map)
@@ -137,9 +157,8 @@ export default defineComponent({
       const existing = this.existingRelatedResources;
       const targets = new Map();
 
-      const addTarget = (type, resource) => {
-        const name = resource?.metadata?.name;
-        const ns = resource?.metadata?.namespace;
+      const addTarget = (type, name, namespace) => {
+        const ns = namespace || '';
 
         if (!name) {
           return;
@@ -153,17 +172,20 @@ export default defineComponent({
       };
 
       for (const plan of this.value || []) {
-        existing[HCI.FORKLIFT_NETWORK_MAP]
-          .filter((resource) => this.ownedByPlan(resource, plan))
-          .forEach((resource) => addTarget(HCI.FORKLIFT_NETWORK_MAP, resource));
+        const networkMapRef = this.getPlanMapRef(plan, 'network');
+        const storageMapRef = this.getPlanMapRef(plan, 'storage');
 
-        existing[HCI.FORKLIFT_STORAGE_MAP]
-          .filter((resource) => this.ownedByPlan(resource, plan))
-          .forEach((resource) => addTarget(HCI.FORKLIFT_STORAGE_MAP, resource));
+        if (networkMapRef) {
+          addTarget(HCI.FORKLIFT_NETWORK_MAP, networkMapRef.name, networkMapRef.namespace);
+        }
+
+        if (storageMapRef) {
+          addTarget(HCI.FORKLIFT_STORAGE_MAP, storageMapRef.name, storageMapRef.namespace);
+        }
 
         existing[HCI.FORKLIFT_MIGRATION]
           .filter((resource) => this.ownedByPlan(resource, plan))
-          .forEach((resource) => addTarget(HCI.FORKLIFT_MIGRATION, resource));
+          .forEach((resource) => addTarget(HCI.FORKLIFT_MIGRATION, resource?.metadata?.name, resource?.metadata?.namespace));
       }
 
       return [...targets.values()];
@@ -256,11 +278,11 @@ export default defineComponent({
       <div>• {{ t('harvester.addons.vmMigration.labels.migration') }}:</div>
       <template v-if="summary.migrations.length">
         <div
-          v-for="migration in summary.migrations"
-          :key="`${ migration.namespace }/${ migration.name }`"
+          v-for="migrationName in summary.migrations"
+          :key="migrationName"
         >
           <div class="ml-20">
-            - {{ migration.name }}
+            - {{ migrationName }}
           </div>
         </div>
       </template>


### PR DESCRIPTION
### Summary
Fix create plan 409 conflict error.

<img width="1467" height="843" alt="Screenshot 2026-08-10 at 5 10 56 PM" src="https://github.com/user-attachments/assets/369bfc4b-003c-49b8-97dd-7159c80024ee" />


### PR Checklist
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue
harvester/harvester#10417

### Test Steps
1. Go to Virtual Machine Migration and create a new migration plan.
2. Click Create and Start on the review step.
3. Verify plan creation succeeds without the extra ownerReference write-back updates to map resources.
4. Delete the created migration plan from the migration list.
5. Verify related NetworkMap and StorageMap referenced by the plan are cleaned up via `plan.spec.map.*`.

### Test screenshot or video
- N/A (logic change validated via lint and code-path verification)
