### PR TITLE
fix: preserve per-volume storage class when editing image-sourced volume

### DIFF
--- a/pkg/harvester/mixins/harvester-vm/index.js
+++ b/pkg/harvester/mixins/harvester-vm/index.js
@@ -1317,8 +1317,9 @@ export default {
       case SOURCE_TYPE.IMAGE: {
         const image = this.images.find( (I) => R.image === I.id);
 
+        out.spec.storageClassName = R.realName ? R.storageClassName : (R.storageClassName || image?.storageClassName);
+
         if (image) {
-          out.spec.storageClassName = image.storageClassName;
           out.metadata.annotations = { [HCI_ANNOTATIONS.IMAGE_ID]: image.id };
         } else {
           out.metadata.annotations = { [HCI_ANNOTATIONS.IMAGE_ID]: '' };


### PR DESCRIPTION
### Summary
When an existing vm is loaded, getDiskRows() correctly reads each volume's StorageClassName from the existing ``harvesterhci.io/volumeClaimTemplates`` annotation and stores it in R.storageClassName.However, when the VM is saved, [parseDiskRows](https://github.com/harvester/harvester-ui-extension/blob/main/pkg/harvester/mixins/harvester-vm/index.js#L875)() regenerates the complete volumeClaimTemplates annotation...


For ``SOURCE_TYPE.IMAGE`` volumes, parseVolumeClaimTemplate() ignores the existing ``R.storageClassName`` and unconditionally replaces it with image.``storageClassName``.Which causes the dashboard to silently change the StorageClass of existing image-backed volumes whenever the VM is saved. The admission webhook then correctly rejects the update because the StorageClass of an existing volume cannot be changed...

<!-- Give the fix root cause or feature requirement, at least list what this PR changes  -->


### PR Checklist
<!-- Check Yes if there is backend PR related to this UI PR, tag the backend owner's Github account  -->
- Are backend engineers aware of UI changes ?
    - [ ] Yes, the backend owner is @
    - [x] No, frontend-only.

### Related Issue
https://github.com/harvester/harvester/issues/11579
 <!-- Link the issue as harvester/harvester#<issue_number> -->


### Test Steps

1 - Create Harvester cluster on 1.8.1 or 1.8.2 version
2 - Create the following VM

```
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: vm-reproduce-mixed-sc
  namespace: default
  annotations:
    harvesterhci.io/volumeClaimTemplates: |-
      [
        {
          "metadata": {
            "name": "vm-reproduce-mixed-sc-disk-0",
            "annotations": {
              "harvesterhci.io/imageId": "default/<image-id>"
            }
          },
          "spec": {
            "accessModes": ["ReadWriteMany"],
            "resources": {
              "requests": {
                "storage": "10Gi"
              }
            },
            "volumeMode": "Block",
            "storageClassName": "<storageclass-1>"
          }
        },
        {
          "metadata": {
            "name": "vm-reproduce-mixed-sc-disk-1"
          },
          "spec": {
            "accessModes": ["ReadWriteMany"],
            "resources": {
              "requests": {
                "storage": "20Gi"
              }
            },
            "volumeMode": "Block",
            "storageClassName": "<Storageclass-2>"
          }
        }
      ]
spec:
  running: true
  template:
    metadata:
      labels:
        harvesterhci.io/vmName: vm-reproduce-mixed-sc
    spec:
      domain:
        cpu:
          cores: 1
          sockets: 1
          threads: 1
        devices:
          disks:
            - bootOrder: 1
              cdrom:
                bus: sata
              name: vm-reproduce-mixed-sc-disk-0
            - bootOrder: 2
              disk:
                bus: virtio
              name: vm-reproduce-mixed-sc-disk-1
          interfaces:
            - name: default
              bridge: {}
        resources:
          limits:
            cpu: "1"
            memory: 2Gi
          requests:
            cpu: "1"
            memory: 2Gi
      networks:
        - name: default
          multus:
            networkName: test
      volumes:
        - name: vm-reproduce-mixed-sc-disk-0
          persistentVolumeClaim:
            claimName: vm-reproduce-mixed-sc-disk-0
        - name: vm-reproduce-mixed-sc-disk-1
          persistentVolumeClaim:
            claimName: vm-reproduce-mixed-sc-disk-1

```
3 - Once the Virtual Machine is created -> Edit Config -> volumes -> Remove or Modify second volume -> Save

 <!-- Provide the test steps for reviewer to verify the issue -->

### Test screenshot or video
<!-- Attach screenshot or video of the changes and eventual comparison -->


