### PR TITLE
fix: prevent duplicated cloud-config for empty user data

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/impl.js
+++ b/pkg/harvester/mixins/harvester-vm/impl.js
@@ -38,6 +38,10 @@ export const SSH_EXISTING_TYPE = {
 export default {
   methods: {
     hasCloudConfigComment(userScript) {
+      if (typeof userScript === 'string' && /(^|\n)\s*#cloud-config(\s|$)/.test(userScript)) {
+        return true;
+      }
+
       // Check that userData contains: #cloud-config
       const userDataDoc = userScript ? YAML.parseDocument(userScript) : YAML.parseDocument({});
       const items = userDataDoc?.contents?.items || [];
@@ -49,6 +53,14 @@ export default {
       }
 
       if (userDataDoc?.commentBefore === 'cloud-config' || userDataDoc?.commentBefore?.includes('cloud-config\n')) {
+        exist = true;
+      }
+
+      if (userDataDoc?.contents?.commentBefore === 'cloud-config' || userDataDoc?.contents?.commentBefore?.includes('cloud-config\n')) {
+        exist = true;
+      }
+
+      if (userDataDoc?.contents?.comment === 'cloud-config' || userDataDoc?.contents?.comment?.includes('cloud-config\n')) {
         exist = true;
       }
 

--- a/pkg/harvester/mixins/harvester-vm/impl.js
+++ b/pkg/harvester/mixins/harvester-vm/impl.js
@@ -38,7 +38,7 @@ export const SSH_EXISTING_TYPE = {
 export default {
   methods: {
     hasCloudConfigComment(userScript) {
-      if (typeof userScript === 'string' && /(^|\n)\s*#cloud-config(\s|$)/.test(userScript)) {
+      if (typeof userScript === 'string' && /^\s*#cloud-config(\s|$)/.test(userScript)) {
         return true;
       }
 

--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -1211,9 +1211,10 @@ export default {
 
         userDataDoc = config.installAgent ? this.mergeQGA({ userDataDoc, ...config }) : this.deleteQGA({ userDataDoc, ...config });
         const userDataYaml = userDataDoc.toString();
+        const userDataValue = userDataDoc.toJSON();
 
-        if (userDataYaml === '{}\n') {
-          // When the YAML parsed value is '{}\n', it means that the userData is empty, then undefined is returned.
+        if (userDataValue === null || (typeof userDataValue === 'object' && !Array.isArray(userDataValue) && isEmpty(userDataValue))) {
+          // Empty userData should not create cloud-init content like `null`.
           return undefined;
         }
 


### PR DESCRIPTION
### Summary
Fix duplicated cloud init in user data after VM created.

<img width="767" height="445" alt="image" src="https://github.com/user-attachments/assets/d935a8d4-3be7-484a-afb7-0e9bd3f28ce7" />

This PR updates cloud-config handling to:
- Treat parsed `null` user data as empty and return `undefined` instead of emitting `null`.
- Improve `#cloud-config` detection so existing comments are recognized consistently (including scalar/comment placements), preventing duplicate header prepends.

### PR Checklist
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue
harvester/harvester#11213

### Test Steps
1. Open **Virtual Machines > Create**.
2. Leave **User Data** empty.
3. Optionally set **Network Data** (or leave it empty).
4. Save the VM.
5. Inspect generated cloud-init user data in the created VM spec/secret.
6. Verify user data is not rendered as repeated `#cloud-config` headers and does not contain `null` for empty input.

### Test screenshot or video

https://github.com/user-attachments/assets/3c335efa-a470-43ec-9a66-041199aa2011

