### PR TITLE
feat: LHv2: graduate from "Experimental" to "Preview"

### DIFF
--- a/pkg/harvester/components/SettingList.vue
+++ b/pkg/harvester/components/SettingList.vue
@@ -359,29 +359,19 @@ export default {
   flex: 1;
 }
 
-.modified {
-  margin-left: 10px;
-  border: 1px solid var(--primary);
-  border-radius: 5px;
-  padding: 2px 10px;
-  font-size: 12px;
-}
-
-.experimental {
-  margin-left: 10px;
-  border: 1px solid var(--error);
-  border-radius: 5px;
-  padding: 2px 10px;
-  font-size: 12px;
-}
-
+.modified,
+.experimental,
 .preview {
   margin-left: 10px;
-  border: 1px solid var(--warning);
+  border: 1px solid;
   border-radius: 5px;
   padding: 2px 10px;
   font-size: 12px;
 }
+
+.modified { border-color: var(--primary); }
+.experimental { border-color: var(--error); }
+.preview { border-color: var(--warning); }
 
 .no-search-match {
   text-align: center;

--- a/pkg/harvester/components/SettingList.vue
+++ b/pkg/harvester/components/SettingList.vue
@@ -245,7 +245,7 @@ export default {
               v-clean-tooltip="t('advancedSettings.preview')"
               class="preview"
             >
-              Preview
+              Technical Preview
             </span>
           </h1>
           <h2 v-clean-html="t(setting.description, getDocLinkParams(setting) || {}, true)">

--- a/pkg/harvester/components/SettingList.vue
+++ b/pkg/harvester/components/SettingList.vue
@@ -240,6 +240,13 @@ export default {
             >
               Experimental
             </span>
+            <span
+              v-if="setting.preview"
+              v-clean-tooltip="t('advancedSettings.preview')"
+              class="preview"
+            >
+              Preview
+            </span>
           </h1>
           <h2 v-clean-html="t(setting.description, getDocLinkParams(setting) || {}, true)">
           </h2>
@@ -363,6 +370,14 @@ export default {
 .experimental {
   margin-left: 10px;
   border: 1px solid var(--error);
+  border-radius: 5px;
+  padding: 2px 10px;
+  font-size: 12px;
+}
+
+.preview {
+  margin-left: 10px;
+  border: 1px solid var(--warning);
   border-radius: 5px;
   padding: 2px 10px;
   font-size: 12px;

--- a/pkg/harvester/components/SettingList.vue
+++ b/pkg/harvester/components/SettingList.vue
@@ -231,21 +231,21 @@ export default {
               v-if="setting.customized"
               class="modified"
             >
-              Modified
+              {{ t('advancedSettings.tags.modified.label') }}
             </span>
             <span
               v-if="setting.experimental"
-              v-clean-tooltip="t('advancedSettings.experimental')"
+              v-clean-tooltip="t('advancedSettings.tags.experimental.description')"
               class="experimental"
             >
-              Experimental
+              {{ t('advancedSettings.tags.experimental.label') }}
             </span>
             <span
               v-if="setting.preview"
-              v-clean-tooltip="t('advancedSettings.preview')"
+              v-clean-tooltip="t('advancedSettings.tags.preview.description')"
               class="preview"
             >
-              Technical Preview
+              {{ t('advancedSettings.tags.preview.label') }}
             </span>
           </h1>
           <h2 v-clean-html="t(setting.description, getDocLinkParams(setting) || {}, true)">

--- a/pkg/harvester/config/settings.ts
+++ b/pkg/harvester/config/settings.ts
@@ -111,15 +111,17 @@ export const HCI_ALLOWED_SETTINGS = {
   [HCI_SETTING.KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES]:   { kind: 'number', featureFlag: 'kubeconfigDefaultTokenTTLMinutesSetting' },
   [HCI_SETTING.LONGHORN_V2_DATA_ENGINE_ENABLED]:        {
     kind:         'boolean',
-    experimental: true,
+    preview:      true,
     featureFlag:  'longhornV2LVMSupport'
   },
   [HCI_SETTING.LONGHORN_V2_DATA_ENGINE_HUGEPAGE_ENABLED]: {
     kind:         'boolean',
+    preview:      true,
     featureFlag:  'longhornV2HugepageSettings'
   },
   [HCI_SETTING.LONGHORN_V2_DATA_ENGINE_MEMORY_SIZE]: {
     kind:         'number',
+    preview:      true,
     featureFlag:  'longhornV2HugepageSettings'
   },
   [HCI_SETTING.ADDITIONAL_GUEST_MEMORY_OVERHEAD_RATIO]: { kind: 'string', from: 'import' },

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -2417,8 +2417,8 @@ typeDescription:
   harvester: "Branding allows administrators to globally re-brand the UI by customizing the Harvester product name, logos and color scheme."
 
 advancedSettings:
-  experimental: 'Experimental features allow users to test and evaluate early-access functionality prior to official supported releases'
-  preview: 'Preview features allow users to test and evaluate early-access functionality prior to official supported releases'
+  experimental: 'Experimental: The feature is incomplete but its essential functionality is operational. The feature is not recommended for use in production environments.'
+  preview: 'Technical Preview: The feature is almost complete and its functionality is not expected to change significantly. Explore the feature extensively before using in production environments.'
   descriptions:
     'harv-vlan': Default Network Interface name of the VLAN network.
     'harv-backup-target': Custom backup target to store virtual machine backups.

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -2417,8 +2417,15 @@ typeDescription:
   harvester: "Branding allows administrators to globally re-brand the UI by customizing the Harvester product name, logos and color scheme."
 
 advancedSettings:
-  experimental: 'Experimental: The feature is incomplete but its essential functionality is operational. The feature is not recommended for use in production environments.'
-  preview: 'Technical Preview: The feature is almost complete and its functionality is not expected to change significantly. Explore the feature extensively before using in production environments.'
+  tags:
+    modified:
+      label: Modified
+    experimental:
+      label: Experimental
+      description: 'Experimental: The feature is incomplete but its essential functionality is operational. The feature is not recommended for use in production environments.'
+    preview:
+      label: Technical Preview
+      description: 'Technical Preview: The feature is almost complete and its functionality is not expected to change significantly. Explore the feature extensively before using in production environments.'
   descriptions:
     'harv-vlan': Default Network Interface name of the VLAN network.
     'harv-backup-target': Custom backup target to store virtual machine backups.

--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -2418,6 +2418,7 @@ typeDescription:
 
 advancedSettings:
   experimental: 'Experimental features allow users to test and evaluate early-access functionality prior to official supported releases'
+  preview: 'Preview features allow users to test and evaluate early-access functionality prior to official supported releases'
   descriptions:
     'harv-vlan': Default Network Interface name of the VLAN network.
     'harv-backup-target': Custom backup target to store virtual machine backups.


### PR DESCRIPTION
### Summary
In Harvester v1.9.0, we're moving LHv2 from "Experimental" to "Preview", so I've added a new preview label to the settings interface.  I figure given Experimental had the "error" color, I should make "Preview" use the warning color, to make it a bit less alarming :-)

### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [x] Yes, the backend owner is @brandboat
    - [ ] No, frontend-only.

### Related Issue
https://github.com/harvester/harvester/issues/9960

### Test Steps
Check the settings screen and make sure the `longhorn-v2-*` settings have the Preview label.

### Test screenshot or video
Before:
<img width="884" height="215" alt="image" src="https://github.com/user-attachments/assets/e0883d95-970b-415b-9c61-91d2d4ee54e1" />

After:
<img width="894" height="560" alt="image" src="https://github.com/user-attachments/assets/608a404d-3e51-4159-b376-88df6689c41c" />



