### PR TITLE
fix: ACCESS_MODE undefined error in forklift mapping page

### DIFF
--- a/pkg/harvester/components/vm-migration/ConfigureMappingsStep.vue
+++ b/pkg/harvester/components/vm-migration/ConfigureMappingsStep.vue
@@ -15,7 +15,7 @@ import MappingColumn from './MappingColumn.vue';
 import StorageDefaultsModal from './StorageDefaultsModal.vue';
 
 const DEFAULT_VOLUME_MODE = VOLUME_MODE.FILE_SYSTEM;
-const DEFAULT_ACCESS_MODE = ACCESS_MODE?.READ_WRITE_MANY || 'ReadWriteMany';
+const DEFAULT_ACCESS_MODE = ACCESS_MODE?.READ_WRITE_MANY ?? 'ReadWriteMany';
 
 const props = defineProps({
   providerName:       { type: String, default: '' },

--- a/pkg/harvester/components/vm-migration/ConfigureMappingsStep.vue
+++ b/pkg/harvester/components/vm-migration/ConfigureMappingsStep.vue
@@ -15,7 +15,7 @@ import MappingColumn from './MappingColumn.vue';
 import StorageDefaultsModal from './StorageDefaultsModal.vue';
 
 const DEFAULT_VOLUME_MODE = VOLUME_MODE.FILE_SYSTEM;
-const DEFAULT_ACCESS_MODES = [ACCESS_MODE.READ_WRITE_MANY];
+const DEFAULT_ACCESS_MODE = ACCESS_MODE?.READ_WRITE_MANY || 'ReadWriteMany';
 
 const props = defineProps({
   providerName:       { type: String, default: '' },
@@ -268,9 +268,9 @@ const buildStorageEntries = () => {
               capacity:              0,
               target:                '',
               volumeMode:            DEFAULT_VOLUME_MODE,
-              accessModes:           [...DEFAULT_ACCESS_MODES],
+              accessModes:           [DEFAULT_ACCESS_MODE],
               inheritedVolumeMode:   DEFAULT_VOLUME_MODE,
-              inheritedAccessModes:  [...DEFAULT_ACCESS_MODES],
+              inheritedAccessModes:  [DEFAULT_ACCESS_MODE],
               inheritedFromProvider: false,
               overridden:            false,
               usedBy:                [],
@@ -310,9 +310,9 @@ const buildStorageEntriesFromProvider = (datastoresData) => {
     capacity:              ds.capacity || 0,
     target:                '',
     volumeMode:            DEFAULT_VOLUME_MODE,
-    accessModes:           [...DEFAULT_ACCESS_MODES],
+    accessModes:           [DEFAULT_ACCESS_MODE],
     inheritedVolumeMode:   DEFAULT_VOLUME_MODE,
-    inheritedAccessModes:  [...DEFAULT_ACCESS_MODES],
+    inheritedAccessModes:  [DEFAULT_ACCESS_MODE],
     inheritedFromProvider: false,
     overridden:            false,
     usedBy:                [],

--- a/pkg/harvester/components/vm-migration/StorageDefaultsModal.vue
+++ b/pkg/harvester/components/vm-migration/StorageDefaultsModal.vue
@@ -8,16 +8,22 @@ import { useI18n } from '@shell/composables/useI18n';
 import { VOLUME_MODE, ACCESS_MODE } from '../../config/types';
 
 const VOLUME_MODE_OPTIONS = [VOLUME_MODE.FILE_SYSTEM, VOLUME_MODE.BLOCK];
-const ACCESS_MODE_OPTIONS = [ACCESS_MODE.READ_WRITE_ONCE, ACCESS_MODE.READ_WRITE_MANY, ACCESS_MODE.READ_ONLY_MANY];
+const {
+  READ_WRITE_ONCE = 'ReadWriteOnce',
+  READ_ONLY_MANY = 'ReadOnlyMany',
+  READ_WRITE_MANY = 'ReadWriteMany',
+  READ_WRITE_ONCE_POD = 'ReadWriteOncePod'
+} = ACCESS_MODE || {};
+const ACCESS_MODE_OPTIONS = [READ_WRITE_ONCE, READ_WRITE_MANY, READ_ONLY_MANY, READ_WRITE_ONCE_POD];
 
 const props = defineProps({
   storageClassName:     { type: String, default: '' },
   providerName:         { type: String, default: '' },
   showInherited:        { type: Boolean, default: false },
   volumeMode:           { type: String, default: VOLUME_MODE.FILE_SYSTEM },
-  accessModes:          { type: Array, default: () => [ACCESS_MODE.READ_WRITE_MANY] },
+  accessModes:          { type: Array, default: () => ['ReadWriteMany'] },
   inheritedVolumeMode:  { type: String, default: VOLUME_MODE.FILE_SYSTEM },
-  inheritedAccessModes: { type: Array, default: () => [ACCESS_MODE.READ_WRITE_MANY] },
+  inheritedAccessModes: { type: Array, default: () => ['ReadWriteMany'] },
 });
 
 const emit = defineEmits(['apply', 'close']);
@@ -26,7 +32,7 @@ const store = useStore();
 const { t } = useI18n(store);
 
 const localVolumeMode = ref(props.volumeMode || VOLUME_MODE.FILE_SYSTEM);
-const localAccessMode = ref(props.accessModes?.[0] || ACCESS_MODE.READ_WRITE_MANY);
+const localAccessMode = ref(props.accessModes?.[0] || READ_WRITE_MANY);
 
 const volumeModeOptions = VOLUME_MODE_OPTIONS.map((value) => ({ label: value, value }));
 const accessModeOptions = ACCESS_MODE_OPTIONS.map((value) => ({ label: value, value }));
@@ -42,7 +48,7 @@ const apply = () => {
 // Repopulate the dropdowns with the provider default values; the user then applies.
 const reset = () => {
   localVolumeMode.value = props.inheritedVolumeMode || VOLUME_MODE.FILE_SYSTEM;
-  localAccessMode.value = props.inheritedAccessModes?.[0] || ACCESS_MODE.READ_WRITE_MANY;
+  localAccessMode.value = props.inheritedAccessModes?.[0] || READ_WRITE_MANY;
 };
 
 const cancel = () => {


### PR DESCRIPTION
### Summary
Fix ACCESS_MODE undefined error with fallback value.

<img width="1020" height="567" alt="image" src="https://github.com/user-attachments/assets/270e3c15-4a48-40f4-bc9e-da3befbd7e6d" />

### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue
 <!-- Link the issue as harvester/harvester#<issue_number> -->
 harvester/harvester#10417


### Test Steps
1. Go to VM migration page
2. Create migration plan
3. choose provider -> choose VM -> should show storage / network mapping

### Test screenshot or video
In theory , below javascript is correct, but runtime has `ACCESS_MODE` undefined error....
```
import { VOLUME_MODE, ACCESS_MODE } from '../../config/types';

const DEFAULT_ACCESS_MODES = [ACCESS_MODE.READ_WRITE_MANY];

```


https://github.com/user-attachments/assets/e940a04d-5988-424d-98c8-09031d57b986



