### PR TITLE
fix: keep forklift namespace visible in Rancher namespace model

### DIFF
--- a/pkg/harvester/models/harvester/namespace.js
+++ b/pkg/harvester/models/harvester/namespace.js
@@ -5,6 +5,7 @@ import SYSTEM_NAMESPACES from '@shell/config/system-namespaces';
 import { get } from '@shell/utils/object';
 import { NAMESPACE } from '@shell/config/types';
 import { PRODUCT_NAME as HARVESTER_PRODUCT } from '@pkg/harvester/config/harvester';
+import { FORKLIFT_NAMESPACE } from '@pkg/harvester/config/harvester-map';
 import { HCI } from '../../types';
 
 const OBSCURE_NAMESPACE_PREFIX = [
@@ -93,6 +94,10 @@ export default class HciNamespace extends namespace {
   }
 
   get isSystem() {
+    if (this.metadata?.name === FORKLIFT_NAMESPACE) {
+      return false;
+    }
+
     const systemNamespaces = ['fleet-default'];
 
     if (systemNamespaces.includes(this.metadata.name)) {


### PR DESCRIPTION
### Summary
Fixes provider rows under Virtual Machine Migration not showing in Rancher when resources are in the `forklift` namespace.

Root cause:
- `pkg/harvester/models/harvester/namespace.js` classified `forklift` as a system namespace via the custom `isSystem` logic, so namespace-filtered lists could hide those resources.

What this PR changes:
- Imports `FORKLIFT_NAMESPACE` from `@pkg/harvester/config/harvester-map`.
- Adds an early return in `isSystem` to keep `forklift` non-system (`false`).
- Leaves all other namespace system checks unchanged.

### PR Checklist
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue
harvester/harvester#10417

### Test Steps
1. Open Rancher with Harvester UI extension enabled.
2. Navigate to `Virtual Machine Migration` -> `Providers`.
3. Ensure providers created in namespace `forklift` are visible in the list.
4. Confirm other known system namespaces remain filtered as before.

### Test screenshot or video
- Before: provider list hidden due to namespace classification.
<img width="1470" height="817" alt="Screenshot 2026-08-14 at 11 07 45 PM" src="https://github.com/user-attachments/assets/8c7d4c60-093a-4088-940c-8fe6e5270161" />

- After: provider rows in `forklift` namespace are displayed.

https://github.com/user-attachments/assets/5b95e5ab-8807-4ed4-8994-e111abfd02fd

