### PR TITLE
feat(storage): expose volume encryption for the LVM CSI StorageClass

### DIFF
--- a/pkg/harvester/config/feature-flags.js
+++ b/pkg/harvester/config/feature-flags.js
@@ -76,6 +76,7 @@ const FEATURE_FLAGS = {
     'longhornV2HugepageSettings',
     'staticIPForVM',
     'fsFreezeDeadline',
+    'lvmVolumeEncryption',
   ],
 };
 

--- a/pkg/harvester/edit/harvesterhci.io.storage/provisioners/lvm.driver.harvesterhci.io.vue
+++ b/pkg/harvester/edit/harvesterhci.io.storage/provisioners/lvm.driver.harvesterhci.io.vue
@@ -2,12 +2,25 @@
 
 import KeyValue from '@shell/components/form/KeyValue';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
+import RadioGroup from '@components/Form/Radio/RadioGroup';
 
 import { allHash } from '@shell/utils/promise';
 import { clone } from '@shell/utils/object';
 import { HCI } from '../../../types';
-import { NODE } from '@shell/config/types';
+import { NODE, SECRET } from '@shell/config/types';
+import { CSI_SECRETS } from '@pkg/harvester/config/harvester-map';
 import { LVM_TOPOLOGY_LABEL } from '../index.vue';
+
+const {
+  CSI_PROVISIONER_SECRET_NAME,
+  CSI_PROVISIONER_SECRET_NAMESPACE,
+  CSI_NODE_PUBLISH_SECRET_NAME,
+  CSI_NODE_PUBLISH_SECRET_NAMESPACE,
+  CSI_NODE_STAGE_SECRET_NAME,
+  CSI_NODE_STAGE_SECRET_NAMESPACE,
+  CSI_NODE_EXPAND_SECRET_NAME,
+  CSI_NODE_EXPAND_SECRET_NAMESPACE
+} = CSI_SECRETS;
 
 const DEFAULT_PARAMETERS = [
   'type',
@@ -25,6 +38,7 @@ export default {
   components: {
     KeyValue,
     LabeledSelect,
+    RadioGroup,
   },
 
   props: {
@@ -45,10 +59,16 @@ export default {
   async fetch() {
     const inStore = this.$store.getters['currentProduct'].inStore;
 
-    await allHash({
+    const hash = {
       nodes:           this.$store.dispatch(`${ inStore }/findAll`, { type: NODE }),
       lvmVolumeGroups: this.$store.dispatch(`${ inStore }/findAll`, { type: HCI.LVM_VOLUME_GROUP }),
-    });
+    };
+
+    if (this.value.lvmVolumeEncryptionFeatureEnabled) {
+      hash.secrets = this.$store.dispatch(`${ inStore }/findAll`, { type: SECRET });
+    }
+
+    await allHash(hash);
   },
 
   data() {
@@ -69,7 +89,7 @@ export default {
       allowedTopologies[0].matchLabelExpressions[0].values = [value];
 
       this.value.allowedTopologies = allowedTopologies;
-    }
+    },
   },
 
   computed: {
@@ -89,11 +109,87 @@ export default {
         .map((g) => g.spec.vgName);
     },
 
+    secrets() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+      const allSecrets = this.$store.getters[`${ inStore }/all`](SECRET) || [];
+
+      // only show non-system secret to user to select
+      return allSecrets.filter((secret) => secret.isSystem === false);
+    },
+
+    secretOptions() {
+      return this.secrets.map((secret) => secret.id);
+    },
+
+    volumeEncryptionOptions() {
+      return [{
+        label: this.t('generic.yes'),
+        value: 'true'
+      }, {
+        label: this.t('generic.no'),
+        value: 'false'
+      }];
+    },
+
+    volumeEncryption: {
+      set(neu) {
+        this.value['parameters'] = {
+          ...this.value.parameters,
+          encrypted: neu
+        };
+      },
+
+      get() {
+        return this.value?.parameters?.encrypted || 'false';
+      }
+    },
+
+    secret: {
+      get() {
+        const selectedNs = this.value.parameters[CSI_PROVISIONER_SECRET_NAMESPACE];
+        const selectedName = this.value.parameters[CSI_PROVISIONER_SECRET_NAME];
+
+        if (selectedNs && selectedName) {
+          return `${ selectedNs }/${ selectedName }`;
+        }
+
+        return '';
+      },
+
+      // All four references point at the same secret. The LVM driver needs the
+      // passphrase when it provisions the volume, when it opens the dm-crypt
+      // device at publish, and when it resizes that device at expand - the
+      // node-expand reference is what makes external-resizer send the
+      // credential, so without it an encrypted volume can never grow, online or
+      // offline. The node-stage reference is not read by the driver, but the
+      // Harvester StorageClass webhook requires it on an encrypted class.
+      set(selectedSecret) {
+        const [namespace, name] = selectedSecret.split('/');
+
+        this.value['parameters'] = {
+          ...this.value.parameters,
+          [CSI_PROVISIONER_SECRET_NAME]:       name,
+          [CSI_NODE_PUBLISH_SECRET_NAME]:      name,
+          [CSI_NODE_STAGE_SECRET_NAME]:        name,
+          [CSI_NODE_EXPAND_SECRET_NAME]:       name,
+          [CSI_PROVISIONER_SECRET_NAMESPACE]:  namespace,
+          [CSI_NODE_PUBLISH_SECRET_NAMESPACE]: namespace,
+          [CSI_NODE_STAGE_SECRET_NAMESPACE]:   namespace,
+          [CSI_NODE_EXPAND_SECRET_NAMESPACE]:  namespace,
+        };
+      }
+    },
+
     parameters: {
       get() {
         const parameters = clone(this.value?.parameters) || {};
 
-        DEFAULT_PARAMETERS.map((key) => {
+        const managedKeys = [
+          ...DEFAULT_PARAMETERS,
+          ...(this.value.lvmVolumeEncryptionFeatureEnabled ? ['encrypted', ...Object.values(CSI_SECRETS)] : []),
+        ];
+
+        managedKeys.forEach((key) => {
           delete parameters[key];
         });
 
@@ -158,6 +254,31 @@ export default {
         />
       </div>
     </div>
+    <template v-if="value.lvmVolumeEncryptionFeatureEnabled">
+      <div class="row mt-20">
+        <RadioGroup
+          v-model:value="volumeEncryption"
+          name="volumeEncryption"
+          :label="t('harvester.storage.volumeEncryption')"
+          :mode="mode"
+          :options="volumeEncryptionOptions"
+        />
+      </div>
+      <div
+        v-if="value.parameters.encrypted === 'true'"
+        class="row mt-20"
+      >
+        <div class="col span-6">
+          <LabeledSelect
+            v-model:value="secret"
+            :label="t('harvester.storage.secret')"
+            :options="secretOptions"
+            :mode="mode"
+            :required="true"
+          />
+        </div>
+      </div>
+    </template>
     <KeyValue
       v-model:value="parameters"
       :add-label="t('storageClass.longhorn.addLabel')"

--- a/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
+++ b/pkg/harvester/models/harvester/storage.k8s.io.storageclass.js
@@ -100,6 +100,13 @@ export default class HciStorageClass extends StorageClass {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('expandOnlineEncryptedVolume');
   }
 
+  // The LVM CSI driver only honors the encrypted parameter from the release
+  // that ships dm-crypt support; older drivers silently ignore it and create
+  // plaintext volumes, so the LVM form is gated separately from Longhorn's.
+  get lvmVolumeEncryptionFeatureEnabled() {
+    return this.$rootGetters['harvester-common/getFeatureEnabled']('lvmVolumeEncryption');
+  }
+
   get thirdPartyStorageFeatureEnabled() {
     return this.$rootGetters['harvester-common/getFeatureEnabled']('thirdPartyStorage');
   }


### PR DESCRIPTION
## Problem

The StorageClass creation form renders the encryption toggle + secret picker **only**
for the Longhorn provisioner components (`provisioners/driver.longhorn.io_v1.vue` /
`_v2.vue`). The LVM provisioner form (`provisioners/lvm.driver.harvesterhci.io.vue`) has
no way to enable encryption, so users cannot create an encrypted
`lvm.driver.harvesterhci.io` StorageClass from the dashboard — they'd have to hand-edit
YAML.

## Change

Add the same encryption UI to the LVM provisioner component:

- **Volume Encryption** `RadioGroup` bound to `parameters.encrypted`.
- **Secret** `LabeledSelect` that populates **all four** `csi.storage.k8s.io/*` secret
  reference pairs — provisioner, node-publish, node-stage and node-expand — from the
  shared `CSI_SECRETS` map, with the one selected secret.
- Gated on a **new `lvmVolumeEncryption` feature flag** rather than the existing
  `volumeEncryption` one (see below); reuses the `SECRET` prefetch already done in
  `index.vue`.
- Encryption-managed params are stripped from the raw `KeyValue` editor to avoid
  double entry.

Nothing else needs to change: images, volumes, VMs and snapshot/backup restore already
detect encryption generically via `StorageClass.isEncrypted`
(`parameters.encrypted === 'true'`), which is provisioner-agnostic. The **CDI Settings**
tab already lets users set `cloneStrategy: copy`, which encrypted LVM SCs need so CDI
image clones write through the dm-crypt mapper.

## Two LVM-specific differences from the Longhorn form

Both come from validating the driver side (harvester/csi-driver-lvm#67) on a live
cluster, and both are deliberate divergences — reviewers may want to weigh in.

**1. `node-expand-secret-*` is always written, and there is no expansion checkbox.**
Longhorn gates that reference behind `expandOnlineEncryptedVolume` + an "Enable
Expansion" checkbox. For LVM the reference is needed for *any* expansion: growing the
volume means resizing the dm-crypt mapper first, `cryptsetup resize` needs the
passphrase, and `external-resizer` only puts a credential in the `NodeExpandVolume`
request when the StorageClass carries the reference — offline expansion included, since
kubelet still issues `NodeExpandVolume` at the next mount. Gated as it was, an encrypted
LVM StorageClass created on a cluster without that feature flag produced volumes that
could never grow, and the reference cannot be added afterwards without recreating the
StorageClass.

**2. New `lvmVolumeEncryption` feature flag.** Reusing `volumeEncryption` (v1.4.0) would
show the toggle on clusters whose LVM driver predates dm-crypt support. That driver does
not reject `encrypted: "true"` — it ignores it — so the user would get a **plaintext
volume that the dashboard presents as encrypted**. The flag is declared under `v1.9.0`
in `feature-flags.js`; **please move it to whichever release actually ships the driver
support** if that is not v1.9.0.

## Why the same secret schema works

The LVM CSI driver uses the same `encrypted: "true"` + `CRYPTO_KEY_*` secret convention
as Longhorn (validated end-to-end: LUKS2/aes-xts-plain64 on disk, Linux + Windows VMs,
snapshots, Kasten backup/restore, and a five-case snapshot-restore matrix all confirmed).
Driver-side support: **harvester/csi-driver-lvm#67**.

Two constraints Harvester's own StorageClass webhook imposes, which shape this form:

- the secret reference is resolved **literally** at admission, so `${pvc.name}` /
  `${pvc.namespace}` templating cannot be used — "pick an existing secret", as this form
  does, is the only workable model, and there is no per-PVC key option to expose;
- every `CRYPTO_KEY_*` field in the referenced secret must be present and non-empty, so
  an incomplete secret is rejected on save. The picker currently lists all non-system
  secrets (same as Longhorn's form); filtering to valid encryption secrets would be a
  nice follow-up, but I kept the two forms consistent.

Authorization for the referenced secret (a cluster-scoped StorageClass pointing at a
namespaced Secret) is **out of scope here** and tracked in harvester/harvester#11558: it
has to be enforced by an admission webhook, since the same StorageClass can be created
with `kubectl`. What this form does give is that the picker only lists secrets the
logged-in user can already read — a UX guardrail, not enforcement.

## Test plan

- `commitlint` passes locally on the commit message (the previous CI failure was
  `footer-leading-blank`, now fixed).
- Needs CI for `yarn lint` + build — I still cannot run the extension's full toolchain
  locally.
- Manual: with the feature flag enabled, create a StorageClass, select the LVM
  provisioner, toggle Volume Encryption on, pick a `CRYPTO_KEY_*` secret, save, and
  confirm the resulting SC has `encrypted: "true"` plus all four CSI secret parameter
  pairs; then provision a PVC from it and expand it.

## Related

- Tracking issue: harvester/harvester#11442 (children #11556, #11557, #11558)
- Driver support: harvester/csi-driver-lvm#67
- Docs: harvester/docs#1107
